### PR TITLE
mixin: add read compartment helper and compartments mixin tests

### DIFF
--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+TEST_DIR="${SCRIPT_DIR}"/test-compartments
+ALERTS_FILE="${TEST_DIR}"/alerts.yaml
+RULES_FILE="${TEST_DIR}"/rules.yaml
+FAILED=0
+
+assert_failed() {
+  MSG=$1
+
+  echo ""
+  echo -e "$MSG"
+  echo ""
+  FAILED=1
+}
+
+assert_absent() {
+  FILEPATH=$1
+  NEEDLE=$2
+  MSG=$3
+
+  MATCHES=$(grep -F -- "${NEEDLE}" "${FILEPATH}" || true)
+  if [ -n "$MATCHES" ]; then
+    assert_failed "${MSG}\nFound in $(basename "${FILEPATH}"):\n${MATCHES}"
+  fi
+}
+
+assert_matches() {
+  FILEPATH=$1
+  PATTERN=$2
+  MSG=$3
+
+  if ! grep -qE -- "${PATTERN}" "${FILEPATH}"; then
+    assert_failed "${MSG}\nNo match for '${PATTERN}' in $(basename "${FILEPATH}")"
+  fi
+}
+
+echo "Checking ${ALERTS_FILE}"
+
+# See stripDashboardVars in alerts/alerts-utils.libsonnet.
+assert_absent "${ALERTS_FILE}" '$read_compartment' \
+  "Alerts must not reference the \$read_compartment dashboard variable: it is not interpolated in rules, so the matcher would never match."
+
+# The ingester ring ("ingester") is intentionally not in this list: it is shared by all compartments.
+for RING_NAME in "compactor" "store-gateway"; do
+  for FILEPATH in "${ALERTS_FILE}" "${RULES_FILE}"; do
+    assert_absent "${FILEPATH}" "name=\"${RING_NAME}\"" \
+      "Ring \"${RING_NAME}\" is suffixed with \"-rc-<id>\" when compartments are enabled, so an equality matcher on the bare name never matches. Use a matcher that accepts the suffix."
+  done
+done
+
+if [ $FAILED -ne 0 ]; then
+  exit 1
+fi

--- a/operations/mimir-mixin-tests/test-compartments.libsonnet
+++ b/operations/mimir-mixin-tests/test-compartments.libsonnet
@@ -1,0 +1,8 @@
+(import 'mixin-compiled.libsonnet') + {
+  _config+:: {
+    compartments_enabled: true,
+
+    // The scheduler is deployed per read compartment, so enable it to generate and check its alerts too.
+    compactor_scheduler_enabled: true,
+  },
+}

--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -18,6 +18,10 @@
     else if std.isString(job) then stripDashboardVars(job)
     else error 'expected job "%s" to be a string or an array, but it is type "%s"' % [job, std.type(job)],
 
+  // Adds a "read_compartment" label with the ID parsed out of the "-rc-<id>" suffix of sourceLabel, if present.
+  withReadCompartmentLabel(query, sourceLabel=$._config.per_job_label)::
+    'label_replace(%s, "read_compartment", "$1", "%s", ".*-rc-([0-9]+)")' % [query, sourceLabel],
+
   withRunbookURL(url_format, groups)::
     local update_rule(rule) =
       if std.objectHas(rule, 'alert')


### PR DESCRIPTION
#### What this PR does

adds a `withReadCompartmentLabel` helper to keep a regex to extract `-rc-<id>` in one place, plus a compartments variant of the mixin tests: the compiled mixin has compartments disabled, so nothing exercised these code paths before.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
