### PR TITLE
ci: install zstd in the build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr16327-e6bd1b71f4@sha256:61d10fc7939761c4ffc6217db15fabda8949b7e65605dd1910ebb0f20fd3c90b
+LATEST_BUILD_IMAGE_TAG ?= pr16336-e30cf26c29@sha256:df69ecf046713d76b792d83a916d5652635cf532a559231764c4b49333090e89
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
       jq \
       zip \
       unzip \
+      zstd \
       protobuf-compiler \
       libprotobuf-dev \
       shellcheck \


### PR DESCRIPTION
## what
installs `zstd` in the build image.

## why
`actions/cache` only uses zstd if a zstd binary is on PATH, and it runs *inside* the job container. the build image never had one, so every job running in it fell back to gzip which is slower and leads to bigger artifacts:

|                        | gzip           | zstd           |
|------------------------|----------------|----------------|
| restore step, median   | 35s            | **20s**        |
| restore step, min/max  | 31s / 46s      | 15s / 32s      |
| archive size           | 1062 MB        | 1014 MB        |

that 30s of gunzip is on the critical path for many jobs, and the warmup jobs on main pay it again on the compress side.

## notes
- integration jobs are already using zstd so this applies to unit tests
- merging this will invalidate the cache for unit and image-and-lint, but after a first cold start caching will resume as always 