### PR TITLE
mixin: compare partitions to consumers per read compartment

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1671,10 +1671,19 @@ spec:
               severity: critical
           - alert: MimirFewerIngestersConsumingThanActivePartitions
             annotations:
-              message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} have fewer ingesters consuming than active partitions.
+              message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} have fewer ingesters consuming than active partitions.
               runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
             expr: |
-              max(cortex_partition_ring_partitions{name="ingester-partitions", state="Active"}) by (cluster, namespace) > count(count(cortex_ingest_storage_reader_last_consumed_offset{}) by (cluster, namespace, partition)) by (cluster, namespace)
+              max by (cluster, namespace, read_compartment) (label_replace(cortex_partition_ring_partitions{name=~"ingester-partitions(-rc-[0-9]+)?", state="Active"}, "read_compartment", "$1", "name", ".*-rc-([0-9]+)"))
+                >
+              (
+                count by (cluster, namespace, read_compartment) (
+                  count by (cluster, namespace, read_compartment, partition) (label_replace(cortex_ingest_storage_reader_last_consumed_offset{}, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
+                )
+                  or
+                # A compartment that lost all its consumers has no series here and would drop out of the comparison, so default it to zero.
+                (max by (cluster, namespace, read_compartment) (label_replace(cortex_partition_ring_partitions{name=~"ingester-partitions(-rc-[0-9]+)?", state="Active"}, "read_compartment", "$1", "name", ".*-rc-([0-9]+)")) * 0)
+              )
             for: 15m
             labels:
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1645,10 +1645,19 @@ groups:
             severity: critical
         - alert: MimirFewerIngestersConsumingThanActivePartitions
           annotations:
-            message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} have fewer ingesters consuming than active partitions.
+            message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} have fewer ingesters consuming than active partitions.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
           expr: |
-            max(cortex_partition_ring_partitions{name="ingester-partitions", state="Active"}) by (cluster, namespace) > count(count(cortex_ingest_storage_reader_last_consumed_offset{}) by (cluster, namespace, partition)) by (cluster, namespace)
+            max by (cluster, namespace, read_compartment) (label_replace(cortex_partition_ring_partitions{name=~"ingester-partitions(-rc-[0-9]+)?", state="Active"}, "read_compartment", "$1", "name", ".*-rc-([0-9]+)"))
+              >
+            (
+              count by (cluster, namespace, read_compartment) (
+                count by (cluster, namespace, read_compartment, partition) (label_replace(cortex_ingest_storage_reader_last_consumed_offset{}, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
+              )
+                or
+              # A compartment that lost all its consumers has no series here and would drop out of the comparison, so default it to zero.
+              (max by (cluster, namespace, read_compartment) (label_replace(cortex_partition_ring_partitions{name=~"ingester-partitions(-rc-[0-9]+)?", state="Active"}, "read_compartment", "$1", "name", ".*-rc-([0-9]+)")) * 0)
+            )
           for: 15m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1659,10 +1659,19 @@ groups:
             severity: critical
         - alert: MimirFewerIngestersConsumingThanActivePartitions
           annotations:
-            message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} have fewer ingesters consuming than active partitions.
+            message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} have fewer ingesters consuming than active partitions.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
           expr: |
-            max(cortex_partition_ring_partitions{name="ingester-partitions", state="Active"}) by (cluster, namespace) > count(count(cortex_ingest_storage_reader_last_consumed_offset{}) by (cluster, namespace, partition)) by (cluster, namespace)
+            max by (cluster, namespace, read_compartment) (label_replace(cortex_partition_ring_partitions{name=~"ingester-partitions(-rc-[0-9]+)?", state="Active"}, "read_compartment", "$1", "name", ".*-rc-([0-9]+)"))
+              >
+            (
+              count by (cluster, namespace, read_compartment) (
+                count by (cluster, namespace, read_compartment, partition) (label_replace(cortex_ingest_storage_reader_last_consumed_offset{}, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
+              )
+                or
+              # A compartment that lost all its consumers has no series here and would drop out of the comparison, so default it to zero.
+              (max by (cluster, namespace, read_compartment) (label_replace(cortex_partition_ring_partitions{name=~"ingester-partitions(-rc-[0-9]+)?", state="Active"}, "read_compartment", "$1", "name", ".*-rc-([0-9]+)")) * 0)
+            )
           for: 15m
           labels:
             severity: critical

--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -46,11 +46,18 @@ assert_absent "${ALERTS_FILE}" '$read_compartment' \
   "Alerts must not reference the \$read_compartment dashboard variable: it is not interpolated in rules, so the matcher would never match."
 
 # The ingester ring ("ingester") is intentionally not in this list: it is shared by all compartments.
-for RING_NAME in "compactor" "store-gateway"; do
+for RING_NAME in "ingester-partitions" "compactor" "store-gateway"; do
   for FILEPATH in "${ALERTS_FILE}" "${RULES_FILE}"; do
     assert_absent "${FILEPATH}" "name=\"${RING_NAME}\"" \
       "Ring \"${RING_NAME}\" is suffixed with \"-rc-<id>\" when compartments are enabled, so an equality matcher on the bare name never matches. Use a matcher that accepts the suffix."
   done
+done
+
+PARTITION_ALERT_EXPR=$(yq eval '.groups[].rules[] | select(.alert == "MimirFewerIngestersConsumingThanActivePartitions") | .expr' "${ALERTS_FILE}")
+for METRIC in "cortex_partition_ring_partitions" "cortex_ingest_storage_reader_last_consumed_offset"; do
+  if ! echo "${PARTITION_ALERT_EXPR}" | grep -F -- "${METRIC}" | grep -q -F -- 'read_compartment'; then
+    assert_failed "MimirFewerIngestersConsumingThanActivePartitions does not derive a read_compartment label from ${METRIC}.\nPartition IDs collide across compartments, so both sides must be compared per compartment."
+  fi
 done
 
 if [ $FAILED -ne 0 ]; then

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -391,14 +391,27 @@ local utils = import 'mixin-utils/utils.libsonnet';
         {
           alert: $.alertName('FewerIngestersConsumingThanActivePartitions'),
           expr: |||
-            max(cortex_partition_ring_partitions{name="ingester-partitions", state="Active"}) by (%(alert_aggregation_labels)s) > count(count(cortex_ingest_storage_reader_last_consumed_offset{}) by (%(alert_aggregation_labels)s, partition)) by (%(alert_aggregation_labels)s)
-          ||| % $._config,
+            max by (%(alert_aggregation_labels)s, read_compartment) (%(active_partitions)s)
+              >
+            (
+              count by (%(alert_aggregation_labels)s, read_compartment) (
+                count by (%(alert_aggregation_labels)s, read_compartment, partition) (%(partition_consumers)s)
+              )
+                or
+              # A compartment that lost all its consumers has no series here and would drop out of the comparison, so default it to zero.
+              (max by (%(alert_aggregation_labels)s, read_compartment) (%(active_partitions)s) * 0)
+            )
+          ||| % $._config {
+            // The compartment is in the ring name on one side, in the ingester job name on the other.
+            active_partitions: $.withReadCompartmentLabel('cortex_partition_ring_partitions{name=~"ingester-partitions(-rc-[0-9]+)?", state="Active"}', 'name'),
+            partition_consumers: $.withReadCompartmentLabel('cortex_ingest_storage_reader_last_consumed_offset{}'),
+          },
           'for': '15m',
           labels: {
             severity: 'critical',
           },
           annotations: {
-                         message: '%(product)s ingesters in %(alert_aggregation_variables)s have fewer ingesters consuming than active partitions.' % $._config,
+                         message: '%(product)s ingesters in %(alert_aggregation_variables)s{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} have fewer ingesters consuming than active partitions.' % $._config,
                        }
                        // Alternative dashboards for investigation:
                        //   - Mimir / Reads (mimir-reads.json)


### PR DESCRIPTION
#### What this PR does

Fix `MimirFewerIngestersConsumingThanActivePartitions` and add a regression test case.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
