### PR TITLE
helm: increase default memcached memory requests and limits to match jsonnet

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [CHANGE] Set default memberlist `rejoin_interval` to 60s so that a member evicted from the gossip ring by a transient network fault periodically rejoins the cluster instead of staying isolated until restart. #16332
 * [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
+* [CHANGE] `chunks-cache`, `index-cache`, `metadata-cache`, `results-cache`: increase the default memory requests and limits of the memcached containers. `requests.memory` is now `(round (* 1.2 allocatedMemory) + 100Mi)` and `limits.memory` is now `(round (* 1.5 allocatedMemory))`, matching the buffers used in Jsonnet, giving memcached headroom before the container is OOM killed. #16348
 
 
 ## 6.2.0

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,9 +30,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [CHANGE] Set default memberlist `rejoin_interval` to 60s so that a member evicted from the gossip ring by a transient network fault periodically rejoins the cluster instead of staying isolated until restart. #16332
-* [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
 * [CHANGE] `chunks-cache`, `index-cache`, `metadata-cache`, `results-cache`: increase the default memory requests and limits of the memcached containers. `requests.memory` is now `(round (* 1.2 allocatedMemory) + 100Mi)` and `limits.memory` is now `(round (* 1.5 allocatedMemory))`, matching the buffers used in Jsonnet, giving memcached headroom before the container is OOM killed. #16348
-
+* [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
 
 ## 6.2.0
 

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -100,10 +100,16 @@ spec:
           {{- if .resources }}
             {{- toYaml .resources | nindent 12 }}
           {{- else }}
-          {{- /* Calculate requested memory as round(allocatedMemory * 1.2). But with integer built-in operators. */}}
-          {{- $requestMemory := div (add (mul .allocatedMemory 12) 5) 10 }}
+          {{- /* Calculate requested memory as round(allocatedMemory * 1.2) + 100Mi and the memory limit as
+                 round(allocatedMemory * 1.5), matching the buffers used by the memcached jsonnet library.
+                 The flat overhead covers memcached's memory usage that doesn't scale with allocatedMemory, such as
+                 connection buffers, the hash table and thread stacks, which a purely multiplicative buffer
+                 under-provisions for small caches. The limit is floored at the request so that a small
+                 allocatedMemory can't yield a request larger than the limit. But with integer built-in operators. */}}
+          {{- $requestMemory := add (div (add (mul .allocatedMemory 12) 5) 10) 100 }}
+          {{- $limitMemory := max (div (add (mul .allocatedMemory 15) 5) 10) $requestMemory }}
             limits:
-              memory: {{ $requestMemory }}Mi
+              memory: {{ $limitMemory }}Mi
             requests:
               cpu: 500m
               memory: {{ $requestMemory }}Mi

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2737,7 +2737,12 @@ chunks-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the chunks-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # To change how much memory the chunks-cache uses, set allocatedMemory rather than overriding this directly:
+  # memcached's own memory ceiling (the -m flag) is always derived from allocatedMemory, and by default
+  # requests.memory is set to (round (* 1.2 allocatedMemory) + 100Mi) and limits.memory to
+  # (round (* 1.5 allocatedMemory)), giving memcached headroom before the container is OOM killed.
+  # Overriding resources here does not change the -m flag, so the container's memory limit can end up
+  # inconsistent with the amount of memory memcached is configured to use.
   resources: null
 
   # -- Service annotations and labels
@@ -2845,7 +2850,12 @@ index-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the index-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # To change how much memory the index-cache uses, set allocatedMemory rather than overriding this directly:
+  # memcached's own memory ceiling (the -m flag) is always derived from allocatedMemory, and by default
+  # requests.memory is set to (round (* 1.2 allocatedMemory) + 100Mi) and limits.memory to
+  # (round (* 1.5 allocatedMemory)), giving memcached headroom before the container is OOM killed.
+  # Overriding resources here does not change the -m flag, so the container's memory limit can end up
+  # inconsistent with the amount of memory memcached is configured to use.
   resources: null
 
   # -- Service annotations and labels
@@ -2953,7 +2963,12 @@ metadata-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the metadata-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # To change how much memory the metadata-cache uses, set allocatedMemory rather than overriding this directly:
+  # memcached's own memory ceiling (the -m flag) is always derived from allocatedMemory, and by default
+  # requests.memory is set to (round (* 1.2 allocatedMemory) + 100Mi) and limits.memory to
+  # (round (* 1.5 allocatedMemory)), giving memcached headroom before the container is OOM killed.
+  # Overriding resources here does not change the -m flag, so the container's memory limit can end up
+  # inconsistent with the amount of memory memcached is configured to use.
   resources: null
 
   # -- Service annotations and labels
@@ -3061,7 +3076,12 @@ results-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the results-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # To change how much memory the results-cache uses, set allocatedMemory rather than overriding this directly:
+  # memcached's own memory ceiling (the -m flag) is always derived from allocatedMemory, and by default
+  # requests.memory is set to (round (* 1.2 allocatedMemory) + 100Mi) and limits.memory to
+  # (round (* 1.5 allocatedMemory)), giving memcached headroom before the container is OOM killed.
+  # Overriding resources here does not change the -m flag, so the container's memory limit can end up
+  # inconsistent with the amount of memory memcached is configured to use.
   resources: null
 
   # -- Service annotations and labels

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 9830Mi
+              memory: 12288Mi
             requests:
               cpu: 500m
-              memory: 9830Mi
+              memory: 9930Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 2458Mi
+              memory: 3072Mi
             requests:
               cpu: 500m
-              memory: 2458Mi
+              memory: 2558Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 614Mi
+              memory: 768Mi
             requests:
               cpu: 500m
-              memory: 614Mi
+              memory: 714Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 1229Mi
+              memory: 1536Mi
             requests:
               cpu: 500m
-              memory: 1229Mi
+              memory: 1329Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 9830Mi
+              memory: 12288Mi
             requests:
               cpu: 500m
-              memory: 9830Mi
+              memory: 9930Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 2458Mi
+              memory: 3072Mi
             requests:
               cpu: 500m
-              memory: 2458Mi
+              memory: 2558Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 614Mi
+              memory: 768Mi
             requests:
               cpu: 500m
-              memory: 614Mi
+              memory: 714Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -52,10 +52,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 614Mi
+              memory: 768Mi
             requests:
               cpu: 500m
-              memory: 614Mi
+              memory: 714Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -53,10 +53,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 9830Mi
+              memory: 12288Mi
             requests:
               cpu: 500m
-              memory: 9830Mi
+              memory: 9930Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -53,10 +53,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 2458Mi
+              memory: 3072Mi
             requests:
               cpu: 500m
-              memory: 2458Mi
+              memory: 2558Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -53,10 +53,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 614Mi
+              memory: 768Mi
             requests:
               cpu: 500m
-              memory: 614Mi
+              memory: 714Mi
           ports:
             - containerPort: 11211
               name: client

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -53,10 +53,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: 614Mi
+              memory: 768Mi
             requests:
               cpu: 500m
-              memory: 614Mi
+              memory: 714Mi
           ports:
             - containerPort: 11211
               name: client


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Increases the default memory requests and limits of the memcached containers for the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` StatefulSets, so that memcached has headroom below its container's memory limit before being OOM killed.

Previously both `requests.memory` and `limits.memory` were set to the same computed value, `round(1.2 * allocatedMemory)` — so there was no buffer at all between the request and the hard limit. This now matches the buffers used by the memcached jsonnet library:

| | before | after |
|---|---|---|
| `requests.memory` | `round(1.2 * allocatedMemory)` | `round(1.2 * allocatedMemory) + 100Mi` |
| `limits.memory` | `round(1.2 * allocatedMemory)` | `round(1.5 * allocatedMemory)` |

The flat `100Mi` overhead mirrors jsonnet's `memory_request_overhead_mb` and covers memcached's memory usage that doesn't scale with `allocatedMemory` (connection buffers, hash table, thread stacks), which a purely multiplicative buffer under-provisions for small caches. The limit is floored at the request so a small `allocatedMemory` can't produce a request larger than the limit.

With the default `allocatedMemory` values this works out to:

| cache | `allocatedMemory` | request | limit |
|---|---|---|---|
| chunks-cache | 8192 | 9830 → 9930Mi | 9830 → 12288Mi |
| index-cache | 2048 | 2458 → 2558Mi | 2458 → 3072Mi |
| metadata-cache / results-cache | 512 | 614 → 714Mi | 614 → 768Mi |

Also clarifies in `values.yaml` that `allocatedMemory` — not `resources` — is the supported way to size a cache, since memcached's `-m` flag is always derived from `allocatedMemory` and overriding `resources` does not change it.

#### Which issue(s) this PR fixes or relates to

Fixes #9737

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
