### PR TITLE
mixin: rewrite MimirSchedulerQueriesStuck using cortex_query_scheduler_queue_max_wait_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Mixin
 
 * [CHANGE] Mixin: Default `_config.scrape_interval` is now `1m` (was `15s`) so precompiled recording rules and alerts work with common Alloy/ServiceMonitor scrape defaults. Rebuild the mixin if your scrape interval differs. #16178
+* [CHANGE] Alerts: Rewrite `MimirSchedulerQueriesStuck` to fire when the oldest request waiting in the query-scheduler queue has been waiting for more than 60 seconds, using the `cortex_query_scheduler_queue_max_wait_seconds` metric introduced in Mimir 3.2, instead of inferring stuck queries from a non-decreasing queue length. #16365
 * [FEATURE] Block-builder: add jsonnet for deploying the experimental block-builder and block-builder-scheduler. Enable with `block_builder.enabled: true`. #16175 #16337
 * [ENHANCEMENT] Add the `compactor_standalone_enabled` config option (enabled by default) to hide standalone-mode compactor panels and alerts, and stop collapsing scheduler-mode dashboard rows. #16239
 * [ENHANCEMENT] Dashboards: Make the boot/root disk device regex used to filter it out of the "Disk writes" and "Disk reads" panels configurable via `_config.node_boot_disk_device_regex` (default unchanged: `.*sda.*`), so clusters where the root device isn't `sda` (e.g. `vda` on some cloud providers) don't lose data on those panels. #16235

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1092,7 +1092,7 @@ How to **investigate**:
 
 ### MimirSchedulerQueriesStuck
 
-This alert fires if queries are piling up in the query-scheduler.
+This alert fires when the oldest query waiting in the query-scheduler queue has been waiting for too long, indicating that queries are stuck rather than being processed. The alert is based on `cortex_query_scheduler_queue_max_wait_seconds`, which reports how long the oldest request still waiting in the queue has been waiting since it was enqueued. Requests already dispatched to a querier are excluded.
 
 #### Dashboard Panels
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -120,26 +120,12 @@ spec:
           - alert: MimirSchedulerQueriesStuck
             annotations:
               message: |
-                  There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
+                  The oldest query queued in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }} has been waiting for {{ printf "%.0f" $value }} seconds.
               runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirschedulerqueriesstuck
             expr: |
-              # There are some queries in the queue.
-              (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
-  
-              # And the queue size doesn't decrease.
-              # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
-              # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
-              # queue length that fall between evaluation points, causing delta() to appear non-negative even when
-              # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
-              and (
-                min_over_time(
-                  delta(
-                    sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length)
-                    [4m:5s]
-                  )
-                  [4m:5s]
-                ) >= 0
-              )
+              max by (cluster, namespace, job) (
+                cortex_query_scheduler_queue_max_wait_seconds
+              ) > 60
             for: 7m
             labels:
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -108,26 +108,12 @@ groups:
         - alert: MimirSchedulerQueriesStuck
           annotations:
             message: |
-                There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
+                The oldest query queued in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }} has been waiting for {{ printf "%.0f" $value }} seconds.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirschedulerqueriesstuck
           expr: |
-            # There are some queries in the queue.
-            (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
-
-            # And the queue size doesn't decrease.
-            # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
-            # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
-            # queue length that fall between evaluation points, causing delta() to appear non-negative even when
-            # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
-            and (
-              min_over_time(
-                delta(
-                  sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length)
-                  [4m:5s]
-                )
-                [4m:5s]
-              ) >= 0
-            )
+            max by (cluster, namespace, job) (
+              cortex_query_scheduler_queue_max_wait_seconds
+            ) > 60
           for: 7m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -108,26 +108,12 @@ groups:
         - alert: MimirSchedulerQueriesStuck
           annotations:
             message: |
-                There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
+                The oldest query queued in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }} has been waiting for {{ printf "%.0f" $value }} seconds.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirschedulerqueriesstuck
           expr: |
-            # There are some queries in the queue.
-            (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
-
-            # And the queue size doesn't decrease.
-            # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
-            # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
-            # queue length that fall between evaluation points, causing delta() to appear non-negative even when
-            # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
-            and (
-              min_over_time(
-                delta(
-                  sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length)
-                  [4m:5s]
-                )
-                [4m:5s]
-              ) >= 0
-            )
+            max by (cluster, namespace, job) (
+              cortex_query_scheduler_queue_max_wait_seconds
+            ) > 60
           for: 7m
           labels:
             severity: critical

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -226,27 +226,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
         {
           alert: $.alertName('SchedulerQueriesStuck'),
           expr: |||
-            # There are some queries in the queue.
-            (sum by (%(group_by)s, %(job_label)s) (cortex_query_scheduler_queue_length) > 0)
-
-            # And the queue size doesn't decrease.
-            # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
-            # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
-            # queue length that fall between evaluation points, causing delta() to appear non-negative even when
-            # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
-            and (
-              min_over_time(
-                delta(
-                  sum by (%(group_by)s, %(job_label)s) (cortex_query_scheduler_queue_length)
-                  [%(rate_interval)s:5s]
-                )
-                [%(rate_interval)s:5s]
-              ) >= 0
-            )
+            max by (%(group_by)s, %(job_label)s) (
+              cortex_query_scheduler_queue_max_wait_seconds
+            ) > 60
           ||| % {
             group_by: $._config.alert_aggregation_labels,
             job_label: $._config.per_job_label,
-            rate_interval: $.rateInterval('1m'),
           },
           'for': '7m',  // We don't want to block for longer.
           labels: {
@@ -255,7 +240,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           annotations: (
             {
               message: |||
-                There are {{ $value }} queued up queries in %(alert_aggregation_variables)s {{ $labels.%(per_job_label)s }}.
+                The oldest query queued in %(alert_aggregation_variables)s {{ $labels.%(per_job_label)s }} has been waiting for {{ printf "%%.0f" $value }} seconds.
               ||| % $._config,
             }
           ) + (


### PR DESCRIPTION
#### What this PR does

rewrites the `MimirSchedulerQueriesStuck` alert to fire when the oldest request waiting in the query-scheduler queue has been waiting for more than 60 seconds, sustained for 7 minutes, using `cortex_query_scheduler_queue_max_wait_seconds` (added in #15419, reworked in #15960).

the old expression inferred stuck queries from a non-decreasing `cortex_query_scheduler_queue_length`, which can false-positive while queries are still making progress, and false-negative when a single tenant's queue is stalled while others drain. the new metric directly measures what we want to alert on: how long the oldest request has been sitting in the queue.

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.