### PR TITLE
compartments: name the read compartment in query-path ring errors

### DIFF
--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -159,7 +159,7 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, ma
 			for _, c := range targets {
 				r, err := d.partitionInstanceRings.Get(c).ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, now)
 				if err != nil {
-					return nil, err
+					return nil, errors.Wrapf(err, "read compartment %d", c)
 				}
 
 				// If the lookback cap filters out every partition in a targeted compartment,
@@ -167,7 +167,7 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, ma
 				// empty compartments (serving that data from storage instead) is left to a follow-up.
 				sets, err := r.GetReplicationSetsForOperation(readNoExtend)
 				if err != nil {
-					return nil, err
+					return nil, errors.Wrapf(err, "read compartment %d", c)
 				}
 				replicationSets = append(replicationSets, sets...)
 			}

--- a/pkg/distributor/query_compartments_test.go
+++ b/pkg/distributor/query_compartments_test.go
@@ -209,6 +209,23 @@ func TestDistributor_getIngesterReplicationSetsForQuery_Compartments(t *testing.
 		cortex_querier_compartments_hit_per_query_count{storage="ingester"} 3
 	`
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_querier_compartments_hit_per_query"))
+
+	for unhealthy := 0; unhealthy < numCompartments; unhealthy++ {
+		t.Run(fmt.Sprintf("a ring error names the read compartment it came from: compartment %d", unhealthy), func(t *testing.T) {
+			ringStates := make([]ring.InstanceState, numCompartments)
+			for c := range ringStates {
+				ringStates[c] = ring.ACTIVE
+			}
+			// LEAVING is not part of readNoExtend, so the only owner of this compartment's partition is unhealthy.
+			ringStates[unhealthy] = ring.LEAVING
+
+			d, _, _ := prepareCompartmentsQueryTestDistributorWithRingStates(t, tenantID, numCompartments, ringStates)
+
+			_, err := d.getIngesterReplicationSetsForQuery(ctx, nil)
+			require.ErrorIs(t, err, ring.ErrTooManyUnhealthyInstances)
+			require.ErrorContains(t, err, fmt.Sprintf("read compartment %d", unhealthy))
+		})
+	}
 }
 
 // TestDistributor_QueryExemplars_Compartments verifies that the exemplars API, which accepts multiple
@@ -374,6 +391,14 @@ func assertCompartmentsHitObservation(t *testing.T, reg *prometheus.Registry, nu
 func prepareCompartmentsQueryTestDistributor(t *testing.T, tenantID string, numCompartments int) (*Distributor, *prometheus.Registry, []string) {
 	t.Helper()
 
+	return prepareCompartmentsQueryTestDistributorWithRingStates(t, tenantID, numCompartments, nil)
+}
+
+// prepareCompartmentsQueryTestDistributorWithRingStates is prepareCompartmentsQueryTestDistributor with
+// explicit ingester ring states, indexed like the ingesters. A nil ringStates leaves every ingester ACTIVE.
+func prepareCompartmentsQueryTestDistributorWithRingStates(t *testing.T, tenantID string, numCompartments int, ringStates []ring.InstanceState) (*Distributor, *prometheus.Registry, []string) {
+	t.Helper()
+
 	activePartitions := make(map[int][]int32, numCompartments)
 	for c := 0; c < numCompartments; c++ {
 		activePartitions[c] = []int32{int32(c)}
@@ -384,7 +409,7 @@ func prepareCompartmentsQueryTestDistributor(t *testing.T, tenantID string, numC
 		ingestStorageEnabled:    true,
 		ingestStoragePartitions: int32(numCompartments),
 		ingesterStateByZone: map[string]ingesterZoneState{
-			"zone-a": {numIngesters: numCompartments, happyIngesters: numCompartments},
+			"zone-a": {numIngesters: numCompartments, happyIngesters: numCompartments, ringStates: ringStates},
 		},
 		ingesterDataTenantID:        tenantID,
 		replicationFactor:           1,

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -832,7 +832,7 @@ func (q *blocksStoreQuerier) targetCompartments(tenantID string, matchers []*lab
 // and returns the first error, cancelling the in-flight siblings on error.
 func (q *blocksStoreQuerier) forEachCompartment(ctx context.Context, targets []int, fn func(ctx context.Context, c blocksStoreCompartment) error) error {
 	if len(targets) == 1 {
-		return fn(ctx, q.compartments[targets[0]])
+		return q.wrapCompartmentError(targets[0], fn(ctx, q.compartments[targets[0]]))
 	}
 
 	// fn may open store-gateway streams that are read lazily after this returns, so the context passed to
@@ -842,7 +842,7 @@ func (q *blocksStoreQuerier) forEachCompartment(ctx context.Context, targets []i
 	g := &errgroup.Group{}
 	for _, c := range targets {
 		g.Go(func() error {
-			if err := fn(ctx, q.compartments[c]); err != nil {
+			if err := q.wrapCompartmentError(c, fn(ctx, q.compartments[c])); err != nil {
 				cancel(err)
 				return err
 			}
@@ -850,6 +850,16 @@ func (q *blocksStoreQuerier) forEachCompartment(ctx context.Context, targets []i
 		})
 	}
 	return g.Wait() //nolint:govet // OK to return without cancelling ctx on success, see comment above.
+}
+
+// wrapCompartmentError annotates err with the read compartment it came from, and returns it unchanged
+// when compartments are disabled.
+func (q *blocksStoreQuerier) wrapCompartmentError(compartmentID int, err error) error {
+	if err == nil || q.router == nil {
+		return err
+	}
+
+	return errors.Wrapf(err, "read compartment %d", compartmentID)
 }
 
 // queryCompartmentsWithConsistencyCheck runs queryWithConsistencyCheck against each targeted compartment

--- a/pkg/querier/blocks_store_queryable_compartments_test.go
+++ b/pkg/querier/blocks_store_queryable_compartments_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
 	"github.com/oklog/ulid/v2"
@@ -207,6 +208,53 @@ func TestBlocksStoreQuerier_Compartments_LabelNames(t *testing.T) {
 		// The hit metric is not registered when compartments are disabled.
 		require.Equal(t, 0, testutil.CollectAndCount(reg, "cortex_querier_compartments_hit_per_query"))
 		assertStoreGatewayInstancesHit(t, reg, 1, 0)
+	})
+
+	t.Run("should name the read compartment a ring error came from", func(t *testing.T) {
+		router := compartments.NewRouter(2)
+		block := ulid.MustNew(1, nil)
+
+		t.Run("when the query is pinned to the failing compartment", func(t *testing.T) {
+			for failing := 0; failing < 2; failing++ {
+				t.Run(fmt.Sprintf("compartment %d", failing), func(t *testing.T) {
+					finders := []*blocksFinderMock{{}, {}}
+					finders[failing].On("GetBlocks", mock.Anything, compartmentsTestTenant, minT, maxT).Return(bucketindex.Blocks{{ID: block}}, &bucketindex.Metadata{}, nil)
+
+					stores := []BlocksStoreSet{&blocksStoreSetMock{}, &blocksStoreSetMock{}}
+					stores[failing] = &blocksStoreSetMock{mockedResponses: []interface{}{ring.ErrTooManyUnhealthyInstances}}
+
+					q := newCompartmentsTestQuerier(finders, stores, prometheus.NewPedanticRegistry(), minT, maxT)
+
+					matcher := labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricNameForCompartment(t, router, failing))
+					_, _, err := q.LabelNames(ctx, nil, matcher)
+					require.ErrorIs(t, err, ring.ErrTooManyUnhealthyInstances)
+					require.ErrorContains(t, err, fmt.Sprintf("read compartment %d", failing))
+				})
+			}
+		})
+
+		t.Run("when the query fans out to all compartments", func(t *testing.T) {
+			for failing := 0; failing < 2; failing++ {
+				t.Run(fmt.Sprintf("compartment %d", failing), func(t *testing.T) {
+					// Only the failing compartment has blocks, so only it can fail. If both failed, the fan-out
+					// would return whichever error came first and the assertions below would flake.
+					finders := make([]BlocksFinder, 2)
+					stores := make([]BlocksStoreSet, 2)
+					for c := range finders {
+						finders[c] = &stubBlocksFinder{meta: &bucketindex.Metadata{}}
+						stores[c] = &blocksStoreSetMock{}
+					}
+					finders[failing] = &stubBlocksFinder{blocks: bucketindex.Blocks{{ID: block}}, meta: &bucketindex.Metadata{}}
+					stores[failing] = &blocksStoreSetMock{mockedResponses: []interface{}{ring.ErrTooManyUnhealthyInstances}}
+
+					q := newCompartmentsTestQuerierWithFinders(finders, stores, prometheus.NewPedanticRegistry(), minT, maxT)
+
+					_, _, err := q.LabelNames(ctx, nil, labels.MustNewMatcher(labels.MatchEqual, "job", "test"))
+					require.ErrorIs(t, err, ring.ErrTooManyUnhealthyInstances)
+					require.ErrorContains(t, err, fmt.Sprintf("read compartment %d", failing))
+				})
+			}
+		})
 	})
 }
 

--- a/pkg/querier/blocks_store_queryable_compartments_test.go
+++ b/pkg/querier/blocks_store_queryable_compartments_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/flagext"
-	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
 	"github.com/oklog/ulid/v2"
@@ -210,52 +209,6 @@ func TestBlocksStoreQuerier_Compartments_LabelNames(t *testing.T) {
 		assertStoreGatewayInstancesHit(t, reg, 1, 0)
 	})
 
-	t.Run("should name the read compartment a ring error came from", func(t *testing.T) {
-		router := compartments.NewRouter(2)
-		block := ulid.MustNew(1, nil)
-
-		t.Run("when the query is pinned to the failing compartment", func(t *testing.T) {
-			for failing := 0; failing < 2; failing++ {
-				t.Run(fmt.Sprintf("compartment %d", failing), func(t *testing.T) {
-					finders := []*blocksFinderMock{{}, {}}
-					finders[failing].On("GetBlocks", mock.Anything, compartmentsTestTenant, minT, maxT).Return(bucketindex.Blocks{{ID: block}}, &bucketindex.Metadata{}, nil)
-
-					stores := []BlocksStoreSet{&blocksStoreSetMock{}, &blocksStoreSetMock{}}
-					stores[failing] = &blocksStoreSetMock{mockedResponses: []interface{}{ring.ErrTooManyUnhealthyInstances}}
-
-					q := newCompartmentsTestQuerier(finders, stores, prometheus.NewPedanticRegistry(), minT, maxT)
-
-					matcher := labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricNameForCompartment(t, router, failing))
-					_, _, err := q.LabelNames(ctx, nil, matcher)
-					require.ErrorIs(t, err, ring.ErrTooManyUnhealthyInstances)
-					require.ErrorContains(t, err, fmt.Sprintf("read compartment %d", failing))
-				})
-			}
-		})
-
-		t.Run("when the query fans out to all compartments", func(t *testing.T) {
-			for failing := 0; failing < 2; failing++ {
-				t.Run(fmt.Sprintf("compartment %d", failing), func(t *testing.T) {
-					// Only the failing compartment has blocks, so only it can fail. If both failed, the fan-out
-					// would return whichever error came first and the assertions below would flake.
-					finders := make([]BlocksFinder, 2)
-					stores := make([]BlocksStoreSet, 2)
-					for c := range finders {
-						finders[c] = &stubBlocksFinder{meta: &bucketindex.Metadata{}}
-						stores[c] = &blocksStoreSetMock{}
-					}
-					finders[failing] = &stubBlocksFinder{blocks: bucketindex.Blocks{{ID: block}}, meta: &bucketindex.Metadata{}}
-					stores[failing] = &blocksStoreSetMock{mockedResponses: []interface{}{ring.ErrTooManyUnhealthyInstances}}
-
-					q := newCompartmentsTestQuerierWithFinders(finders, stores, prometheus.NewPedanticRegistry(), minT, maxT)
-
-					_, _, err := q.LabelNames(ctx, nil, labels.MustNewMatcher(labels.MatchEqual, "job", "test"))
-					require.ErrorIs(t, err, ring.ErrTooManyUnhealthyInstances)
-					require.ErrorContains(t, err, fmt.Sprintf("read compartment %d", failing))
-				})
-			}
-		})
-	})
 }
 
 func TestBlocksStoreQuerier_Compartments_LabelValues(t *testing.T) {
@@ -569,39 +522,56 @@ func TestBlocksStoreQuerier_Compartments_Select(t *testing.T) {
 
 	t.Run("should stop on the first compartment error", func(t *testing.T) {
 		ctx := user.InjectOrgID(context.Background(), compartmentsTestTenant)
+		router := compartments.NewRouter(2)
 
-		// One compartment's finder fails; the fan-out query must fail fast and return that error. The sibling
-		// compartment may or may not have been reached before the shared context was cancelled.
-		newFinders := func() []*blocksFinderMock {
+		// One compartment's finder fails; the query must fail fast and return that error, naming the
+		// compartment it came from. The sibling compartment may or may not have been reached before the
+		// shared context was cancelled.
+		newFinders := func(failing int) []*blocksFinderMock {
 			finders := []*blocksFinderMock{{}, {}}
-			finders[0].On("GetBlocks", mock.Anything, compartmentsTestTenant, minT, maxT).Return(bucketindex.Blocks(nil), (*bucketindex.Metadata)(nil), errors.New("finder failed"))
-			finders[1].On("GetBlocks", mock.Anything, compartmentsTestTenant, minT, maxT).Return(bucketindex.Blocks(nil), &bucketindex.Metadata{}, nil).Maybe()
+			finders[failing].On("GetBlocks", mock.Anything, compartmentsTestTenant, minT, maxT).Return(bucketindex.Blocks(nil), (*bucketindex.Metadata)(nil), errors.New("finder failed"))
+			finders[1-failing].On("GetBlocks", mock.Anything, compartmentsTestTenant, minT, maxT).Return(bucketindex.Blocks(nil), &bucketindex.Metadata{}, nil).Maybe()
 			return finders
 		}
 		stores := func() []BlocksStoreSet { return []BlocksStoreSet{&blocksStoreSetMock{}, &blocksStoreSetMock{}} }
-		fanOut := labels.MustNewMatcher(labels.MatchEqual, "job", "test")
 
-		t.Run("via LabelNames", func(t *testing.T) {
-			reg := prometheus.NewPedanticRegistry()
-			q := newCompartmentsTestQuerier(newFinders(), stores(), reg, minT, maxT)
-			_, _, err := q.LabelNames(ctx, nil, fanOut)
-			require.ErrorContains(t, err, "finder failed")
-			// A failed query observes none of the per-query metrics.
-			assertStoreGatewayInstancesHit(t, reg, 0, 0)
-		})
+		for failing := 0; failing < 2; failing++ {
+			matchers := []struct {
+				name    string
+				matcher *labels.Matcher
+			}{
+				{"pinned to the failing compartment", labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricNameForCompartment(t, router, failing))},
+				{"fanned out to all compartments", labels.MustNewMatcher(labels.MatchEqual, "job", "test")},
+			}
 
-		t.Run("via Select", func(t *testing.T) {
-			sctx := limiter.AddQueryLimiterToContext(ctx, limiter.NewQueryLimiter(0, 0, 0, 0, nil))
-			sctx = limiter.ContextWithNewUnlimitedMemoryConsumptionTracker(sctx)
-			sctx = limiter.ContextWithNewSeriesLabelsDeduplicator(sctx, limiter.NewSeriesDeduplicatorMetrics(prometheus.NewPedanticRegistry()))
-			_, sctx = stats.ContextWithEmptyStats(sctx)
+			for _, m := range matchers {
+				t.Run(fmt.Sprintf("compartment %d, %s", failing, m.name), func(t *testing.T) {
+					expectedErr := fmt.Sprintf("read compartment %d: finder failed", failing)
 
-			reg := prometheus.NewPedanticRegistry()
-			q := newCompartmentsTestQuerier(newFinders(), stores(), reg, minT, maxT)
-			set := q.Select(sctx, true, &storage.SelectHints{Start: minT, End: maxT}, fanOut)
-			require.ErrorContains(t, set.Err(), "finder failed")
-			assertStoreGatewayInstancesHit(t, reg, 0, 0)
-		})
+					t.Run("via LabelNames", func(t *testing.T) {
+						reg := prometheus.NewPedanticRegistry()
+						q := newCompartmentsTestQuerier(newFinders(failing), stores(), reg, minT, maxT)
+						_, _, err := q.LabelNames(ctx, nil, m.matcher)
+						require.EqualError(t, err, expectedErr)
+						// A failed query observes none of the per-query metrics.
+						assertStoreGatewayInstancesHit(t, reg, 0, 0)
+					})
+
+					t.Run("via Select", func(t *testing.T) {
+						sctx := limiter.AddQueryLimiterToContext(ctx, limiter.NewQueryLimiter(0, 0, 0, 0, nil))
+						sctx = limiter.ContextWithNewUnlimitedMemoryConsumptionTracker(sctx)
+						sctx = limiter.ContextWithNewSeriesLabelsDeduplicator(sctx, limiter.NewSeriesDeduplicatorMetrics(prometheus.NewPedanticRegistry()))
+						_, sctx = stats.ContextWithEmptyStats(sctx)
+
+						reg := prometheus.NewPedanticRegistry()
+						q := newCompartmentsTestQuerier(newFinders(failing), stores(), reg, minT, maxT)
+						set := q.Select(sctx, true, &storage.SelectHints{Start: minT, End: maxT}, m.matcher)
+						require.EqualError(t, set.Err(), expectedErr)
+						assertStoreGatewayInstancesHit(t, reg, 0, 0)
+					})
+				})
+			}
+		}
 	})
 }
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2200,8 +2200,10 @@ func TestBlocksStoreQuerier_Labels(t *testing.T) {
 			expectedErrRegex: "",
 		},
 		"error while finding blocks matching the query time range": {
-			finderErr:        errors.New("unable to find blocks"),
-			expectedErrRegex: "unable to find blocks",
+			finderErr: errors.New("unable to find blocks"),
+			// Anchored: with compartments disabled the error must reach the caller verbatim, with no read
+			// compartment prefixed to it.
+			expectedErrRegex: "^unable to find blocks$",
 		},
 		"error while getting clients to query the store-gateway": {
 			finderResult: bucketindex.Blocks{
@@ -2211,7 +2213,7 @@ func TestBlocksStoreQuerier_Labels(t *testing.T) {
 			storeSetResponses: []interface{}{
 				errors.New("no client found"),
 			},
-			expectedErrRegex: "no client found",
+			expectedErrRegex: "^no client found$",
 		},
 		"a single store-gateway instance holds the required blocks": {
 			finderResult: bucketindex.Blocks{


### PR DESCRIPTION
With read compartments enabled, a query that fails on an unhealthy ring reports e.g.  "partition 5: too many unhealthy instances in the ring". Every compartment has its own rings and numbers its partitions from zero, so that message doesn't say which compartment is affected.

Ring errors on the query paths now name the compartment: `read compartment 2: partition 5: too many unhealthy instances in the ring`.

