### PR TITLE
Ingester: account for duplicate samples silently dropped at TSDB commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Ingester: `cortex_ingester_ingested_samples_total` no longer counts samples that the TSDB silently dropped at commit time because the series already had a sample at the same timestamp. Samples rejected at commit time for other reasons, such as out-of-order samples, are still counted. The dropped duplicates still count toward the `-ingester.instance-limits.max-ingestion-rate` limit and user stats, since they cost the full write path. #16347
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
+* [ENHANCEMENT] Ingester: Duplicate samples silently dropped by the TSDB at commit time are now counted in `cortex_discarded_samples_total`: exact duplicates (same timestamp and value, e.g. client retries) under the new reason `same-value-for-timestamp`, and same-timestamp conflicts only detectable at commit time under the existing reason `new-value-for-timestamp`. The drops are also attributed per series in cost attribution. #16347
 * [ENHANCEMENT] Compactor: Add the experimental `-compactor.block-health-validation-concurrency` option to limit how many blocks are validated concurrently within a compaction job. #16269
 * [ENHANCEMENT] Query-frontend: Improve the stability of cardinality estimates and therefore sharding factors for queries when running splitting and caching inside MQE is enabled, or range vector splitting is enabled. #16274 #16301 #16305 #16311
   * When running splitting and caching inside MQE is enabled, the `cortex_query_frontend_cardinality_estimation_difference` metric will no longer be emitted.

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -3866,10 +3866,26 @@ will remain in the `Terminated` state. This is harmless and will remain there un
 
 This means a sample with the same timestamp as the latest one was received with a different value. The number of occurrences is recorded in the `cortex_discarded_samples_total` metric with the label `reason="new-value-for-timestamp"`.
 
+Samples that exactly duplicate an already-stored sample are dropped without an error or log line. Refer to [Samples discarded with reason same-value-for-timestamp](#samples-discarded-with-reason-same-value-for-timestamp).
+
 Possible reasons for this are:
 
 - Incorrect relabelling rules can cause a label to be dropped from a series so that multiple series have the same labels. If these series were collected from the same target they will have the same timestamp.
 - The exporter being scraped sets the same timestamp on every scrape. Note that exporters should generally not set timestamps.
+- Multiple processes exporting metrics with the same identity (for example, prefork workers missing a `service.instance.id` resource attribute in OTLP setups), so their samples collide on the same series.
+
+## Samples discarded with reason same-value-for-timestamp
+
+This means a sample was received that exactly duplicates an already-stored sample of the same series: same timestamp and same value. These samples are dropped silently: the client receives a successful response and no log line is emitted. The number of occurrences is recorded in the `cortex_discarded_samples_total` metric with the label `reason="same-value-for-timestamp"`, and the drops are attributed per series in cost attribution when it's enabled.
+
+Possible reasons for this are:
+
+- Clients or shippers retrying, or double-sending, remote-write requests.
+- Multiple processes exporting identical metrics with the same identity, for example, prefork workers missing a `service.instance.id` resource attribute in OTLP setups.
+- With ingest storage enabled, ingesters can re-process recent Kafka records after a restart or a partition rebalance, and the replayed samples are discarded with this reason. Bursts following ingester rollouts are expected and don't indicate a client problem.
+- With created timestamp zero ingestion enabled, the synthetic zero sample that the ingester writes at a series' created timestamp can collide with a stored zero sample at the same timestamp, typically once when the series is created. These discards count a sample that the client never sent, so a small reconciliation gap against received samples is expected for such tenants.
+
+These discards are harmless because the sample's value is already stored. A sustained high rate indicates duplicated client traffic that is wasting write-path resources.
 
 ## Investigating query evaluation issues
 

--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260811220505-057e2c3231f4
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260812165107-b5a9b560a806
 
 // Replace memberlist with our fork which includes some changes that haven't been
 // merged upstream yet for years and we don't expect to change anytime soon.

--- a/go.sum
+++ b/go.sum
@@ -582,8 +582,8 @@ github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7 h1:F5hMoc+tCK
 github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7/go.mod h1:OSu8+LHxPUHB67c9v5Gfw5NQZxFWOL3EKmn9TgHvyCo=
 github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d h1:k4NIVPYPP0sLJoGNzGwoQs2MpnWTvTcgbWPCzfdX66c=
 github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260811220505-057e2c3231f4 h1:yhMSK7LgINCnYSGPFhKpGca/66xXpEGxiWSvPc5PlAo=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260811220505-057e2c3231f4/go.mod h1:ktbUbunZNb4VYpL2OBxBEoViff/uWLng+4yu3rkGvQU=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260812165107-b5a9b560a806 h1:ujG9m+2DJJogjkAhO9usPZBMKe0AAuXfUL1u0wch3Ls=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260812165107-b5a9b560a806/go.mod h1:ktbUbunZNb4VYpL2OBxBEoViff/uWLng+4yu3rkGvQU=
 github.com/grafana/otel-profiling-go v0.6.0 h1:W7lOZaJj4IJISXMcM1UBk3fJF3tzF2OD6MJBJaQp1H8=
 github.com/grafana/otel-profiling-go v0.6.0/go.mod h1:cqLIDgNXlnzknJ0WLiEe+JPjZk2MZ4ftMdqRJRWj1ZM=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.12 h1:X6OemT2WcLtxdmNukEQuIp0c+efWVI/tBTd0oeWeDHI=

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -90,6 +90,7 @@ const (
 	reasonSampleTooOld           = "sample-too-old"
 	reasonSampleTooFarInFuture   = "sample-too-far-in-future"
 	reasonNewValueForTimestamp   = "new-value-for-timestamp"
+	reasonSameValueForTimestamp  = "same-value-for-timestamp"
 	reasonSampleTimestampTooOld  = "sample-timestamp-too-old"
 	reasonPerUserSeriesLimit     = "per_user_series_limit"
 	reasonPerMetricSeriesLimit   = "per_metric_series_limit"

--- a/pkg/ingester/ingester_push.go
+++ b/pkg/ingester/ingester_push.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
 
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -34,6 +35,9 @@ import (
 type extendedAppender interface {
 	storage.Appender
 	storage.GetRef
+	// Part of extendedAppender so a wrapper that fails to forward it breaks loudly
+	// at appender creation instead of silently zeroing the duplicate accounting.
+	tsdb.CommitStatsReporter
 }
 
 type pushStats struct {
@@ -46,6 +50,7 @@ type pushStats struct {
 	sampleTooOldCount           int
 	sampleTooFarInFutureCount   int
 	newValueForTimestampCount   int
+	sameValueForTimestampCount  int
 	perUserSeriesLimitCount     int
 	perMetricSeriesLimitCount   int
 	invalidNativeHistogramCount int
@@ -439,6 +444,26 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 	i.metrics.appenderCommitDuration.Observe(commitDuration.Seconds())
 	spanlog.DebugLog("event", "complete commit", "commitDuration", commitDuration.String())
 
+	// Same-timestamp duplicates pass Append but are silently dropped at commit:
+	// count them as discarded. They stay in succeededSamplesCount so that the
+	// ingestion rate limit and user stats keep accounting for their write-path
+	// cost; only ingestedSamples reports the stored count. Stats are only valid
+	// after a successful Commit.
+	dropped := app.CommitStats().DiscardedSamples
+	droppedNewValue := dropped.TotalDifferentValue()
+	droppedSameValue := dropped.TotalSameValue()
+	stats.newValueForTimestampCount += droppedNewValue
+	stats.sameValueForTimestampCount += droppedSameValue
+
+	if cast != nil && droppedNewValue+droppedSameValue > 0 {
+		for _, d := range dropped.SameTimestampDifferentValue {
+			cast.IncrementDiscardedSamples(mimirpb.FromLabelsToLabelAdapters(d.Labels), float64(d.Count), reasonNewValueForTimestamp, startAppend)
+		}
+		for _, d := range dropped.SameTimestampSameValue {
+			cast.IncrementDiscardedSamples(mimirpb.FromLabelsToLabelAdapters(d.Labels), float64(d.Count), reasonSameValueForTimestamp, startAppend)
+		}
+	}
+
 	// If only invalid samples are pushed, don't change "last update", as TSDB was not modified.
 	if stats.succeededSamplesCount > 0 {
 		db.setLastUpdate(time.Now())
@@ -447,7 +472,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 	// Increment metrics only if the samples have been successfully committed.
 	// If the code didn't reach this point, it means that we returned an error
 	// which will be converted into an HTTP 5xx and the client should/will retry.
-	i.metrics.ingestedSamples.WithLabelValues(userID).Add(float64(stats.succeededSamplesCount))
+	i.metrics.ingestedSamples.WithLabelValues(userID).Add(float64(stats.succeededSamplesCount - droppedNewValue - droppedSameValue))
 	i.metrics.ingestedSamplesFail.WithLabelValues(userID).Add(float64(stats.failedSamplesCount))
 	i.metrics.ingestedExemplars.Add(float64(stats.succeededExemplarsCount))
 	i.metrics.ingestedExemplarsFail.Add(float64(stats.failedExemplarsCount))
@@ -484,6 +509,9 @@ func (i *Ingester) updateMetricsFromPushStats(userID string, group string, stats
 	}
 	if stats.newValueForTimestampCount > 0 {
 		discarded.newValueForTimestamp.WithLabelValues(userID, group).Add(float64(stats.newValueForTimestampCount))
+	}
+	if stats.sameValueForTimestampCount > 0 {
+		discarded.sameValueForTimestamp.WithLabelValues(userID, group).Add(float64(stats.sameValueForTimestampCount))
 	}
 	if stats.perUserSeriesLimitCount > 0 {
 		discarded.perUserSeriesLimit.WithLabelValues(userID, group).Add(float64(stats.perUserSeriesLimitCount))

--- a/pkg/ingester/ingester_push_duplicate_test.go
+++ b/pkg/ingester/ingester_push_duplicate_test.go
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingester
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/grafana/mimir/pkg/costattribution"
+	"github.com/grafana/mimir/pkg/costattribution/costattributionmodel"
+	"github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util/globalerror"
+	util_test "github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+// writeRequestManySeries builds one WriteRequest with one timeseries per sample, all sharing lbls.
+func writeRequestManySeries(lbls labels.Labels, samples []mimirpb.Sample) *mimirpb.WriteRequest {
+	req := &mimirpb.WriteRequest{Source: mimirpb.API}
+	for _, s := range samples {
+		ts := &mimirpb.TimeSeries{
+			Labels:  mimirpb.FromLabelsToLabelAdapters(lbls),
+			Samples: []mimirpb.Sample{s},
+		}
+		req.Timeseries = append(req.Timeseries, mimirpb.PreallocTimeseries{TimeSeries: ts})
+	}
+	return req
+}
+
+// tsdbSampleCounter returns the {type=<sampleType>} value of the named TSDB counter, or 0 if absent.
+func tsdbSampleCounter(t *testing.T, reg *prometheus.Registry, name, sampleType string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "type" && l.GetValue() == sampleType {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// TestIngester_Push_DuplicateTimestampWithinAndAcrossRequests covers how the ingester
+// accounts for multiple samples sharing a timestamp for the same series:
+//
+//  1. Exact duplicate (same ts + same value) within a single WriteRequest: the extra
+//     sample is dropped at commit time and counted as discarded "same-value-for-timestamp".
+//  2. Conflicting value (same ts, different value) within a single WriteRequest: the
+//     conflict is only detectable at commit time; the extra sample is dropped and
+//     counted as discarded "new-value-for-timestamp".
+//  3. Exact duplicate (same ts + same value) across two separate WriteRequests: tolerated
+//     at Append time (value matches the committed sample), then dropped at commit and
+//     counted as discarded "same-value-for-timestamp" — the across-requests counterpart
+//     of scenario 1.
+//  4. Conflicting value (same ts, different value) across two separate WriteRequests:
+//     rejected at Append time with the pre-existing soft "new-value-for-timestamp"
+//     error — the across-requests counterpart of scenario 2.
+//
+// In every scenario the dropped samples are subtracted from
+// cortex_ingester_ingested_samples_total, so it reflects what was actually stored.
+func TestIngester_Push_DuplicateTimestampWithinAndAcrossRequests(t *testing.T) {
+	metricLabels := labels.FromStrings(model.MetricNameLabel, "test")
+	metricLabelSet := mimirpb.FromLabelAdaptersToMetric(mimirpb.FromLabelsToLabelAdapters(metricLabels))
+	userID := "test"
+
+	// Ingester-tracked metrics.
+	sampleMetricNames := []string{
+		"cortex_ingester_ingested_samples_total",
+		"cortex_ingester_ingested_samples_failures_total",
+		"cortex_discarded_samples_total",
+	}
+
+	type testCase struct {
+		reqs []*mimirpb.WriteRequest
+		// expectedLastReqErr is the soft error expected from the last request, nil for none.
+		expectedLastReqErr error
+		expectedIngested   model.Matrix
+		expectedMetrics    string
+		// TSDB-head metrics, counted at commit time in the per-tenant registry.
+		expectedTSDBSamplesAppended float64 // prometheus_tsdb_head_samples_appended_total{type="float"}
+		expectedTSDBOutOfOrder      float64 // prometheus_tsdb_out_of_order_samples_total{type="float"}
+	}
+
+	tests := map[string]testCase{
+		// Exact duplicate within one request.
+		"exact duplicate within a single request is discarded as same-value-for-timestamp": {
+			reqs: []*mimirpb.WriteRequest{
+				writeRequestManySeries(metricLabels, []mimirpb.Sample{
+					{TimestampMs: 100, Value: 1},
+					{TimestampMs: 100, Value: 1},
+					{TimestampMs: 101, Value: 2},
+				}),
+			},
+			expectedIngested: model.Matrix{
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 100}, {Value: 2, Timestamp: 101}}},
+			},
+			expectedMetrics: `
+				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+				# TYPE cortex_ingester_ingested_samples_total counter
+				cortex_ingester_ingested_samples_total{user="test"} 2
+				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+				# TYPE cortex_ingester_ingested_samples_failures_total counter
+				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="test"} 1
+			`,
+			expectedTSDBSamplesAppended: 2,
+			expectedTSDBOutOfOrder:      0,
+		},
+
+		// Conflicting value within one request: only detectable at commit time.
+		"conflicting value within a single request is discarded as new-value-for-timestamp": {
+			reqs: []*mimirpb.WriteRequest{
+				writeRequestManySeries(metricLabels, []mimirpb.Sample{
+					{TimestampMs: 100, Value: 1},
+					{TimestampMs: 100, Value: 2},
+					{TimestampMs: 101, Value: 3},
+				}),
+			},
+			expectedIngested: model.Matrix{
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 100}, {Value: 3, Timestamp: 101}}},
+			},
+			// Still no push error for the client; only the accounting changes.
+			expectedMetrics: `
+				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+				# TYPE cortex_ingester_ingested_samples_total counter
+				cortex_ingester_ingested_samples_total{user="test"} 2
+				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+				# TYPE cortex_ingester_ingested_samples_failures_total counter
+				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="test"} 1
+			`,
+			expectedTSDBSamplesAppended: 2,
+			expectedTSDBOutOfOrder:      0,
+		},
+
+		// Exact duplicate across two requests.
+		"exact duplicate across two requests is discarded as same-value-for-timestamp": {
+			reqs: []*mimirpb.WriteRequest{
+				writeRequestManySeries(metricLabels, []mimirpb.Sample{{TimestampMs: 100, Value: 1}}),
+				writeRequestManySeries(metricLabels, []mimirpb.Sample{{TimestampMs: 100, Value: 1}}),
+			},
+			expectedIngested: model.Matrix{
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 100}}},
+			},
+			expectedMetrics: `
+				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+				# TYPE cortex_ingester_ingested_samples_total counter
+				cortex_ingester_ingested_samples_total{user="test"} 1
+				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+				# TYPE cortex_ingester_ingested_samples_failures_total counter
+				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="test"} 1
+			`,
+			expectedTSDBSamplesAppended: 1,
+			expectedTSDBOutOfOrder:      0,
+		},
+
+		// Conflicting value across two requests: rejected at Append time with a soft error.
+		"conflicting value across two requests is surfaced as a soft error": {
+			reqs: []*mimirpb.WriteRequest{
+				writeRequestManySeries(metricLabels, []mimirpb.Sample{{TimestampMs: 100, Value: 1}}),
+				writeRequestManySeries(metricLabels, []mimirpb.Sample{{TimestampMs: 100, Value: 2}}),
+			},
+			expectedLastReqErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError("duplicate sample for timestamp 100; overrides not allowed: existing 1, new value 2", model.Time(100), mimirpb.FromLabelsToLabelAdapters(metricLabels)), userID), codes.InvalidArgument),
+			expectedIngested: model.Matrix{
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 100}}},
+			},
+			expectedMetrics: `
+				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+				# TYPE cortex_ingester_ingested_samples_total counter
+				cortex_ingester_ingested_samples_total{user="test"} 1
+				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+				# TYPE cortex_ingester_ingested_samples_failures_total counter
+				cortex_ingester_ingested_samples_failures_total{user="test"} 1
+				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="test"} 1
+			`,
+			expectedTSDBSamplesAppended: 1,
+			expectedTSDBOutOfOrder:      0,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+
+			cfg := defaultIngesterTestConfig(t)
+			cfg.IngesterRing.ReplicationFactor = 1
+			limits := defaultLimitsTestConfig()
+
+			i, r, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, nil, "", registry)
+			require.NoError(t, err)
+			startAndWaitHealthy(t, i, r)
+
+			ctx := user.InjectOrgID(t.Context(), userID)
+
+			// Push all requests. Only the last request may return an error.
+			for idx, req := range testData.reqs {
+				_, err := i.Push(ctx, req)
+				if idx == len(testData.reqs)-1 && testData.expectedLastReqErr != nil {
+					require.Error(t, err)
+					errWithStatus, ok := mapPushErrorToErrorWithStatus(err).(globalerror.ErrorWithStatus)
+					require.True(t, ok)
+					require.Truef(t, errWithStatus.Equals(testData.expectedLastReqErr), "errors don't match \nactual:   '%v'\nexpected: '%v'", errWithStatus, testData.expectedLastReqErr)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			// Read back the samples that were actually stored.
+			s := &stream{ctx: ctx}
+			err = i.QueryStream(&client.QueryRequest{
+				StartTimestampMs: math.MinInt64,
+				EndTimestampMs:   math.MaxInt64,
+				Matchers:         []*client.LabelMatcher{{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: ".*"}},
+			}, s)
+			require.NoError(t, err)
+
+			res, err := client.StreamsToMatrixForTests(model.Earliest, model.Latest, s.responses)
+			require.NoError(t, err)
+			if len(res) == 0 {
+				res = nil
+			}
+			require.Equal(t, testData.expectedIngested, res)
+
+			// Check the samples-related metrics tracked by the ingester.
+			require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(testData.expectedMetrics), sampleMetricNames...))
+
+			tsdbReg := i.tsdbMetrics.RegistryForTenant(userID)
+			require.NotNil(t, tsdbReg)
+			require.Equal(t, testData.expectedTSDBSamplesAppended, tsdbSampleCounter(t, tsdbReg, "prometheus_tsdb_head_samples_appended_total", "float"), "TSDB in-order float samples appended")
+			require.Equal(t, testData.expectedTSDBOutOfOrder, tsdbSampleCounter(t, tsdbReg, "prometheus_tsdb_out_of_order_samples_total", "float"), "TSDB out-of-order float samples rejected")
+		})
+	}
+}
+
+// histogramPoint builds native histogram samples; equal idx generates equal histograms.
+type histogramPoint struct {
+	ts  int64
+	idx int
+}
+
+// writeRequestManyHistogramSeries is the native-histogram analog of writeRequestManySeries.
+func writeRequestManyHistogramSeries(lbls labels.Labels, points []histogramPoint) *mimirpb.WriteRequest {
+	req := &mimirpb.WriteRequest{Source: mimirpb.API}
+	for _, p := range points {
+		ts := &mimirpb.TimeSeries{
+			Labels:     mimirpb.FromLabelsToLabelAdapters(lbls),
+			Histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(p.ts, util_test.GenerateTestHistogram(p.idx))},
+		}
+		req.Timeseries = append(req.Timeseries, mimirpb.PreallocTimeseries{TimeSeries: ts})
+	}
+	return req
+}
+
+// TestIngester_Push_DuplicateTimestampHistograms is the native-histogram counterpart of
+// TestIngester_Push_DuplicateTimestampWithinAndAcrossRequests.
+func TestIngester_Push_DuplicateTimestampHistograms(t *testing.T) {
+	metricLabels := labels.FromStrings(model.MetricNameLabel, "test")
+	userID := "test"
+
+	sampleMetricNames := []string{
+		"cortex_ingester_ingested_samples_total",
+		"cortex_ingester_ingested_samples_failures_total",
+		"cortex_discarded_samples_total",
+	}
+
+	type testCase struct {
+		points                       []histogramPoint
+		expectedMetrics              string
+		expectedTSDBHistogramsAppend float64
+	}
+
+	tests := map[string]testCase{
+		// Exact duplicate histogram within one request.
+		"exact duplicate histogram within a single request is discarded as same-value-for-timestamp": {
+			points: []histogramPoint{{ts: 100, idx: 1}, {ts: 100, idx: 1}, {ts: 101, idx: 2}},
+			expectedMetrics: `
+				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+				# TYPE cortex_ingester_ingested_samples_total counter
+				cortex_ingester_ingested_samples_total{user="test"} 2
+				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+				# TYPE cortex_ingester_ingested_samples_failures_total counter
+				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="test"} 1
+			`,
+			expectedTSDBHistogramsAppend: 2,
+		},
+
+		// Conflicting histogram within one request.
+		"conflicting histogram within a single request is discarded as new-value-for-timestamp": {
+			points: []histogramPoint{{ts: 100, idx: 1}, {ts: 100, idx: 2}, {ts: 101, idx: 3}},
+			expectedMetrics: `
+				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+				# TYPE cortex_ingester_ingested_samples_total counter
+				cortex_ingester_ingested_samples_total{user="test"} 2
+				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+				# TYPE cortex_ingester_ingested_samples_failures_total counter
+				cortex_ingester_ingested_samples_failures_total{user="test"} 0
+				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="test"} 1
+			`,
+			expectedTSDBHistogramsAppend: 2,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+
+			cfg := defaultIngesterTestConfig(t)
+			cfg.IngesterRing.ReplicationFactor = 1
+			limits := defaultLimitsTestConfig()
+			limits.NativeHistogramsIngestionEnabled = true
+
+			i, r, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, nil, "", registry)
+			require.NoError(t, err)
+			startAndWaitHealthy(t, i, r)
+
+			ctx := user.InjectOrgID(t.Context(), userID)
+
+			_, err = i.Push(ctx, writeRequestManyHistogramSeries(metricLabels, testData.points))
+			require.NoError(t, err)
+
+			require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(testData.expectedMetrics), sampleMetricNames...))
+
+			tsdbReg := i.tsdbMetrics.RegistryForTenant(userID)
+			require.NotNil(t, tsdbReg)
+			require.Equal(t, testData.expectedTSDBHistogramsAppend, tsdbSampleCounter(t, tsdbReg, "prometheus_tsdb_head_samples_appended_total", "histogram"), "TSDB in-order histogram samples appended")
+		})
+	}
+}
+
+// TestIngester_Push_DuplicateTimestampCostAttribution verifies commit-time drops are
+// attributed per series in cortex_discarded_attributed_samples_total and reconciled
+// against the received-samples accounting.
+func TestIngester_Push_DuplicateTimestampCostAttribution(t *testing.T) {
+	const userID = "test"
+	metricLabels := labels.FromStrings(model.MetricNameLabel, "test", "team", "foo")
+
+	limits := defaultLimitsTestConfig()
+	limits.CostAttributionBaseTrackers = costattributionmodel.TrackerConfigs{
+		costattributionmodel.DefaultTrackerName: {Labels: costattributionmodel.Labels{{Input: "team"}}},
+	}
+	limits.MaxCostAttributionCardinality = 100
+	overrides := validation.NewOverrides(limits, nil)
+
+	registry := prometheus.NewRegistry()
+	caRegistry := prometheus.NewRegistry()
+	cam, err := costattribution.NewManager(5*time.Second, 10*time.Second, nil, overrides, registry, caRegistry)
+	require.NoError(t, err)
+
+	cfg := defaultIngesterTestConfig(t)
+	cfg.IngesterRing.ReplicationFactor = 1
+	i, r, err := prepareIngesterWithBlockStorageOverridesAndCostAttribution(t, cfg, overrides, nil, "", "", registry, cam)
+	require.NoError(t, err)
+	startAndWaitHealthy(t, i, r)
+
+	ctx := user.InjectOrgID(t.Context(), userID)
+
+	req := writeRequestManySeries(metricLabels, []mimirpb.Sample{
+		{TimestampMs: 100, Value: 1},
+		{TimestampMs: 100, Value: 1}, // exact duplicate -> same-value-for-timestamp
+		{TimestampMs: 101, Value: 2},
+		{TimestampMs: 200, Value: 5},
+		{TimestampMs: 200, Value: 6}, // conflict -> new-value-for-timestamp
+		{TimestampMs: 201, Value: 7},
+	})
+
+	// Received-samples accounting lives in the distributor; simulate it here.
+	cam.SampleTracker(userID).IncrementReceivedSamples(req, time.Now())
+
+	_, err = i.Push(ctx, req)
+	require.NoError(t, err)
+
+	expected := `
+		# HELP cortex_distributor_received_attributed_samples_total The total number of samples that were received per attribution.
+		# TYPE cortex_distributor_received_attributed_samples_total counter
+		cortex_distributor_received_attributed_samples_total{team="foo",tenant="test",tracker="cost-attribution"} 6
+		# HELP cortex_discarded_attributed_samples_total The total number of samples that were discarded per attribution.
+		# TYPE cortex_discarded_attributed_samples_total counter
+		cortex_discarded_attributed_samples_total{reason="new-value-for-timestamp",team="foo",tenant="test",tracker="cost-attribution"} 1
+		cortex_discarded_attributed_samples_total{reason="same-value-for-timestamp",team="foo",tenant="test",tracker="cost-attribution"} 1
+	`
+	require.NoError(t, testutil.GatherAndCompare(caRegistry, strings.NewReader(expected),
+		"cortex_distributor_received_attributed_samples_total", "cortex_discarded_attributed_samples_total"))
+}
+
+// TestIngester_Push_DuplicateTimestampOutOfOrder verifies OOO duplicates are classified
+// by value like in-order ones (exercises OOOChunk.Insert's value comparison).
+func TestIngester_Push_DuplicateTimestampOutOfOrder(t *testing.T) {
+	metricLabels := labels.FromStrings(model.MetricNameLabel, "test")
+	metricLabelSet := mimirpb.FromLabelAdaptersToMetric(mimirpb.FromLabelsToLabelAdapters(metricLabels))
+	const userID = "test"
+
+	sampleMetricNames := []string{
+		"cortex_ingester_ingested_samples_total",
+		"cortex_ingester_ingested_samples_failures_total",
+		"cortex_discarded_samples_total",
+	}
+
+	registry := prometheus.NewRegistry()
+	cfg := defaultIngesterTestConfig(t)
+	cfg.IngesterRing.ReplicationFactor = 1
+	limits := defaultLimitsTestConfig()
+	limits.OutOfOrderTimeWindow = model.Duration(time.Hour)
+
+	i, r, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, nil, "", registry)
+	require.NoError(t, err)
+	startAndWaitHealthy(t, i, r)
+
+	ctx := user.InjectOrgID(t.Context(), userID)
+
+	// Advance the head's max time with an in-order sample so the later samples are OOO.
+	_, err = i.Push(ctx, writeRequestManySeries(metricLabels, []mimirpb.Sample{{TimestampMs: 1000, Value: 100}}))
+	require.NoError(t, err)
+
+	_, err = i.Push(ctx, writeRequestManySeries(metricLabels, []mimirpb.Sample{
+		{TimestampMs: 500, Value: 1},
+		{TimestampMs: 500, Value: 2}, // OOO conflict -> new-value-for-timestamp
+		{TimestampMs: 600, Value: 3},
+		{TimestampMs: 600, Value: 3}, // OOO exact duplicate -> same-value-for-timestamp
+	}))
+	require.NoError(t, err)
+
+	// Read back stored samples: the first value at each timestamp wins.
+	s := &stream{ctx: ctx}
+	err = i.QueryStream(&client.QueryRequest{
+		StartTimestampMs: math.MinInt64,
+		EndTimestampMs:   math.MaxInt64,
+		Matchers:         []*client.LabelMatcher{{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: ".*"}},
+	}, s)
+	require.NoError(t, err)
+	res, err := client.StreamsToMatrixForTests(model.Earliest, model.Latest, s.responses)
+	require.NoError(t, err)
+	require.Equal(t, model.Matrix{
+		&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{
+			{Value: 1, Timestamp: 500},
+			{Value: 3, Timestamp: 600},
+			{Value: 100, Timestamp: 1000},
+		}},
+	}, res)
+
+	expectedMetrics := `
+		# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
+		# TYPE cortex_ingester_ingested_samples_total counter
+		cortex_ingester_ingested_samples_total{user="test"} 3
+		# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
+		# TYPE cortex_ingester_ingested_samples_failures_total counter
+		cortex_ingester_ingested_samples_failures_total{user="test"} 0
+		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+		# TYPE cortex_discarded_samples_total counter
+		cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="test"} 1
+		cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="test"} 1
+	`
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), sampleMetricNames...))
+}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -11200,6 +11200,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="user-1"} 3
 				cortex_discarded_samples_total{group="",reason="sample-timestamp-too-old",user="user-1"} 8
 				cortex_discarded_samples_total{group="",reason="sample-timestamp-too-old",user="user-2"} 2
 			`,
@@ -11234,6 +11235,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="user-1"} 3
 				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="user-1"} 4
 				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="user-2"} 1
 			`,
@@ -11262,6 +11264,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="user-1"} 3
 				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="user-1"} 4
 				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="user-2"} 1
 			`,
@@ -11290,6 +11293,11 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[1]), codes.InvalidArgument),
 			},
 			expectedSampling: false,
+			expectedMetrics: `
+				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+				# TYPE cortex_discarded_samples_total counter
+				cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="user-1"} 3
+			`,
 		},
 		"should soft fail on two different sample values at the same timestamp": {
 			reqs: []*mimirpb.WriteRequest{
@@ -11677,6 +11685,7 @@ func TestIngester_SampledUserLimitExceeded(t *testing.T) {
 		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 		# TYPE cortex_discarded_samples_total counter
 		cortex_discarded_samples_total{group="",reason="per_user_series_limit",user="1"} 10
+		cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="1"} 9
 	`
 	err = testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...)
 	assert.NoError(t, err)
@@ -11775,6 +11784,7 @@ func TestIngester_SampledMetricLimitExceeded(t *testing.T) {
 		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 		# TYPE cortex_discarded_samples_total counter
 		cortex_discarded_samples_total{group="",reason="per_metric_series_limit",user="1"} 10
+		cortex_discarded_samples_total{group="",reason="same-value-for-timestamp",user="1"} 9
 	`
 	err = testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...)
 	assert.NoError(t, err)

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -507,6 +507,7 @@ type discardedMetrics struct {
 	sampleTooOld           *prometheus.CounterVec
 	sampleTooFarInFuture   *prometheus.CounterVec
 	newValueForTimestamp   *prometheus.CounterVec
+	sameValueForTimestamp  *prometheus.CounterVec
 	perUserSeriesLimit     *prometheus.CounterVec
 	perMetricSeriesLimit   *prometheus.CounterVec
 	invalidNativeHistogram *prometheus.CounterVec
@@ -520,6 +521,7 @@ func newDiscardedMetrics(r prometheus.Registerer) *discardedMetrics {
 		sampleTooOld:           validation.DiscardedSamplesCounter(r, reasonSampleTooOld),
 		sampleTooFarInFuture:   validation.DiscardedSamplesCounter(r, reasonSampleTooFarInFuture),
 		newValueForTimestamp:   validation.DiscardedSamplesCounter(r, reasonNewValueForTimestamp),
+		sameValueForTimestamp:  validation.DiscardedSamplesCounter(r, reasonSameValueForTimestamp),
 		perUserSeriesLimit:     validation.DiscardedSamplesCounter(r, reasonPerUserSeriesLimit),
 		perMetricSeriesLimit:   validation.DiscardedSamplesCounter(r, reasonPerMetricSeriesLimit),
 		invalidNativeHistogram: validation.DiscardedSamplesCounter(r, reasonInvalidNativeHistogram),
@@ -533,6 +535,7 @@ func (m *discardedMetrics) DeletePartialMatch(filter prometheus.Labels) {
 	m.sampleTooOld.DeletePartialMatch(filter)
 	m.sampleTooFarInFuture.DeletePartialMatch(filter)
 	m.newValueForTimestamp.DeletePartialMatch(filter)
+	m.sameValueForTimestamp.DeletePartialMatch(filter)
 	m.perUserSeriesLimit.DeletePartialMatch(filter)
 	m.perMetricSeriesLimit.DeletePartialMatch(filter)
 	m.invalidNativeHistogram.DeletePartialMatch(filter)
@@ -545,6 +548,7 @@ func (m *discardedMetrics) DeleteLabelValues(userID string, group string) {
 	m.sampleTooOld.DeleteLabelValues(userID, group)
 	m.sampleTooFarInFuture.DeleteLabelValues(userID, group)
 	m.newValueForTimestamp.DeleteLabelValues(userID, group)
+	m.sameValueForTimestamp.DeleteLabelValues(userID, group)
 	m.perUserSeriesLimit.DeleteLabelValues(userID, group)
 	m.perMetricSeriesLimit.DeleteLabelValues(userID, group)
 	m.invalidNativeHistogram.DeleteLabelValues(userID, group)

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -458,6 +458,7 @@ type headMetrics struct {
 	chunksRemoved             prometheus.Counter
 	gcDuration                prometheus.Summary
 	samplesAppended           *prometheus.CounterVec
+	duplicateSamples          *prometheus.CounterVec
 	outOfOrderSamplesAppended *prometheus.CounterVec
 	outOfBoundSamples         *prometheus.CounterVec
 	outOfOrderSamples         *prometheus.CounterVec
@@ -558,6 +559,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 		samplesAppended: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_samples_appended_total",
 			Help: "Total number of appended samples.",
+		}, []string{"type"}),
+		duplicateSamples: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "prometheus_tsdb_duplicate_samples_total",
+			Help: "Total number of samples dropped because the series already had a sample at the same timestamp, either silently at commit time or with an error at append time. Rejections of synthetic start-timestamp zero samples are not counted.",
 		}, []string{"type"}),
 		outOfOrderSamplesAppended: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_out_of_order_samples_appended_total",
@@ -660,6 +665,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.walCorruptionsTotal,
 			m.dataTotalReplayDuration,
 			m.samplesAppended,
+			m.duplicateSamples,
 			m.outOfOrderSamplesAppended,
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
@@ -429,7 +429,11 @@ type headAppenderBase struct {
 	storeST                         bool // Whether start-timestamp storage is enabled for this append.
 	useXOR2                         bool // Whether XOR2 encoding is used for float chunks in this append.
 	useHistogramST                  bool // Whether ST-capable histogram chunk encoding is used in this append.
+
+	// commitStats is populated at the end of Commit, readable via CommitStats.
+	commitStats CommitStats
 }
+
 type headAppender struct {
 	headAppenderBase
 	hints *storage.AppendOptions
@@ -497,6 +501,8 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
 		case errors.Is(err, storage.ErrTooOldSample):
 			a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
+		case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
+			a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
 		}
 		return 0, err
 	}
@@ -873,6 +879,8 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 				a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			case errors.Is(err, storage.ErrTooOldSample):
 				a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+			case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
+				a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			}
 			return 0, err
 		}
@@ -905,6 +913,8 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 				a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			case errors.Is(err, storage.ErrTooOldSample):
 				a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+			case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
+				a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			}
 			return 0, err
 		}
@@ -1178,6 +1188,10 @@ type appenderCommitContext struct {
 	// Number of samples out of order but accepted: with ooo enabled and within time window.
 	oooFloatsAccepted    int
 	oooHistogramAccepted int
+	// Number of samples dropped at commit time because the series already had a
+	// sample at the same timestamp, with an equal or a conflicting value.
+	floatDuplicatesDropped int
+	histoDuplicatesDropped int
 	// Number of samples rejected due to: out of order but OOO support disabled.
 	floatOOORejected int
 	histoOOORejected int
@@ -1185,8 +1199,13 @@ type appenderCommitContext struct {
 	floatTooOldRejected int
 	histoTooOldRejected int
 	// Number of samples rejected due to: out of bounds: with t < minValidTime (OOO support disabled).
-	floatOOBRejected    int
-	histoOOBRejected    int
+	floatOOBRejected int
+	histoOOBRejected int
+	// Same-timestamp drops aggregated per series, allocated lazily on the first drop.
+	droppedConflict     []DiscardedSeriesSamples
+	droppedExactDup     []DiscardedSeriesSamples
+	droppedConflictIdx  map[chunks.HeadSeriesRef]int
+	droppedExactDupIdx  map[chunks.HeadSeriesRef]int
 	inOrderMint         int64
 	inOrderMaxt         int64
 	appendChunkOpts     chunkOpts
@@ -1400,6 +1419,9 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 		oooSample, _, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
+			if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				acc.recordDroppedConflict(series, &acc.floatDuplicatesDropped)
+			}
 			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected)
 		}
 
@@ -1413,7 +1435,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, s.V, nil, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			var result OOOInsertResult
+			result, chunkCreated, mmapRefs = series.insertWithResult(s.ST, s.T, s.V, nil, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1438,7 +1461,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 					acc.oooMmapMarkersCount++
 				}
 			}
-			if ok {
+			switch result {
+			case OOOInserted:
 				acc.wblSamples = append(acc.wblSamples, s)
 				if s.T < acc.oooMinT {
 					acc.oooMinT = s.T
@@ -1447,12 +1471,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 					acc.oooMaxT = s.T
 				}
 				acc.oooFloatsAccepted++
-			} else {
-				// Sample is an exact duplicate of the last sample.
-				// NOTE: We can only detect updates if they clash with a sample in the OOOHeadChunk,
-				// not with samples in already flushed OOO chunks.
-				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
-				acc.floatsAppended--
+			case OOODuplicateExact, OOODuplicateConflict:
+				acc.recordOOODuplicate(result, series, &acc.floatsAppended, &acc.floatDuplicatesDropped)
 			}
 		default:
 			if math.Float64bits(s.V) == value.QuietZeroNaN {
@@ -1475,6 +1495,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			} else {
 				// The sample is an exact duplicate, and should be silently dropped.
 				acc.floatsAppended--
+				acc.recordDroppedExactDup(series, &acc.floatDuplicatesDropped)
 			}
 		}
 
@@ -1508,6 +1529,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 
 		oooSample, _, err := series.appendableHistogram(s.T, s.H, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
+			if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				acc.recordDroppedConflict(series, &acc.histoDuplicatesDropped)
+			}
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
@@ -1519,7 +1543,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, 0, s.H, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			var result OOOInsertResult
+			result, chunkCreated, mmapRefs = series.insertWithResult(s.ST, s.T, 0, s.H, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1544,7 +1569,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 					acc.oooMmapMarkersCount++
 				}
 			}
-			if ok {
+			switch result {
+			case OOOInserted:
 				acc.wblHistograms = append(acc.wblHistograms, s)
 				if s.T < acc.oooMinT {
 					acc.oooMinT = s.T
@@ -1553,12 +1579,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 					acc.oooMaxT = s.T
 				}
 				acc.oooHistogramAccepted++
-			} else {
-				// Sample is an exact duplicate of the last sample.
-				// NOTE: We can only detect updates if they clash with a sample in the OOOHeadChunk,
-				// not with samples in already flushed OOO chunks.
-				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
-				acc.histogramsAppended--
+			case OOODuplicateExact, OOODuplicateConflict:
+				acc.recordOOODuplicate(result, series, &acc.histogramsAppended, &acc.histoDuplicatesDropped)
 			}
 		default:
 			wasStale, wasHistogram, oldBuckets := series.sampleState()
@@ -1575,8 +1597,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
+				// The sample is an exact duplicate, and should be silently dropped.
 				acc.histogramsAppended--
-				acc.histoOOORejected++
+				acc.recordDroppedExactDup(series, &acc.histoDuplicatesDropped)
 			}
 		}
 
@@ -1610,6 +1633,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 
 		oooSample, _, err := series.appendableFloatHistogram(s.T, s.FH, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
+			if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				acc.recordDroppedConflict(series, &acc.histoDuplicatesDropped)
+			}
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
@@ -1621,7 +1647,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, 0, nil, s.FH, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			var result OOOInsertResult
+			result, chunkCreated, mmapRefs = series.insertWithResult(s.ST, s.T, 0, nil, s.FH, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1646,7 +1673,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 					acc.oooMmapMarkersCount++
 				}
 			}
-			if ok {
+			switch result {
+			case OOOInserted:
 				acc.wblFloatHistograms = append(acc.wblFloatHistograms, s)
 				if s.T < acc.oooMinT {
 					acc.oooMinT = s.T
@@ -1655,12 +1683,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 					acc.oooMaxT = s.T
 				}
 				acc.oooHistogramAccepted++
-			} else {
-				// Sample is an exact duplicate of the last sample.
-				// NOTE: We can only detect updates if they clash with a sample in the OOOHeadChunk,
-				// not with samples in already flushed OOO chunks.
-				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
-				acc.histogramsAppended--
+			case OOODuplicateExact, OOODuplicateConflict:
+				acc.recordOOODuplicate(result, series, &acc.histogramsAppended, &acc.histoDuplicatesDropped)
 			}
 		default:
 			wasStale, wasHistogram, oldBuckets := series.sampleState()
@@ -1677,8 +1701,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
+				// The sample is an exact duplicate, and should be silently dropped.
 				acc.histogramsAppended--
-				acc.histoOOORejected++
+				acc.recordDroppedExactDup(series, &acc.histoDuplicatesDropped)
 			}
 		}
 
@@ -1794,10 +1819,19 @@ func (a *headAppenderBase) Commit() (err error) {
 	h.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatTooOldRejected))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatsAppended))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histogramsAppended))
+	h.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatDuplicatesDropped))
+	h.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoDuplicatesDropped))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.oooFloatsAccepted))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.oooHistogramAccepted))
 	h.updateMinMaxTime(acc.inOrderMint, acc.inOrderMaxt)
 	h.updateMinOOOMaxOOOTime(acc.oooMinT, acc.oooMaxT)
+
+	a.commitStats = CommitStats{
+		DiscardedSamples: DiscardedSampleStats{
+			SameTimestampDifferentValue: acc.droppedConflict,
+			SameTimestampSameValue:      acc.droppedExactDup,
+		},
+	}
 
 	acc.collectOOORecords(a)
 	if h.wbl != nil {
@@ -1814,26 +1848,8 @@ func (a *headAppenderBase) Commit() (err error) {
 
 // insert is like append, except it inserts. Used for OOO samples.
 func (s *memSeries) insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, o chunkOpts, oooCapMax int64, logger *slog.Logger) (inserted, chunkCreated bool, mmapRefs []chunks.ChunkDiskMapperRef) {
-	if s.ooo == nil {
-		s.ooo = &memSeriesOOOFields{}
-	}
-	c := s.ooo.oooHeadChunk
-	if c == nil || c.chunk.NumSamples() == int(oooCapMax) {
-		// Note: If no new samples come in then we rely on compaction to clean up stale in-memory OOO chunks.
-		c, mmapRefs = s.cutNewOOOHeadChunk(t, o, logger)
-		chunkCreated = true
-	}
-
-	ok := c.chunk.Insert(st, t, v, h, fh)
-	if ok {
-		if chunkCreated || t < c.minTime {
-			c.minTime = t
-		}
-		if chunkCreated || t > c.maxTime {
-			c.maxTime = t
-		}
-	}
-	return ok, chunkCreated, mmapRefs
+	result, chunkCreated, mmapRefs := s.insertWithResult(st, t, v, h, fh, o, oooCapMax, logger)
+	return result == OOOInserted, chunkCreated, mmapRefs
 }
 
 // chunkOpts are chunk-level options that are passed when appending to a memSeries.

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_append_mimir.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_append_mimir.go
@@ -1,0 +1,155 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// CommitStats reports what the most recent Commit did beyond its error return.
+type CommitStats struct {
+	// DiscardedSamples reports samples silently dropped because the series already
+	// had a sample at that timestamp.
+	DiscardedSamples DiscardedSampleStats
+}
+
+// DiscardedSampleStats reports samples that Commit silently dropped because the
+// series already had a sample at that timestamp. No Append error is returned for
+// these drops, so this is the only signal that they were not stored.
+type DiscardedSampleStats struct {
+	// SameTimestampDifferentValue aggregates drops whose value differed from the stored sample.
+	SameTimestampDifferentValue []DiscardedSeriesSamples
+	// SameTimestampSameValue aggregates drops that exactly duplicated the stored sample.
+	SameTimestampSameValue []DiscardedSeriesSamples
+}
+
+// TotalDifferentValue returns the number of dropped samples across all series in
+// the SameTimestampDifferentValue category.
+func (s DiscardedSampleStats) TotalDifferentValue() int {
+	return totalDiscarded(s.SameTimestampDifferentValue)
+}
+
+// TotalSameValue returns the number of dropped samples across all series in the
+// SameTimestampSameValue category.
+func (s DiscardedSampleStats) TotalSameValue() int {
+	return totalDiscarded(s.SameTimestampSameValue)
+}
+
+func totalDiscarded(dropped []DiscardedSeriesSamples) (n int) {
+	for _, d := range dropped {
+		n += d.Count
+	}
+	return n
+}
+
+// DiscardedSeriesSamples aggregates the dropped samples of one series.
+type DiscardedSeriesSamples struct {
+	// Labels references the head's own series labels; read them synchronously after Commit.
+	Labels labels.Labels
+	Count  int
+}
+
+// CommitStatsReporter is implemented by appenders that report what their most
+// recent Commit did. Wrappers must forward the method.
+type CommitStatsReporter interface {
+	CommitStats() CommitStats
+}
+
+var (
+	_ CommitStatsReporter = &initAppender{}
+	_ CommitStatsReporter = &headAppender{}
+	_ CommitStatsReporter = &initAppenderV2{}
+	_ CommitStatsReporter = &headAppenderV2{}
+	_ CommitStatsReporter = dbAppender{}
+	_ CommitStatsReporter = dbAppenderV2{}
+)
+
+// CommitStats returns what the most recent Commit did.
+func (a *headAppenderBase) CommitStats() CommitStats {
+	return a.commitStats
+}
+
+// CommitStats returns the zero value if nothing was ever appended.
+func (a *initAppender) CommitStats() CommitStats {
+	if s, ok := a.app.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+// CommitStats returns the zero value if nothing was ever appended.
+func (a *initAppenderV2) CommitStats() CommitStats {
+	if s, ok := a.app.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+func (a dbAppender) CommitStats() CommitStats {
+	if s, ok := a.Appender.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+func (a dbAppenderV2) CommitStats() CommitStats {
+	if s, ok := a.AppenderV2.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+// recordDroppedConflict records a commit-time drop whose value differed from the
+// stored same-timestamp sample. Callers must hold s's lock.
+func (acc *appenderCommitContext) recordDroppedConflict(s *memSeries, dropped *int) {
+	*dropped++
+	acc.droppedConflict, acc.droppedConflictIdx = recordDroppedSample(acc.droppedConflict, acc.droppedConflictIdx, s)
+}
+
+// recordDroppedExactDup records a commit-time drop that exactly duplicated the
+// stored same-timestamp sample. Callers must hold s's lock.
+func (acc *appenderCommitContext) recordDroppedExactDup(s *memSeries, dropped *int) {
+	*dropped++
+	acc.droppedExactDup, acc.droppedExactDupIdx = recordDroppedSample(acc.droppedExactDup, acc.droppedExactDupIdx, s)
+}
+
+// recordOOODuplicate accounts for an out-of-order sample dropped because its
+// timestamp already exists. Callers must hold s's lock.
+//
+// NOTE: The clash can only be detected against samples in the OOO head chunk,
+// not against samples in already flushed OOO chunks.
+// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
+func (acc *appenderCommitContext) recordOOODuplicate(result OOOInsertResult, s *memSeries, appended, dropped *int) {
+	*appended--
+	if result == OOODuplicateConflict {
+		acc.recordDroppedConflict(s, dropped)
+	} else {
+		acc.recordDroppedExactDup(s, dropped)
+	}
+}
+
+// recordDroppedSample reads s.lset directly rather than calling s.labels(): callers
+// hold s's lock and labels() locks again under the dedupelabels build tag.
+func recordDroppedSample(dropped []DiscardedSeriesSamples, idx map[chunks.HeadSeriesRef]int, s *memSeries) ([]DiscardedSeriesSamples, map[chunks.HeadSeriesRef]int) {
+	if idx == nil {
+		idx = map[chunks.HeadSeriesRef]int{}
+	}
+	if i, ok := idx[s.ref]; ok {
+		dropped[i].Count++
+		return dropped, idx
+	}
+	idx[s.ref] = len(dropped)
+	return append(dropped, DiscardedSeriesSamples{Labels: s.lset, Count: 1}), idx
+}

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_append_v2.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_append_v2.go
@@ -188,6 +188,8 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricType).Inc()
 		case errors.Is(appErr, storage.ErrTooOldSample):
 			a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricType).Inc()
+		case errors.Is(appErr, storage.ErrDuplicateSampleForTimestamp):
+			a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricType).Inc()
 		}
 		return 0, appErr
 	}

--- a/vendor/github.com/prometheus/prometheus/tsdb/ooo_head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/ooo_head.go
@@ -14,8 +14,6 @@
 package tsdb
 
 import (
-	"sort"
-
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
@@ -35,35 +33,7 @@ func NewOOOChunk() *OOOChunk {
 // Insert inserts the sample such that order is maintained.
 // Returns false if insert was not possible due to the same timestamp already existing.
 func (o *OOOChunk) Insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
-	// Although out-of-order samples can be out-of-order amongst themselves, we
-	// are opinionated and expect them to be usually in-order meaning we could
-	// try to append at the end first if the new timestamp is higher than the
-	// last known timestamp.
-	if len(o.samples) == 0 || t > o.samples[len(o.samples)-1].t {
-		o.samples = append(o.samples, sample{st, t, v, h, fh})
-		return true
-	}
-
-	// Find index of sample we should replace.
-	i := sort.Search(len(o.samples), func(i int) bool { return o.samples[i].t >= t })
-
-	if i >= len(o.samples) {
-		// none found. append it at the end
-		o.samples = append(o.samples, sample{st, t, v, h, fh})
-		return true
-	}
-
-	// Duplicate sample for timestamp is not allowed.
-	if o.samples[i].t == t {
-		return false
-	}
-
-	// Expand length by 1 to make room. use a zero sample, we will overwrite it anyway.
-	o.samples = append(o.samples, sample{})
-	copy(o.samples[i+1:], o.samples[i:])
-	o.samples[i] = sample{st, t, v, h, fh}
-
-	return true
+	return o.insertWithResult(st, t, v, h, fh) == OOOInserted
 }
 
 func (o *OOOChunk) NumSamples() int {

--- a/vendor/github.com/prometheus/prometheus/tsdb/ooo_head_mimir.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/ooo_head_mimir.go
@@ -1,0 +1,110 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"log/slog"
+	"math"
+	"sort"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// OOOInsertResult reports the outcome of inserting a sample into the out-of-order
+// head chunk. The zero value is deliberately invalid so that a missed assignment
+// cannot read as a successful insert.
+type OOOInsertResult uint8
+
+const (
+	OOOInserted OOOInsertResult = iota + 1
+	// OOODuplicateExact reports a drop: a sample with the same timestamp and an equal value exists.
+	OOODuplicateExact
+	// OOODuplicateConflict reports a drop: a sample with the same timestamp but a different value exists.
+	OOODuplicateConflict
+)
+
+// insertWithResult is OOOChunk.Insert reporting whether a sample dropped for an
+// already existing timestamp was an exact duplicate or a value conflict.
+func (o *OOOChunk) insertWithResult(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) OOOInsertResult {
+	// Although out-of-order samples can be out-of-order amongst themselves, we
+	// are opinionated and expect them to be usually in-order meaning we could
+	// try to append at the end first if the new timestamp is higher than the
+	// last known timestamp.
+	if len(o.samples) == 0 || t > o.samples[len(o.samples)-1].t {
+		o.samples = append(o.samples, sample{st, t, v, h, fh})
+		return OOOInserted
+	}
+
+	// Find index of sample we should replace.
+	i := sort.Search(len(o.samples), func(i int) bool { return o.samples[i].t >= t })
+
+	if i >= len(o.samples) {
+		// none found. append it at the end
+		o.samples = append(o.samples, sample{st, t, v, h, fh})
+		return OOOInserted
+	}
+
+	// Overwrites of an existing timestamp are not allowed.
+	if o.samples[i].t == t {
+		if o.samples[i].valueEqual(v, h, fh) {
+			return OOODuplicateExact
+		}
+		return OOODuplicateConflict
+	}
+
+	// Expand length by 1 to make room. use a zero sample, we will overwrite it anyway.
+	o.samples = append(o.samples, sample{})
+	copy(o.samples[i+1:], o.samples[i:])
+	o.samples[i] = sample{st, t, v, h, fh}
+
+	return OOOInserted
+}
+
+// valueEqual reports whether (v, h, fh) equals s's value; a type mismatch counts as different.
+func (s sample) valueEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
+	switch {
+	case h != nil:
+		return s.h != nil && h.Equals(s.h)
+	case fh != nil:
+		return s.fh != nil && fh.Equals(s.fh)
+	default:
+		return s.h == nil && s.fh == nil && math.Float64bits(s.f) == math.Float64bits(v)
+	}
+}
+
+// insertWithResult is memSeries.insert reporting the OOOInsertResult instead of
+// collapsing it to a bool.
+func (s *memSeries) insertWithResult(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, o chunkOpts, oooCapMax int64, logger *slog.Logger) (result OOOInsertResult, chunkCreated bool, mmapRefs []chunks.ChunkDiskMapperRef) {
+	if s.ooo == nil {
+		s.ooo = &memSeriesOOOFields{}
+	}
+	c := s.ooo.oooHeadChunk
+	if c == nil || c.chunk.NumSamples() == int(oooCapMax) {
+		// Note: If no new samples come in then we rely on compaction to clean up stale in-memory OOO chunks.
+		c, mmapRefs = s.cutNewOOOHeadChunk(t, o, logger)
+		chunkCreated = true
+	}
+
+	result = c.chunk.insertWithResult(st, t, v, h, fh)
+	if result == OOOInserted {
+		if chunkCreated || t < c.minTime {
+			c.minTime = t
+		}
+		if chunkCreated || t > c.maxTime {
+			c.maxTime = t
+		}
+	}
+	return result, chunkCreated, mmapRefs
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1170,7 +1170,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260811220505-057e2c3231f4
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260812165107-b5a9b560a806
 ## explicit; go 1.25.10
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -2222,7 +2222,7 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260811220505-057e2c3231f4
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260812165107-b5a9b560a806
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7
 # go.yaml.in/yaml/v3 => github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71


### PR DESCRIPTION
### What this PR does

The TSDB head appender silently drops samples whose timestamp collides with an already-stored sample: exact duplicates (client retries, duplicate shippers, Kafka replay after an ingester restart) and same-timestamp conflicts that are only detectable at commit time. `Append` returns no error for these, so the ingester counted them as ingested and recorded no discard — making ingestion impossible to reconcile with what senders report.

After a successful commit, the ingester now reads `tsdb.CommitStats` from the appender (added in grafana/mimir-prometheus#1259) and reclassifies the drops:

- `cortex_discarded_samples_total` gains reason `same-value-for-timestamp` (exact duplicates); commit-time conflicts count into the existing `new-value-for-timestamp`.
- `cortex_ingester_ingested_samples_total` no longer counts the dropped samples (it now reflects what was actually stored).
- The drops are attributed per series in cost attribution.
- Dropped duplicates still refresh the TSDB last-update timestamp, so duplicate-only traffic does not idle-close the tenant TSDB.

The stats capability is part of `extendedAppender`, so an appender wrapper that fails to forward it breaks loudly on the first push instead of silently zeroing the accounting.

Notes for reviewers:

- The `vendor/` commit is mechanical — review the TSDB side in grafana/mimir-prometheus#1259. It pins #1259 at `a9570e70dc3b` for testing and must be re-pinned to a merged fork revision before this PR merges. The dependency update also removes two obsolete PromQL parser options from Mimir call sites; these features are now always enabled upstream. **Do not merge before grafana/mimir-prometheus#1259.**
- `cortex_ingester_ingested_samples_total` changes meaning from Append-time counting to post-commit truth (see CHANGELOG `[CHANGE]`); the only mixin consumer is the ingest-activity guard in the `MimirIngesterHasNotShippedBlocks*` alerts, which this makes marginally more accurate.
- In-order histogram exact-duplicates are no longer miscounted as `prometheus_tsdb_out_of_order_samples_total` (vendored change).

Validation on this revision: duplicate-ingestion tests (floats, histograms, OOO, and cost attribution), existing push/accounting tests, mimirtool commands tests, and focused query-frontend feature-gating tests passed locally. GEM/dev-cell validation of this updated dependency combination is still pending.

### Which issue(s) this PR fixes or relates to

Fixes #15552

### Checklist

- [x] Tests updated (`pkg/ingester/ingester_push_duplicate_test.go` — scenarios by @duricanikolic — plus TSDB-level coverage in grafana/mimir-prometheus#1259).
- [x] `CHANGELOG.md` updated.
- [x] Documentation added (runbook: duplicate-timestamp section).

Co-authored with @duricanikolic (design + prototype + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)