### PR TITLE
mixin: alert on compactor scheduler jobs per read compartment

### DIFF
--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -53,7 +53,7 @@ for RING_NAME in "ingester-partitions" "compactor" "store-gateway"; do
   done
 done
 
-for ALERT in "MimirBucketIndexNotUpdated"; do
+for ALERT in "MimirBucketIndexNotUpdated" "MimirCompactorSchedulerNotCompletingJobs" "MimirCompactorSchedulerRepeatedJobFailure"; do
   EXPR=$(ALERT="${ALERT}" yq eval '.groups[].rules[] | select(.alert == env(ALERT)) | .expr' "${ALERTS_FILE}")
 
   if [ -z "${EXPR}" ]; then

--- a/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
@@ -39,17 +39,17 @@
           // Alert if the scheduler has recorded repeated job failures.
           alert: $.alertName('CompactorSchedulerRepeatedJobFailure'),
           expr: |||
-            sum by(%(alert_aggregation_labels)s) (
-              increase(cortex_compactor_scheduler_repeated_job_failures_total[%(rate_interval)s])
+            sum by(%(alert_aggregation_labels)s, read_compartment) (
+              %(repeated_failures)s
             ) > 0
           ||| % $._config {
-            rate_interval: $.rateInterval('20m'),
+            repeated_failures: $.withReadCompartmentLabel('increase(cortex_compactor_scheduler_repeated_job_failures_total[%s])' % $.rateInterval('20m')),
           },
           labels: {
             severity: 'warning',
           },
           annotations: {
-            message: '%(product)s Compactor scheduler in %(alert_aggregation_variables)s has jobs failing repeatedly.' % $._config,
+            message: '%(product)s Compactor scheduler in %(alert_aggregation_variables)s{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} has jobs failing repeatedly.' % $._config,
           },
         },
         {
@@ -57,17 +57,17 @@
           alert: $.alertName('CompactorSchedulerNotCompletingJobs'),
           'for': '30m',
           expr: |||
-            sum by(%(alert_aggregation_labels)s) (
-              increase(cortex_compactor_scheduler_jobs_completed_total[%(rate_interval)s])
+            sum by(%(alert_aggregation_labels)s, read_compartment) (
+              %(jobs_completed)s
             ) == 0
           ||| % $._config {
-            rate_interval: $.rateInterval('6h'),
+            jobs_completed: $.withReadCompartmentLabel('increase(cortex_compactor_scheduler_jobs_completed_total[%s])' % $.rateInterval('6h')),
           },
           labels: {
             severity: 'critical',
           },
           annotations: {
-            message: '%(product)s Compactor scheduler in %(alert_aggregation_variables)s is not completing any jobs.' % $._config,
+            message: '%(product)s Compactor scheduler in %(alert_aggregation_variables)s{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} is not completing any jobs.' % $._config,
           },
         },
       ],


### PR DESCRIPTION
#### What this PR does

fix `CompactorSchedulerRepeatedJobFailure` and `CompactorSchedulerNotCompletingJobs` to group by read compartment

these alerts aren't in the compiled mixin (the compactor scheduler is disabled by default), so there are no compiled output changes here — the compartments mixin test enables the scheduler to exercise them.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
