### PR TITLE
tests: Fix flaky TestSingleClusterPartitionReader_ConsumeAtStartup

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1577,12 +1577,6 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 					testRoutines := sync.WaitGroup{}
 					t.Cleanup(testRoutines.Wait)
 
-					// Create a channel to signal goroutines once the test has done.
-					testDone := make(chan struct{})
-					t.Cleanup(func() {
-						close(testDone)
-					})
-
 					consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 
 					cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
@@ -1599,7 +1593,7 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 								t.Logf("artificially slowing down OffsetFetch request by %s", delay.String())
 
 								select {
-								case <-testDone:
+								case <-ctx.Done():
 								case <-time.After(delay):
 								}
 							})
@@ -1614,21 +1608,17 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 					// Continue to produce records at a high pace, so that we simulate the case there are always new
 					// records to fetch.
-					testRoutines.Add(1)
-					go func() {
-						defer testRoutines.Done()
-
+					testRoutines.Go(func() {
 						for {
 							select {
-							case <-testDone:
+							case <-ctx.Done():
 								return
-
 							case <-time.After(targetLag / 2):
 								produceRecord(ctx, t, writeClient, topicName, partitionID, []byte(fmt.Sprintf("record-%d", nextRecordID.Inc())))
 								t.Log("produced 1 record")
 							}
 						}
-					}()
+					})
 
 					// Create and start the reader.
 					reg := prometheus.NewPedanticRegistry()


### PR DESCRIPTION
#### What this PR does

Fixes a flaky subtest of TestSingleClusterPartitionReader_ConsumeAtStartup that often failed with an unexpected context cancelled error. Avoid this by using the test context to control the producer thread and stopping it when the test ends. This avoids the producer thread trying to write with a cancelled context after the test has ended but before cleanup methods have run.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
