### PR TITLE
Store-gateway: drain chunk range reader before close to allow connection reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
 * [BUGFIX] MQE: Fix an issue where series were joined in binary operations using the wrong labels when `group_left()`/`group_right()` were used in combination with `ignoring()`. This bug manifested as valid queries returning an error `grouping labels must ensure unique matches`. #16387
 * [BUGFIX] Upgrade Go to 1.26 latest with fixes for [CVE-2026-33818](https://pkg.go.dev/vuln/GO-2026-5972), [CVE-2026-39821](https://pkg.go.dev/vuln/GO-2026-5026), [CVE-2026-46600](https://pkg.go.dev/vuln/GO-2026-5942), [CVE-2026-56853](https://pkg.go.dev/vuln/GO-2026-6089), [CVE-2026-56858](https://pkg.go.dev/vuln/GO-2026-6091), [CVE-2026-56859](https://pkg.go.dev/vuln/GO-2026-6088), [CVE-2026-56860](https://pkg.go.dev/vuln/GO-2026-6218), and [CVE-2026-56862](https://pkg.go.dev/vuln/GO-2026-6090). #16408 #16430
-* [BUGFIX] Store-gateway: Drain the chunks range reader before closing it so the underlying HTTP connection can be reused, instead of opening a new connection for every chunk range fetched from object storage. #16338
+* [BUGFIX] Store-gateway: Drain the chunks range reader before closing it so HTTP object storage connections can be reused. #16338
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
 * [BUGFIX] MQE: Fix an issue where series were joined in binary operations using the wrong labels when `group_left()`/`group_right()` were used in combination with `ignoring()`. This bug manifested as valid queries returning an error `grouping labels must ensure unique matches`. #16387
 * [BUGFIX] Upgrade Go to 1.26 latest with fixes for [CVE-2026-33818](https://pkg.go.dev/vuln/GO-2026-5972), [CVE-2026-39821](https://pkg.go.dev/vuln/GO-2026-5026), [CVE-2026-46600](https://pkg.go.dev/vuln/GO-2026-5942), [CVE-2026-56853](https://pkg.go.dev/vuln/GO-2026-6089), [CVE-2026-56858](https://pkg.go.dev/vuln/GO-2026-6091), [CVE-2026-56859](https://pkg.go.dev/vuln/GO-2026-6088), [CVE-2026-56860](https://pkg.go.dev/vuln/GO-2026-6218), and [CVE-2026-56862](https://pkg.go.dev/vuln/GO-2026-6090). #16408 #16430
+* [BUGFIX] Store-gateway: Drain the chunks range reader before closing it so the underlying HTTP connection can be reused, instead of opening a new connection for every chunk range fetched from object storage. #16338
 
 ### Mixin
 

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -134,7 +134,14 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 	if err != nil {
 		return errors.Wrap(err, "get range reader")
 	}
-	defer runutil.CloseWithLogOnErr(r.block.logger, bucketReader, "readChunkRange close range reader")
+	// Drain any unread bytes of the fetched range before closing it, so the underlying HTTP
+	// connection can be returned to the idle pool and reused. The range is fetched using
+	// estimated chunk lengths, so it frequently extends past the last chunk actually read;
+	// closing a response body with unread bytes causes net/http to discard the connection.
+	defer func() {
+		_, _ = io.Copy(io.Discard, bucketReader)
+		runutil.CloseWithLogOnErr(r.block.logger, bucketReader, "readChunkRange close range reader")
+	}()
 
 	// Since we may load many chunks, to avoid having to lock very frequently we accumulate
 	// all stats in a local instance and then merge it in the defer.

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -134,14 +134,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 	if err != nil {
 		return errors.Wrap(err, "get range reader")
 	}
-	// Drain any unread bytes of the fetched range before closing it, so the underlying HTTP
-	// connection can be returned to the idle pool and reused. The range is fetched using
-	// estimated chunk lengths, so it frequently extends past the last chunk actually read;
-	// closing a response body with unread bytes causes net/http to discard the connection.
-	defer func() {
-		_, _ = io.Copy(io.Discard, bucketReader)
-		runutil.CloseWithLogOnErr(r.block.logger, bucketReader, "readChunkRange close range reader")
-	}()
+	defer runutil.CloseWithLogOnErr(r.block.logger, bucketReader, "readChunkRange close range reader")
 
 	// Since we may load many chunks, to avoid having to lock very frequently we accumulate
 	// all stats in a local instance and then merge it in the defer.
@@ -208,6 +201,10 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 		// where the crc32 + length varint size are a substantial part of the chunk.
 		localStats.chunksTouchedSizeSum += varint.UvarintSize(chunkDataLen) + chunkEncDataLen + crc32.Size
 	}
+
+	// Chunk lengths are estimated, so drain any overfetched tail to make the connection reusable.
+	_, _ = io.Copy(io.Discard, reader)
+
 	return nil
 }
 

--- a/pkg/storegateway/bucket_chunk_reader_test.go
+++ b/pkg/storegateway/bucket_chunk_reader_test.go
@@ -513,3 +513,60 @@ type mockObjectStoreBucketReader struct {
 func (r mockObjectStoreBucketReader) GetRange(_ context.Context, _ string, off, length int64) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(r.b[off:min(off+length, int64(len(r.b)))])), nil
 }
+
+// drainTrackingBucketReader records how many bytes of the returned range readers are consumed, so
+// a test can assert the overfetched tail is drained, which is what makes the underlying HTTP
+// connection reusable.
+type drainTrackingBucketReader struct {
+	objstore.BucketReader
+	b        []byte
+	served   *int64
+	consumed *int64
+}
+
+func (r drainTrackingBucketReader) GetRange(_ context.Context, _ string, off, length int64) (io.ReadCloser, error) {
+	end := min(off+length, int64(len(r.b)))
+	*r.served += end - off
+	return io.NopCloser(&countingReader{r: bytes.NewReader(r.b[off:end]), consumed: r.consumed}), nil
+}
+
+type countingReader struct {
+	r        *bytes.Reader
+	consumed *int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	*c.consumed += int64(n)
+	return n, err
+}
+
+func TestBucketChunkReader_loadChunks_drainsOverfetchedTail(t *testing.T) {
+	// A single valid chunk followed by a tail which loadChunks fetches, because chunk lengths are
+	// estimated, but never reads.
+	chunkBytes := createChunkBytes(chunkenc.EncXOR, 100, 1)
+	// The tail must exceed the bufio buffer the chunk reader wraps the range in (sized
+	// EstimatedMaxChunkSize), otherwise read-ahead consumes it incidentally and this test
+	// would pass even without the drain.
+	b := append(chunkBytes, make([]byte, 4*tsdb.EstimatedMaxChunkSize)...)
+
+	var served, consumed int64
+	block := &bucketBlock{
+		bkt:          drainTrackingBucketReader{b: b, served: &served, consumed: &consumed},
+		partitioners: blockPartitioners{naivePartitioner{}, naivePartitioner{}, naivePartitioner{}},
+		chunkObjs:    []string{"test-chunk"},
+	}
+
+	reader := newBucketChunkReader(t.Context(), block)
+	// Deliberately over-estimate the chunk length so the fetched range includes the tail.
+	require.NoError(t, reader.addLoad(chunks.ChunkRef(0), 0, 0, uint32(len(b))))
+
+	loadedChunks := make([]seriesChunks, 1)
+	loadedChunks[0].chks = make([]storepb.AggrChunk, 1)
+	chunksPool := pool.NewSafeSlabPool[byte](chunkBytesSlicePool, seriesChunksSlabSize)
+
+	require.NoError(t, reader.load(loadedChunks, chunksPool, newSafeQueryStats()))
+
+	require.Greater(t, served, int64(0))
+	require.Equal(t, served, consumed, "the whole fetched range should be consumed so the connection can be reused")
+}


### PR DESCRIPTION
### What this PR does

Drains the chunks range reader before closing it in `bucketChunkReader.loadChunks`, so the underlying HTTP connection is returned to the idle pool instead of being discarded.

The range is fetched using estimated chunk lengths, so it frequently extends past the end of the last chunk actually read. `net/http` cannot reuse a connection whose response body has unread bytes, so every chunk range fetch was costing a fresh TCP (and TLS) connection.

Reproduced in isolation — 100 identical 1 MiB ranged GETs against MinIO, TCP dials counted by hooking `Transport.DialContext`:

| | TCP dials |
|---|---|
| body fully drained | 1 |
| 4 KiB read, then Close | 100 |

There is no size threshold: 8 KiB through 4 MiB ranges all produce 100 dials when the body is abandoned. Repro: https://gist.github.com/omkar619-dev/23460d8af1d421479be9804c857ca327

Same class of fix as #16303 (Memcached connection reuse).

### Which issue(s) this PR fixes

Relates to #13841

Approach confirmed by @narqo in https://github.com/grafana/mimir/issues/13841#issuecomment-5239724848 ("simply draining the connection in-place will be enough").

### Notes for reviewers

- `fetchChunkRemainder` uses the same non-draining close but reads an exact length via
  `io.ReadFull`, so it likely consumes fully. Left unchanged to keep this minimal — happy to include it if you'd prefer.
- The drained tail is bounded by chunk-length estimation error, not range size: gaps inside the part are already consumed by `SkipTo`, so only the segment past the last chunk remains, on the order of `EstimatedMaxChunkSize`.

### Checklist

- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
