### PR TITLE
mixin: count ingester series per read compartment

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -272,8 +272,8 @@ spec:
                 or
                 ( # Ingest storage timeseries
                   sum by(cluster, namespace) (
-                    max by(ingester_id, cluster, namespace) (
-                      label_replace(cortex_ingester_memory_series,
+                    max by(ingester_id, read_compartment, cluster, namespace) (
+                      label_replace(label_replace(cortex_ingester_memory_series, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"),
                         "ingester_id", "$1",
                         "pod", ".*-([0-9]+)$"
                       )

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -260,8 +260,8 @@ groups:
               or
               ( # Ingest storage timeseries
                 sum by(cluster, namespace) (
-                  max by(ingester_id, cluster, namespace) (
-                    label_replace(cortex_ingester_memory_series,
+                  max by(ingester_id, read_compartment, cluster, namespace) (
+                    label_replace(label_replace(cortex_ingester_memory_series, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"),
                       "ingester_id", "$1",
                       "instance", ".*-([0-9]+)$"
                     )

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -260,8 +260,8 @@ groups:
               or
               ( # Ingest storage timeseries
                 sum by(cluster, namespace) (
-                  max by(ingester_id, cluster, namespace) (
-                    label_replace(cortex_ingester_memory_series,
+                  max by(ingester_id, read_compartment, cluster, namespace) (
+                    label_replace(label_replace(cortex_ingester_memory_series, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"),
                       "ingester_id", "$1",
                       "pod", ".*-([0-9]+)$"
                     )

--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -53,7 +53,7 @@ for RING_NAME in "ingester-partitions" "compactor" "store-gateway"; do
   done
 done
 
-for ALERT in "MimirBucketIndexNotUpdated" "MimirCompactorSchedulerNotCompletingJobs" "MimirCompactorSchedulerRepeatedJobFailure"; do
+for ALERT in "MimirBucketIndexNotUpdated" "MimirCompactorSchedulerNotCompletingJobs" "MimirCompactorSchedulerRepeatedJobFailure" "MimirIngesterInstanceHasNoTenants"; do
   EXPR=$(ALERT="${ALERT}" yq eval '.groups[].rules[] | select(.alert == env(ALERT)) | .expr' "${ALERTS_FILE}")
 
   if [ -z "${EXPR}" ]; then

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -398,8 +398,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
               or
               ( # Ingest storage timeseries
                 sum by(%(alert_aggregation_labels)s) (
-                  max by(ingester_id, %(alert_aggregation_labels)s) (
-                    label_replace(cortex_ingester_memory_series,
+                  max by(ingester_id, read_compartment, %(alert_aggregation_labels)s) (
+                    label_replace(%(memory_series)s,
                       "ingester_id", "$1",
                       "%(per_instance_label)s", ".*-([0-9]+)$"
                     )
@@ -407,7 +407,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 )
               )
             ) > 100000
-          ||| % $._config,
+          ||| % $._config {
+            memory_series: $.withReadCompartmentLabel('cortex_ingester_memory_series'),
+          },
           labels: {
             severity: 'warning',
           },


### PR DESCRIPTION
#### What this PR does

fix `IngesterInstanceHasNoTenants` to group by both `ingester_id` and read compartment

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
