### PR TITLE
mixin: alert on a stale bucket index per read compartment

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1166,10 +1166,10 @@ spec:
               severity: warning
           - alert: MimirBucketIndexNotUpdated
             annotations:
-              message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
+              message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} has not been updated since {{ $value | humanizeDuration }}.
               runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbucketindexnotupdated
             expr: |
-              min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
+              min by(cluster, namespace, user, read_compartment) (time() - (label_replace(max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))) > 2100
             for: 2m
             labels:
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1140,10 +1140,10 @@ groups:
             severity: warning
         - alert: MimirBucketIndexNotUpdated
           annotations:
-            message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
+            message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} has not been updated since {{ $value | humanizeDuration }}.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
-            min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
+            min by(cluster, namespace, user, read_compartment) (time() - (label_replace(max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))) > 2100
           for: 2m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1154,10 +1154,10 @@ groups:
             severity: warning
         - alert: MimirBucketIndexNotUpdated
           annotations:
-            message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
+            message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} has not been updated since {{ $value | humanizeDuration }}.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
-            min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
+            min by(cluster, namespace, user, read_compartment) (time() - (label_replace(max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))) > 2100
           for: 2m
           labels:
             severity: critical

--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -53,6 +53,16 @@ for RING_NAME in "ingester-partitions" "compactor" "store-gateway"; do
   done
 done
 
+for ALERT in "MimirBucketIndexNotUpdated"; do
+  EXPR=$(ALERT="${ALERT}" yq eval '.groups[].rules[] | select(.alert == env(ALERT)) | .expr' "${ALERTS_FILE}")
+
+  if [ -z "${EXPR}" ]; then
+    assert_failed "Alert ${ALERT} was not found in $(basename "${ALERTS_FILE}"): this assertion is checking nothing."
+  elif ! echo "${EXPR}" | grep -q -F -- 'read_compartment'; then
+    assert_failed "Alert ${ALERT} does not group by read_compartment, so a healthy compartment can mask a failing one."
+  fi
+done
+
 PARTITION_ALERT_EXPR=$(yq eval '.groups[].rules[] | select(.alert == "MimirFewerIngestersConsumingThanActivePartitions") | .expr' "${ALERTS_FILE}")
 for METRIC in "cortex_partition_ring_partitions" "cortex_ingest_storage_reader_last_consumed_offset"; do
   if ! echo "${PARTITION_ALERT_EXPR}" | grep -F -- "${METRIC}" | grep -q -F -- 'read_compartment'; then

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -231,22 +231,22 @@
           },
         },
         {
-          // Alert if the bucket index has not been updated for a given user. The default update interval is 900 seconds
+          // Alert if the bucket index has not been updated for a given <compartment, user>. The default update interval is 900 seconds
           // so we alert if we've missed two updates plus a 300 second buffer to avoid false-positives. It's important
           // that this alert fire before queriers start to return errors because the bucket index is too old (3600 seconds
           // by default). Allow a 15m lookback (the default compactor.cleanup-interval) to include compactors that may have recently updated the index and then been terminated.
           alert: $.alertName('BucketIndexNotUpdated'),
           expr: |||
-            min by(%(alert_aggregation_labels)s, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[%(rate_interval)s]))) > 2100
+            min by(%(alert_aggregation_labels)s, user, read_compartment) (time() - (%(last_update)s)) > 2100
           ||| % $._config {
-            rate_interval: $.rateInterval('15m'),
+            last_update: $.withReadCompartmentLabel('max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[%s])' % $.rateInterval('15m')),
           },
           'for': '2m',  // Extra buffer to allow the compactor that was restarted close to the end of previous update cycle to discover the tenant and udpate their bucket.
           labels: {
             severity: 'critical',
           },
           annotations: {
-            message: '%(product)s bucket index for tenant {{ $labels.user }} in %(alert_aggregation_variables)s has not been updated since {{ $value | humanizeDuration }}.' % $._config,
+            message: '%(product)s bucket index for tenant {{ $labels.user }} in %(alert_aggregation_variables)s{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} has not been updated since {{ $value | humanizeDuration }}.' % $._config,
           },
         },
         {


### PR DESCRIPTION
#### What this PR does

fix `MimirBucketIndexNotUpdated` to group by read compartment

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
