### PR TITLE
ci: batch unit test packages into one go test run per group

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,13 +1,8 @@
 name: cleanup-pr-caches
 
-# A cache written by a pull request run is scoped to that pull request's merge ref, and GitHub
-# only lets re-runs of the same pull request restore it: not main, not other pull requests. Once
-# the pull request is closed nothing can ever hit those entries again, so they just occupy the
-# repository cache quota until the retention policy collects them, shortening how long the
-# shared caches on main survive. Delete them immediately instead.
-#
-# Caches that a pull request merely *read* from main are owned by refs/heads/main. They are a
-# different scope and are never listed, let alone deleted, by this workflow.
+# Caches written by a PR run are scoped to its merge ref and only restorable by re-runs of the
+# same PR, so once it closes nothing can hit them again. Caches it read from main are owned by
+# refs/heads/main and aren't matched by the ref filter below.
 
 on:
   pull_request:
@@ -18,11 +13,10 @@ permissions: {}
 jobs:
   delete-pr-caches:
     runs-on: ubuntu-latest
-    # Fork pull requests receive a read-only GITHUB_TOKEN, so the deletion would fail with
-    # permission denied. Their caches are left to the repository retention policy.
+    # Fork PRs get a read-only token; leave theirs to the retention policy.
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
-      actions: write # So we can delete the caches.
+      actions: write
     steps:
       - name: Delete caches scoped to this pull request
         env:
@@ -32,8 +26,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Deleting entries renumbers the pages of the list endpoint, so collect every id
-          # before deleting any of them.
+          # Collect every id first: deleting shifts the list endpoint's pages.
           IDS=$(gh api --paginate "/repos/$GH_REPO/actions/caches?ref=$PR_REF&per_page=100" --jq '.actions_caches[].id')
 
           if [[ -z "$IDS" ]]; then

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,48 @@
+name: cleanup-pr-caches
+
+# A cache written by a pull request run is scoped to that pull request's merge ref, and GitHub
+# only lets re-runs of the same pull request restore it: not main, not other pull requests. Once
+# the pull request is closed nothing can ever hit those entries again, so they just occupy the
+# repository cache quota until the retention policy collects them, shortening how long the
+# shared caches on main survive. Delete them immediately instead.
+#
+# Caches that a pull request merely *read* from main are owned by refs/heads/main. They are a
+# different scope and are never listed, let alone deleted, by this workflow.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  delete-pr-caches:
+    runs-on: ubuntu-latest
+    # Fork pull requests receive a read-only GITHUB_TOKEN, so the deletion would fail with
+    # permission denied. Their caches are left to the repository retention policy.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: write # So we can delete the caches.
+    steps:
+      - name: Delete caches scoped to this pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+
+          # Deleting entries renumbers the pages of the list endpoint, so collect every id
+          # before deleting any of them.
+          IDS=$(gh api --paginate "/repos/$GH_REPO/actions/caches?ref=$PR_REF&per_page=100" --jq '.actions_caches[].id')
+
+          if [[ -z "$IDS" ]]; then
+            echo "No caches scoped to $PR_REF."
+            exit 0
+          fi
+
+          echo "Found $(echo "$IDS" | wc -l | tr -d ' ') cache(s) scoped to $PR_REF."
+          while read -r id; do
+            gh api --method DELETE "/repos/$GH_REPO/actions/caches/$id" --silent
+            echo "Deleted cache $id"
+          done <<< "$IDS"

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -54,9 +54,7 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ${{ needs.goversion.outputs.version }}
-        # This job's caches are scoped to the PR ref, so they're only ever reused by pushes to
-        # the same PR, while still competing for the repository-wide cache quota with the
-        # go-build-cache-* entries that every branch shares.
+        # PR-scoped, so it only ever competes for quota with the shared go-build-cache-* entries.
         cache: false
     - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
     - name: Download yq

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -54,6 +54,10 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ${{ needs.goversion.outputs.version }}
+        # This job's caches are scoped to the PR ref, so they're only ever reused by pushes to
+        # the same PR, while still competing for the repository-wide cache quota with the
+        # go-build-cache-* entries that every branch shares.
+        cache: false
     - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2

--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -74,35 +74,65 @@ echo
 EXIT_CODE=0
 FAILED_PACKAGES=""
 
-# Run one package at a time so that a failure can be retried individually without re-running
-# the entire group.
+# Run all the packages in a single "go test" invocation: go test runs packages concurrently
+# (up to -p, which defaults to GOMAXPROCS), while invoking it once per package would run them
+# serially. Unit tests are mostly latency-bound (they spend their time waiting, not computing),
+# so this is roughly 2x faster on a CI runner even though the runner only has a few cores.
+# Failed packages are then retried individually, so a flaky package doesn't re-run the group.
 MAX_ATTEMPTS=2
+OUTPUT_FILE=$(mktemp)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
 
-for pkg in $GROUP_TESTS; do
-    if echo "$pkg" | grep -q --extended-regexp "$SKIP_RACE_DETECTOR_PATTERN"; then
-        RACE_FLAG=""
-    else
-        RACE_FLAG="-race"
+RACE_PACKAGES=$(echo "$GROUP_TESTS" | grep -v --extended-regexp "$SKIP_RACE_DETECTOR_PATTERN")
+NO_RACE_PACKAGES=$(echo "$GROUP_TESTS" | grep --extended-regexp "$SKIP_RACE_DETECTOR_PATTERN")
+
+# Runs "go test" on the given packages, setting FAILED to the space separated list of packages
+# that failed. FAILED is set to "$@" if the failure can't be attributed to specific packages.
+run_tests() {
+    local race_flag=$1
+    shift
+
+    # shellcheck disable=SC2086 # we *want* word splitting of race_flag.
+    go test -tags="${BUILD_TAGS}" -timeout 30m $race_flag "$@" 2>&1 | tee "$OUTPUT_FILE"
+
+    if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
+        FAILED=""
+        return
     fi
+
+    # "go test" reports a failed package as "FAIL<tab>package<tab>duration" (or "[build failed]").
+    FAILED=$(grep --extended-regexp "^FAIL[[:space:]]+github.com/grafana/mimir/" "$OUTPUT_FILE" | awk '{print $2}' | sort -u | xargs)
+    if [[ -z "$FAILED" ]]; then
+        FAILED="$*"
+    fi
+}
+
+for RACE_FLAG in "-race" ""; do
+    if [[ "$RACE_FLAG" == "-race" ]]; then
+        PACKAGES=$(echo "$RACE_PACKAGES" | xargs)
+    else
+        PACKAGES=$(echo "$NO_RACE_PACKAGES" | xargs)
+    fi
+
+    [[ -z "$PACKAGES" ]] && continue
 
     for ATTEMPT in $(seq 1 $MAX_ATTEMPTS); do
         if [[ $ATTEMPT -gt 1 ]]; then
-            echo "Retrying failed package: $pkg"
+            echo
+            echo "Retrying failed packages: $PACKAGES"
             echo
         fi
 
-        # shellcheck disable=SC2086 # we *want* word splitting of RACE_FLAG.
-        go test -tags="${BUILD_TAGS}" -timeout 30m $RACE_FLAG "$pkg"
-        PKG_EXIT_CODE=$?
+        # shellcheck disable=SC2086 # we *want* word splitting of PACKAGES.
+        run_tests "$RACE_FLAG" $PACKAGES
+        PACKAGES=$FAILED
 
-        if [[ $PKG_EXIT_CODE -eq 0 ]]; then
-            break
-        fi
+        [[ -z "$PACKAGES" ]] && break
     done
 
-    if [[ $PKG_EXIT_CODE -ne 0 ]]; then
+    if [[ -n "$PACKAGES" ]]; then
         EXIT_CODE=1
-        FAILED_PACKAGES="${FAILED_PACKAGES} ${pkg}"
+        FAILED_PACKAGES="${FAILED_PACKAGES} ${PACKAGES}"
     fi
 done
 

--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -74,11 +74,8 @@ echo
 EXIT_CODE=0
 FAILED_PACKAGES=""
 
-# Run all the packages in a single "go test" invocation: go test runs packages concurrently
-# (up to -p, which defaults to GOMAXPROCS), while invoking it once per package would run them
-# serially. Unit tests are mostly latency-bound (they spend their time waiting, not computing),
-# so this is roughly 2x faster on a CI runner even though the runner only has a few cores.
-# Failed packages are then retried individually, so a flaky package doesn't re-run the group.
+# These tests are latency-bound rather than CPU-bound, so batching all packages into one
+# "go test" is ~2x faster than one invocation per package even on a 4 core runner.
 MAX_ATTEMPTS=2
 OUTPUT_FILE=$(mktemp)
 trap 'rm -f "$OUTPUT_FILE"' EXIT
@@ -86,8 +83,7 @@ trap 'rm -f "$OUTPUT_FILE"' EXIT
 RACE_PACKAGES=$(echo "$GROUP_TESTS" | grep -v --extended-regexp "$SKIP_RACE_DETECTOR_PATTERN")
 NO_RACE_PACKAGES=$(echo "$GROUP_TESTS" | grep --extended-regexp "$SKIP_RACE_DETECTOR_PATTERN")
 
-# Runs "go test" on the given packages, setting FAILED to the space separated list of packages
-# that failed. FAILED is set to "$@" if the failure can't be attributed to specific packages.
+# Sets FAILED to the packages that failed, or to all of "$@" if it can't be attributed.
 run_tests() {
     local race_flag=$1
     shift
@@ -100,7 +96,6 @@ run_tests() {
         return
     fi
 
-    # "go test" reports a failed package as "FAIL<tab>package<tab>duration" (or "[build failed]").
     FAILED=$(grep --extended-regexp "^FAIL[[:space:]]+github.com/grafana/mimir/" "$OUTPUT_FILE" | awk '{print $2}' | sort -u | xargs)
     if [[ -z "$FAILED" ]]; then
         FAILED="$*"

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -186,11 +186,8 @@ jobs:
   # cache entries: integration tests (no -race), unit tests (-race), and image builds + linting
   # (CGO_ENABLED=0, multi-arch for images, single-arch for lint).
   #
-  # Consumers restore with two fallback tiers: same build image first, then any build image.
-  # The second tier matters because the build image is rebuilt whenever its own tooling
-  # dependencies are bumped, which usually leaves the Go toolchain untouched: without it, every
-  # such bump would drop all branches to a cold cache. Entries compiled by a different Go
-  # version are simply never hit, since Go keys the build cache by compiler build ID.
+  # The second restore-keys tier falls back across build images, which get rebuilt for reasons
+  # unrelated to the Go toolchain. Safe: Go keys cache entries by compiler build ID.
   warmup-go-build-cache-integration-tests:
     needs: [goversion, prepare]
     runs-on: ubuntu-latest
@@ -316,10 +313,8 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 5 groups. Each group runs its packages concurrently in a single
-      # "go test" invocation, so a group's runtime is dominated by its slowest package
-      # (~4min for pkg/ingester) rather than by the number of packages in it: more groups
-      # than this just adds job startup and Go build cache restore overhead.
+      # A group's runtime is bounded by its slowest package, not by how many packages it holds,
+      # so more groups only add per-job startup and cache restore overhead.
       matrix:
         test_group_id:    [0, 1, 2, 3, 4]
         test_group_total: [5]

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -86,7 +86,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-image-and-lint-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
         # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
@@ -183,6 +185,12 @@ jobs:
   # There are three separate warmup jobs because different compilation flags produce different
   # cache entries: integration tests (no -race), unit tests (-race), and image builds + linting
   # (CGO_ENABLED=0, multi-arch for images, single-arch for lint).
+  #
+  # Consumers restore with two fallback tiers: same build image first, then any build image.
+  # The second tier matters because the build image is rebuilt whenever its own tooling
+  # dependencies are bumped, which usually leaves the Go toolchain untouched: without it, every
+  # such bump would drop all branches to a cold cache. Entries compiled by a different Go
+  # version are simply never hit, since Go keys the build cache by compiler build ID.
   warmup-go-build-cache-integration-tests:
     needs: [goversion, prepare]
     runs-on: ubuntu-latest
@@ -308,10 +316,13 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 10 groups.
+      # Split tests into 5 groups. Each group runs its packages concurrently in a single
+      # "go test" invocation, so a group's runtime is dominated by its slowest package
+      # (~4min for pkg/ingester) rather than by the number of packages in it: more groups
+      # than this just adds job startup and Go build cache restore overhead.
       matrix:
-        test_group_id:    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        test_group_total: [10]
+        test_group_id:    [0, 1, 2, 3, 4]
+        test_group_total: [5]
         extra_build_tags: ["", "nopools"]
     needs:
       - prepare
@@ -333,7 +344,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-unit-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Symlink Expected Path to Workspace
@@ -425,7 +438,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -449,7 +464,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -473,7 +490,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -497,7 +516,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -521,7 +542,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -549,7 +572,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-image-and-lint-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Build
@@ -633,7 +658,9 @@ jobs:
         with:
           path: /go/cache
           key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-unit-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Install Docker Client
@@ -686,7 +713,9 @@ jobs:
         with:
           path: /home/runner/.cache/go-build
           key: go-build-cache-integration-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
-          restore-keys: go-build-cache-integration-${{ needs.prepare.outputs.build_image }}-
+          restore-keys: |
+            go-build-cache-integration-${{ needs.prepare.outputs.build_image }}-
+            go-build-cache-integration-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Symlink Expected Path to Workspace

--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           # We only use this to run `go mod` commands, so it doesn't need to follow the version used in the Dockerfile.
           go-version: "1.26.5"
+          # `go mod` commands don't populate a build cache worth keeping, and the entries would
+          # compete for the repository-wide cache quota with the go-build-cache-* entries.
+          cache: false
 
       # This job uses "mimir-vendoring bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)
       # because any events triggered by the later don't spawn GitHub actions.

--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -79,8 +79,7 @@ jobs:
         with:
           # We only use this to run `go mod` commands, so it doesn't need to follow the version used in the Dockerfile.
           go-version: "1.26.5"
-          # `go mod` commands don't populate a build cache worth keeping, and the entries would
-          # compete for the repository-wide cache quota with the go-build-cache-* entries.
+          # Nothing worth caching from `go mod`, and it competes for the cache quota.
           cache: false
 
       # This job uses "mimir-vendoring bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)


### PR DESCRIPTION
## what
runs each unit test group as a single `go test` invocation instead of one per package, drops the group count from 10 to 5, and fixes two problems with how we use the actions cache.

## why
`run-unit-tests-group.sh` ran `go test` once per package, serially, so a group used 0.4 of the runner's 4 cores — 98s of CPU over 242s of wall clock. these tests are latency-bound, not CPU-bound, so serializing packages wastes almost the whole runner. batching them lets `go test` schedule packages concurrently up to `-p`.

group wall time is now bounded by the slowest single package rather than by how many packages are in the group, so 10 groups buy nothing over 5. locally at `GOMAXPROCS=4`: group 0 of 5 went 231s -> 94s, and the heaviest group (the one with `pkg/ingester`) ran in 254s against a 485s serial sum.

the cache fixes came out of checking whether we were actually getting anything from the runner cache:

- the restore keys embedded the full build image reference, digest included, in both the primary key *and* its only fallback prefix. the build image gets rebuilt every time its own tooling deps are bumped — 8 times in the currently retained cache window, none of which touch the go toolchain — and each one dropped all three caches to nothing on every branch until main warmed them again. main is doing this right now with #16327.
- `compare-helm-with-jsonnet.yml` and `update-vendored-mimir-prometheus.yml` called `setup-go` without `cache: false`, unlike the two calls in this file. that was 26 entries / 8.18GB, as much as every deliberate go build cache combined, all scoped to `refs/pull/N/merge` so only another push to the same PR could ever restore them. the module half is empty anyway since we vendor.

caches are reclaimed on last access, not on age, so that footprint was shortening how long the shared caches on main survive.

## notes
- per-package retry is why the per-package loop existed. kept it by parsing the `FAIL\t<pkg>` lines out of the output and re-running only those packages.
- the second restore-keys tier is safe because go keys build cache entries by compiler build ID — entries from a different go version get carried but never hit.
- **this renames the required status checks** (`test (0, 10)` -> `test (0, 5)`), so branch protection needs updating or merges will block.
- deliberately based a couple of commits behind main: main just bumped the build image, and branching off that would have measured a cold cache on top of the batching change. will rebase before review.
- `-parallel 16` on top of this is worth another 25-30% but flaked `TestIngester_compactBlocksToReduceInMemorySeries_Concurrency`, so not here.
- the integration test split is 3.03x imbalanced by round-robin and is the next thing worth doing, but it needs a committed timings file since none of those tests call `t.Parallel()`.
