### PR TITLE
mixin: record actual replicas across a component's compartments

### DIFF
--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -94,6 +94,11 @@ for FILEPATH in "${ALERTS_FILE}" "${RULES_FILE}" "${ROLLOUT_DASHBOARD}"; do
   fi
 done
 
+ACTUAL_REPLICA_RULES=$(yq eval '[.groups[].rules[] | select(.record == "cluster_namespace_deployment:actual_replicas:count")] | length' "${RULES_FILE}")
+if [ "${ACTUAL_REPLICA_RULES}" -ne 2 ]; then
+  assert_failed "Expected per-compartment and component-wide actual replica rules."
+fi
+
 if [ $FAILED -ne 0 ]; then
   exit 1
 fi

--- a/operations/mimir-mixin/recording_rules.libsonnet
+++ b/operations/mimir-mixin/recording_rules.libsonnet
@@ -119,6 +119,33 @@ local utils = import 'mixin-utils/utils.libsonnet';
             record: '%(alert_aggregation_rule_prefix)s_deployment:actual_replicas:count' % _config,
             expr: _config.mimir_scaling_rules[_config.deployment_type].actual_replicas_count % _config,
           },
+        ] + (
+          if _config.compartments_enabled then [
+            {
+              // Add bare component totals for namespace-wide scaling rules.
+              record: '%(alert_aggregation_rule_prefix)s_deployment:actual_replicas:count' % _config,
+              expr: |||
+                sum by (%(alert_aggregation_labels)s, deployment) (
+                  label_replace(
+                    sum by (%(alert_aggregation_labels)s, deployment_without_compartment) (
+                      label_replace(
+                        %(actual_replicas)s{deployment=~".*-(?:rc|wc)-[0-9]+"},
+                        "deployment_without_compartment", "$1", "deployment", "(.*)-(?:rc|wc)-[0-9]+"
+                      )
+                    ),
+                    "deployment", "$1", "deployment_without_compartment", "(.*)"
+                  )
+                )
+                # Avoid duplicates during migration. actual_replicas includes this rule's previous output.
+                unless
+                %(actual_replicas_source)s
+              ||| % (_config {
+                       actual_replicas: '%(alert_aggregation_rule_prefix)s_deployment:actual_replicas:count' % _config,
+                       actual_replicas_source: _config.mimir_scaling_rules[_config.deployment_type].actual_replicas_count % _config,
+                     }),
+            },
+          ] else []
+        ) + [
           {
             // Distributors should be able to deal with 240k samples/s.
             record: '%(alert_aggregation_rule_prefix)s_deployment_reason:required_replicas:count' % _config,


### PR DESCRIPTION
#### What this PR does

Adds component-wide actual replica series alongside per-compartment series for scaling dashboard joins.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
