### PR TITLE
mixin: widen CompactorSchedulerRepeatedJobFailure alert lookback to 20m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [FEATURE] Block-builder: add jsonnet for deploying the experimental block-builder and block-builder-scheduler. Enable with `block_builder.enabled: true`. #16175 #16337
 * [ENHANCEMENT] Add the `compactor_standalone_enabled` config option (enabled by default) to hide standalone-mode compactor panels and alerts, and stop collapsing scheduler-mode dashboard rows. #16239
 * [ENHANCEMENT] Dashboards: Make the boot/root disk device regex used to filter it out of the "Disk writes" and "Disk reads" panels configurable via `_config.node_boot_disk_device_regex` (default unchanged: `.*sda.*`), so clusters where the root device isn't `sda` (e.g. `vda` on some cloud providers) don't lose data on those panels. #16235
+* [ENHANCEMENT] Alerts: Widen the `MimirCompactorSchedulerRepeatedJobFailure` lookback window to 20m to prevent the alert from flapping, consistently with `MimirBlockBuilderPersistentJobFailure`. #16346
 * [BUGFIX] Recording rules: Add the `image!=""` selector to the `cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate` recording rule, consistently with the memory one. Where cAdvisor sandbox and parent cgroup series are not dropped at scrape time, CPU usage was counted twice, which also inflated the replica count recommended by the Scaling dashboard. #16320
 * [BUGFIX] Alerts: Point `runbook_url` annotations at `/manage/mimir-runbooks/` (docs moved off `operators-guide`). #16329
 

--- a/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
@@ -43,7 +43,7 @@
               increase(cortex_compactor_scheduler_repeated_job_failures_total[%(rate_interval)s])
             ) > 0
           ||| % $._config {
-            rate_interval: $.rateInterval('5m'),
+            rate_interval: $.rateInterval('20m'),
           },
           labels: {
             severity: 'warning',


### PR DESCRIPTION
#### What this PR does

Widens the `MimirCompactorSchedulerRepeatedJobFailure` alert lookback window to 20m, for the same reasons we did it for the block-builder's equivalent alert in https://github.com/grafana/mimir/pull/15332.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.