### PR TITLE
mixin: fix zones count for MimirIngesterTSDBWALCorrupted severity

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1115,10 +1115,10 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
             expr: |
               # alert when there are more than one corruptions
-              count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+              count by (cluster, namespace, read_compartment) (label_replace(label_replace((rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*")) > 1
               and
               # and there is only one zone
-              count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+              count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace(cortex_ingester_tsdb_wal_corruptions_total, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) == 1
             labels:
               deployment: single-zone
               severity: critical
@@ -1127,11 +1127,11 @@ spec:
               message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
               runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
             expr: |
-              # alert when there are more than one corruptions
-              count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+              # alert when there are corruptions in more than one zone
+              count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace((rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) > 1
               and
               # and there are multiple zones
-              count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+              count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace(cortex_ingester_tsdb_wal_corruptions_total, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) > 1
             labels:
               deployment: multi-zone
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1089,10 +1089,10 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
-            count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+            count by (cluster, namespace, read_compartment) (label_replace(label_replace((rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*")) > 1
             and
             # and there is only one zone
-            count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+            count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace(cortex_ingester_tsdb_wal_corruptions_total, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) == 1
           labels:
             deployment: single-zone
             severity: critical
@@ -1101,11 +1101,11 @@ groups:
             message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
-            # alert when there are more than one corruptions
-            count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+            # alert when there are corruptions in more than one zone
+            count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace((rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) > 1
             and
             # and there are multiple zones
-            count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+            count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace(cortex_ingester_tsdb_wal_corruptions_total, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) > 1
           labels:
             deployment: multi-zone
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1103,10 +1103,10 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
-            count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
+            count by (cluster, namespace, read_compartment) (label_replace(label_replace((rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*")) > 1
             and
             # and there is only one zone
-            count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+            count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace(cortex_ingester_tsdb_wal_corruptions_total, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) == 1
           labels:
             deployment: single-zone
             severity: critical
@@ -1115,11 +1115,11 @@ groups:
             message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
-            # alert when there are more than one corruptions
-            count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
+            # alert when there are corruptions in more than one zone
+            count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace((rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) > 1
             and
             # and there are multiple zones
-            count by (cluster, namespace) (group by (cluster, namespace, job) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+            count by (cluster, namespace, read_compartment) (group by (cluster, namespace, read_compartment, zone) (label_replace(label_replace(cortex_ingester_tsdb_wal_corruptions_total, "read_compartment", "$1", "job", ".*-rc-([0-9]+)"), "zone", "$1", "job", ".*-(zone-[a-z]).*"))) > 1
           labels:
             deployment: multi-zone
             severity: critical

--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -70,6 +70,16 @@ for METRIC in "cortex_partition_ring_partitions" "cortex_ingest_storage_reader_l
   fi
 done
 
+for DEPLOYMENT in single-zone multi-zone; do
+  EXPR=$(yq eval ".groups[].rules[] | select(.alert == \"MimirIngesterTSDBWALCorrupted\" and .labels.deployment == \"${DEPLOYMENT}\") | .expr" "${ALERTS_FILE}")
+  if echo "${EXPR}" | grep -q -F -- ', job)' ||
+    ! echo "${EXPR}" | grep -q -F -- '"read_compartment"' ||
+    ! echo "${EXPR}" | grep -q -F -- 'count by (cluster, namespace, read_compartment)' ||
+    ! echo "${EXPR}" | grep -q -F -- 'group by (cluster, namespace, read_compartment, zone)'; then
+    assert_failed "MimirIngesterTSDBWALCorrupted (${DEPLOYMENT}) does not count zones per read compartment."
+  fi
+done
+
 if [ $FAILED -ne 0 ]; then
   exit 1
 fi

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -1,4 +1,7 @@
 (import 'alerts-utils.libsonnet') {
+  local withCompartmentAndZoneLabels(query) =
+    'label_replace(%s, "zone", "$1", "%s", ".*-(zone-[a-z]).*")' % [$.withReadCompartmentLabel(query), $._config.per_job_label],
+
   local alertGroups = [
     {
       name: 'mimir_blocks_alerts',
@@ -153,12 +156,13 @@
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
             # alert when there are more than one corruptions
-            count by (%(alert_aggregation_labels)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[%(rate_interval)s]) > 0) > 1
+            count by (%(alert_aggregation_labels)s, read_compartment) (%(corruption_rate_by_zone)s) > 1
             and
             # and there is only one zone
-            count by (%(alert_aggregation_labels)s) (group by (%(alert_aggregation_labels)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
+            count by (%(alert_aggregation_labels)s, read_compartment) (group by (%(alert_aggregation_labels)s, read_compartment, zone) (%(corruptions_by_zone)s)) == 1
           ||| % $._config {
-            rate_interval: $.rateInterval('5m'),
+            corruption_rate_by_zone: withCompartmentAndZoneLabels('(rate(cortex_ingester_tsdb_wal_corruptions_total[%s]) > 0)' % $.rateInterval('5m')),
+            corruptions_by_zone: withCompartmentAndZoneLabels('cortex_ingester_tsdb_wal_corruptions_total'),
           },
           labels: {
             severity: 'critical',
@@ -171,13 +175,14 @@
         {
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
-            # alert when there are more than one corruptions
-            count by (%(alert_aggregation_labels)s) (sum by (%(alert_aggregation_labels)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[%(rate_interval)s]) > 0)) > 1
+            # alert when there are corruptions in more than one zone
+            count by (%(alert_aggregation_labels)s, read_compartment) (group by (%(alert_aggregation_labels)s, read_compartment, zone) (%(corruption_rate_by_zone)s)) > 1
             and
             # and there are multiple zones
-            count by (%(alert_aggregation_labels)s) (group by (%(alert_aggregation_labels)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
+            count by (%(alert_aggregation_labels)s, read_compartment) (group by (%(alert_aggregation_labels)s, read_compartment, zone) (%(corruptions_by_zone)s)) > 1
           ||| % $._config {
-            rate_interval: $.rateInterval('5m'),
+            corruption_rate_by_zone: withCompartmentAndZoneLabels('(rate(cortex_ingester_tsdb_wal_corruptions_total[%s]) > 0)' % $.rateInterval('5m')),
+            corruptions_by_zone: withCompartmentAndZoneLabels('cortex_ingester_tsdb_wal_corruptions_total'),
           },
           labels: {
             severity: 'critical',


### PR DESCRIPTION
#### What this PR does

Counts WAL corruption zones per read compartment using labels derived from ingester job names.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
