### PR TITLE
ci: give the slowest integration test a group of its own

### DIFF
--- a/.github/workflows/scripts/run-integration-tests-group.sh
+++ b/.github/workflows/scripts/run-integration-tests-group.sh
@@ -40,8 +40,22 @@ fi
 # List all tests.
 ALL_TESTS=$(go test -tags=stringlabels -list 'Test.*' "${INTEGRATION_DIR}" | grep -E '^Test.*' | sort)
 
-# Filter tests by the requested group.
-GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL="$TOTAL" -v INDEX="$INDEX" 'NR % TOTAL == INDEX')
+# Tests slow enough that no round-robin of the others can balance around them, so they get a
+# group each: TestIngesterSharding alone is 9% of the suite and 2.2x the next slowest test.
+# Pinning it matches the slowest-group time an optimal duration-aware split would reach.
+# Names that no longer exist are ignored, so a rename degrades to a plain round-robin.
+DEDICATED_TESTS="TestIngesterSharding"
+
+PINNED_TESTS=$(echo "$ALL_TESTS" | grep -xF "$DEDICATED_TESTS" || true)
+NUM_PINNED=$(echo "$PINNED_TESTS" | grep -c . || true)
+
+if [[ "$INDEX" -lt "$NUM_PINNED" ]]; then
+    GROUP_TESTS=$(echo "$PINNED_TESTS" | sed -n "$((INDEX + 1))p")
+else
+    # Round-robin the rest over the groups the pinned tests didn't take.
+    GROUP_TESTS=$(echo "$ALL_TESTS" | grep -vxF "$DEDICATED_TESTS" \
+        | awk -v TOTAL="$((TOTAL - NUM_PINNED))" -v INDEX="$((INDEX - NUM_PINNED))" 'NR % TOTAL == INDEX')
+fi
 
 if [[ -z "$GROUP_TESTS" ]]; then
     echo "ERROR: No tests found for group $INDEX of $TOTAL. This likely indicates a compilation error or misconfiguration."


### PR DESCRIPTION
## what
gives `TestIngesterSharding` an integration group to itself and round-robins the remaining 110 tests over the other 19.

## why
the integration split round-robins the sorted test list, which leaves it **3.13x imbalanced**. measured on run 31381351961, the 20 groups ranged from 90s to **703s** against a 224s average.

`TestIngesterSharding` is the whole problem: at **290s**. pinning it takes the slowest group from 628s to 290s of test time.

## notes
- this won't move wall clock on its own: #16335 and this one together are what get a run to ~11 min
