### PR TITLE
cat: Fall back to retained labelset when syncing deleted series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
+* [BUGFIX] Ingester: Fix issue by which cost attribution tracking diverges after early head compaction by avoiding resolving deleted series's labelset from the index. #16368
 
 ### Mixin
 

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -589,24 +589,51 @@ func (s *seriesStripe) reloadConfig(asm *asmodel.Matchers, cat *costattribution.
 
 			// It's possible that a series may have been added while we were in the lookup phase,
 			// So we need to keep this logic here for those.
-			if err := idx.Series(ref, &buf, nil); err != nil {
+			if lbls, ok := s.lookupSeriesLabels(ref, entry, idx, &buf); ok {
+				incrementCatIfChanged(lbls, entry)
+				updateEntryIfMatchersChanged(ref, entry, func() asmodel.PreAllocDynamicSlice { return asm.Matches(lbls) })
+			} else {
 				s.activeSeriesAttributionFailureCounter.Add(1)
 				// If we failed to lookup the series (which shouldn't happen as we're notified of deletions),
 				// we still need to update the entry.matches to make sure it has a coherent size with the matchers we're setting.
 				updateEntryIfMatchersChanged(ref, entry, func() asmodel.PreAllocDynamicSlice { return asm.Matches(labels.EmptyLabels()) })
-				// We do not increment CAT here, because it shouldn't happen, and because nobody would decrement it later.
-				// Or we could do it, if you want to, anyway, this should not happen, why am I even spending my energy writing this comment?
-				continue
 			}
-			lbls := buf.Labels()
-			incrementCatIfChanged(lbls, entry)
-			updateEntryIfMatchersChanged(ref, entry, func() asmodel.PreAllocDynamicSlice { return asm.Matches(lbls) })
 		}
 	}
 
 	if catChanged {
 		s.cat = cat
 	}
+}
+
+func (s *seriesStripe) lookupSeriesLabels(ref storage.SeriesRef, entry seriesEntry, idx tsdb.IndexReader, buf *labels.ScratchBuilder) (labels.Labels, bool) {
+	if err := idx.Series(ref, buf, nil); err == nil {
+		return buf.Labels(), true
+	}
+
+	// The series ref may be missing from the index when the series
+	// was deleted from the head while still active (e.g. early head
+	// compaction). Look up by lbls instead.
+	if entry.isDeleted() {
+		if lbls, ok := s.deleted.labelsOf(ref); ok {
+			return lbls, true
+		}
+	}
+	return labels.Labels{}, false
+}
+
+func (s *seriesStripe) decrementCostAttribution(ref storage.SeriesRef, entry seriesEntry, idx tsdb.IndexReader, buf *labels.ScratchBuilder) {
+	if s.cat == nil {
+		return
+	}
+
+	lbls, ok := s.lookupSeriesLabels(ref, entry, idx, buf)
+	if !ok {
+		s.activeSeriesAttributionFailureCounter.Add(1)
+		return
+	}
+
+	s.cat.Decrement(lbls, entry.numNativeHistogramBuckets)
 }
 
 func (s *seriesStripe) purge(keepUntil time.Time, idx tsdb.IndexReader) {
@@ -632,13 +659,7 @@ func (s *seriesStripe) purge(keepUntil time.Time, idx tsdb.IndexReader) {
 	for ref, entry := range s.refs {
 		ts := entry.nanos.Load()
 		if ts < keepUntilNanos {
-			if s.cat != nil {
-				if err := idx.Series(ref, &buf, nil); err != nil {
-					s.activeSeriesAttributionFailureCounter.Add(1)
-				} else {
-					s.cat.Decrement(buf.Labels(), entry.numNativeHistogramBuckets)
-				}
-			}
+			s.decrementCostAttribution(ref, entry, idx, &buf)
 			if entry.isDeleted() {
 				s.deleted.purge(ref)
 			}
@@ -693,11 +714,7 @@ func (s *seriesStripe) remove(ref storage.SeriesRef, idx tsdb.IndexReader) {
 	s.active--
 	if s.cat != nil {
 		buf := labels.NewScratchBuilder(128)
-		if err := idx.Series(ref, &buf, nil); err != nil {
-			s.activeSeriesAttributionFailureCounter.Add(1)
-		} else {
-			s.cat.Decrement(buf.Labels(), entry.numNativeHistogramBuckets)
-		}
+		s.decrementCostAttribution(ref, entry, idx, &buf)
 	}
 	if entry.numNativeHistogramBuckets >= 0 {
 		s.activeNativeHistograms--
@@ -745,7 +762,12 @@ type deletedSeries struct {
 
 type deletedSeriesRef struct {
 	ref storage.SeriesRef
-	key string
+	// lbls points to deletedSeries.keys[ref] under stringlabels, and to the
+	// original labels.Labels from the head otherwise. So, under stringlabels,
+	// we avoid keeping the original labels.Labels alive after it has been
+	// removed from the head; we made a clone of it in deletedSeries.keys[ref],
+	// so we take advantage of that.
+	lbls labels.Labels
 }
 
 func (ds *deletedSeries) find(lbls labels.Labels) (deletedSeriesRef, bool) {
@@ -774,7 +796,18 @@ func (ds *deletedSeries) add(ref storage.SeriesRef, lbls labels.Labels) {
 	key := string(lbls.Bytes(ds.buf))
 
 	ds.keys[ref] = key
-	ds.refs[key] = deletedSeriesRef{ref, key}
+	ds.refs[key] = deletedSeriesRef{ref: ref, lbls: deletedSeriesLbls(key, lbls)}
+}
+
+func (ds *deletedSeries) labelsOf(ref storage.SeriesRef) (labels.Labels, bool) {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+
+	key, ok := ds.keys[ref]
+	if !ok {
+		return labels.EmptyLabels(), false
+	}
+	return ds.refs[key].lbls, true
 }
 
 func (ds *deletedSeries) purge(ref storage.SeriesRef) {

--- a/pkg/ingester/activeseries/active_series_nostringlabels.go
+++ b/pkg/ingester/activeseries/active_series_nostringlabels.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build slicelabels || dedupelabels
+
+package activeseries
+
+import "github.com/prometheus/prometheus/model/labels"
+
+func deletedSeriesLbls(_ string, lbls labels.Labels) labels.Labels {
+	return lbls.Copy()
+}

--- a/pkg/ingester/activeseries/active_series_stringlabels.go
+++ b/pkg/ingester/activeseries/active_series_stringlabels.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !slicelabels && !dedupelabels
+
+package activeseries
+
+import (
+	"unsafe"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// deletedSeriesLbls transmutes key (which comes from Labels.Bytes()) as
+// labels.Labels. This is only correct under stringlabels.
+func deletedSeriesLbls(key string, _ labels.Labels) labels.Labels {
+	return *(*labels.Labels)(unsafe.Pointer(&key))
+}
+
+// Compile-time assert that sizeof(labels.Labels) == sizeof(string)
+var (
+	_ [unsafe.Sizeof(labels.Labels{}) - unsafe.Sizeof("")]byte
+	_ [unsafe.Sizeof("") - unsafe.Sizeof(labels.Labels{})]byte
+)
+
+// Startup-time assert that Labels.Bytes just returns a copy of itself.
+func init() {
+	lbls := labels.FromMap(map[string]string{"foo": "bar", "baz": "qux"})
+	lblsAsString := *(*string)(unsafe.Pointer(&lbls))
+	lblsEncoded := string(lbls.Bytes(nil))
+	if lblsAsString != lblsEncoded {
+		panic("labels.Labels.Bytes no longer encodes as its own raw string")
+	}
+}

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -576,6 +576,115 @@ func testCostAttributionUpdateSeries(t *testing.T, c *ActiveSeries, reg *prometh
 	assert.Empty(t, c.deleted.keys)
 }
 
+// newCostAttributionTrackerForTest builds a cost attribution ActiveSeriesTracker that attributes
+// cost by the "a" label for tenant "user5", registering its metrics into the given registry.
+func newCostAttributionTrackerForTest(t *testing.T, reg *prometheus.Registry) *costattribution.ActiveSeriesTracker {
+	t.Helper()
+	user := &validation.Limits{
+		MaxCostAttributionCardinality: 10,
+		CostAttributionBaseTrackers: costattributionmodel.TrackerConfigs{
+			costattributionmodel.DefaultTrackerName: {Labels: costattributionmodel.Labels{{Input: "a", Output: "a"}}},
+		},
+	}
+	user.CostAttributionBaseTrackers.Canonicalize()
+	user.ComputeCostAttributionConfigHash()
+	limits := validation.NewOverrides(validation.Limits{}, validation.NewMockTenantLimits(map[string]*validation.Limits{"user5": user}))
+	manager, err := costattribution.NewManager(5*time.Second, 10*time.Second, log.NewNopLogger(), limits, reg, reg)
+	require.NoError(t, err)
+	return manager.ActiveSeriesTracker("user5")
+}
+
+// newActiveSeriesWithCostAttribution builds an ActiveSeries that attributes cost by the "a" label,
+// returning the ActiveSeries and the registry exposing the cost attribution metrics.
+func newActiveSeriesWithCostAttribution(t *testing.T) (*ActiveSeries, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	return NewActiveSeries(&asmodel.Matchers{}, DefaultTimeout, newCostAttributionTrackerForTest(t, reg)), reg
+}
+
+func TestActiveSeries_CostAttribution_SeriesDeletedFromHeadWhileActive(t *testing.T) {
+	attributed := `
+		# HELP cortex_ingester_attributed_active_series The total number of active series per user and attribution.
+		# TYPE cortex_ingester_attributed_active_series gauge
+		cortex_ingester_attributed_active_series{a="1",tenant="user5",tracker="cost-attribution"} 1
+	`
+
+	t.Run("purge decrements using captured labels", func(t *testing.T) {
+		c, reg := newActiveSeriesWithCostAttribution(t)
+		ref1, ls1 := storage.SeriesRef(1), labels.FromStrings("a", "1")
+		idx := &mockIndex{existingLabels: map[storage.SeriesRef]labels.Labels{ref1: ls1}}
+
+		now := time.Now()
+		c.UpdateSeries(ls1, ref1, now, -1, false, idx)
+		c.Purge(now, idx)
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(attributed), "cortex_ingester_attributed_active_series"))
+
+		// Series removed from the head while still active; capture its labels, then make the ref
+		// unresolvable via the index (as if it was dropped by early head compaction).
+		c.PostDeletion(map[chunks.HeadSeriesRef]labels.Labels{chunks.HeadSeriesRef(ref1): ls1})
+		delete(idx.existingLabels, ref1)
+
+		// It becomes inactive and is purged: cost attribution is decremented from the captured
+		// labels, with no attribution failure.
+		c.Purge(now.Add(DefaultTimeout+time.Minute), idx)
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(``), "cortex_ingester_attributed_active_series"))
+		assert.Equal(t, float64(0), c.ActiveSeriesAttributionFailureCount())
+	})
+
+	t.Run("remove decrements using captured labels when the series returns with a new ref", func(t *testing.T) {
+		c, reg := newActiveSeriesWithCostAttribution(t)
+		ref1, ls1 := storage.SeriesRef(1), labels.FromStrings("a", "1")
+		ref2 := storage.SeriesRef(2) // Same labels as ref1.
+		idx := &mockIndex{existingLabels: map[storage.SeriesRef]labels.Labels{ref1: ls1}}
+
+		now := time.Now()
+		c.UpdateSeries(ls1, ref1, now, -1, false, idx)
+		c.Purge(now, idx)
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(attributed), "cortex_ingester_attributed_active_series"))
+
+		// Series removed from the head while still active, then it comes back with a new ref before
+		// becoming inactive. The old ref can no longer be resolved via the index.
+		c.PostDeletion(map[chunks.HeadSeriesRef]labels.Labels{chunks.HeadSeriesRef(ref1): ls1})
+		delete(idx.existingLabels, ref1)
+		idx.existingLabels[ref2] = ls1
+		c.UpdateSeries(ls1, ref2, now, -1, false, idx)
+
+		// The new ref is attributed and the stale one was decremented from the captured labels: net
+		// count stays 1, with no attribution failure.
+		c.Purge(now, idx)
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(attributed), "cortex_ingester_attributed_active_series"))
+		assert.Equal(t, float64(0), c.ActiveSeriesAttributionFailureCount())
+	})
+
+	t.Run("purge after reload decrements using captured labels", func(t *testing.T) {
+		c, reg := newActiveSeriesWithCostAttribution(t)
+		ref1, ls1 := storage.SeriesRef(1), labels.FromStrings("a", "1")
+		idx := &mockIndex{existingLabels: map[storage.SeriesRef]labels.Labels{ref1: ls1}}
+
+		now := time.Now()
+		c.UpdateSeries(ls1, ref1, now, -1, false, idx)
+		c.Purge(now, idx)
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(attributed), "cortex_ingester_attributed_active_series"))
+
+		// Series removed from the head while still active; its labels are captured and its ref becomes
+		// unresolvable via the index.
+		c.PostDeletion(map[chunks.HeadSeriesRef]labels.Labels{chunks.HeadSeriesRef(ref1): ls1})
+		delete(idx.existingLabels, ref1)
+
+		// Reload the cost attribution config while the series is still active-but-deleted. The reloaded
+		// tracker must re-count the series from its captured labels, with no attribution failure.
+		reg2 := prometheus.NewRegistry()
+		c.ReloadSeriesConfig(&asmodel.Matchers{}, newCostAttributionTrackerForTest(t, reg2), false, true, idx)
+		require.NoError(t, testutil.GatherAndCompare(reg2, strings.NewReader(attributed), "cortex_ingester_attributed_active_series"))
+		assert.Equal(t, float64(0), c.ActiveSeriesAttributionFailureCount())
+
+		// When the series becomes inactive it is purged from the reloaded tracker, without leaking or panicking.
+		c.Purge(now.Add(DefaultTimeout+time.Minute), idx)
+		assert.NoError(t, testutil.GatherAndCompare(reg2, strings.NewReader(``), "cortex_ingester_attributed_active_series"))
+		assert.Equal(t, float64(0), c.ActiveSeriesAttributionFailureCount())
+	})
+}
+
 func TestActiveSeries_UpdateSeries_WithMatchers(t *testing.T) {
 	asm := asmodel.NewMatchers(MustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{a=~"2|3|4"}`}))
 	c := NewActiveSeries(asm, DefaultTimeout, nil)

--- a/pkg/ingester/ingester_early_compaction_test.go
+++ b/pkg/ingester/ingester_early_compaction_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +19,8 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/user"
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/prometheus/model/labels"
@@ -27,6 +30,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/costattribution"
+	"github.com/grafana/mimir/pkg/costattribution/costattributionmodel"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	util_test "github.com/grafana/mimir/pkg/util/test"
@@ -1817,6 +1822,83 @@ func TestIngester_compactBlocksDueToNonOwnedSeries_ShouldEvictAgedRefsDespiteFre
 			"every retained pending ref must carry a fresher timestamp than the evicted batch")
 	}
 	db.pendingNonOwnedRefsMtx.Unlock()
+}
+
+// TestIngester_CostAttribution_ActiveSeriesLeaksWhenSamplesLagBehindWallClock reproduces
+// https://github.com/grafana/mimir/issues/16259: cost-attribution active series can leak when
+// early head compaction removes a series from the head while active series tracking still
+// considers it active, because it received a sample recently in wall-clock time, even though the
+// sample's timestamp is older than the idle timeout due to Kafka consumer lag.
+func TestIngester_CostAttribution_ActiveSeriesLeaksWhenSamplesLagBehindWallClock(t *testing.T) {
+	const idleTimeout = 20 * time.Minute
+
+	ctx := context.Background()
+	ctxWithUser := user.InjectOrgID(ctx, userID)
+	now := time.Now()
+
+	// The sample lags wall-clock by more than the idle timeout, but it is ingested now.
+	laggingSampleTS := now.Add(-idleTimeout - 5*time.Minute)
+
+	cfg := defaultIngesterTestConfig(t)
+	cfg.ActiveSeriesMetrics.Enabled = true
+	cfg.ActiveSeriesMetrics.IdleTimeout = idleTimeout
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = time.Hour // Only trigger compaction manually.
+	cfg.BlocksStorageConfig.TSDB.EarlyHeadCompactionMinInMemorySeries = 1
+	cfg.BlocksStorageConfig.TSDB.EarlyHeadCompactionMinEstimatedSeriesReductionPercentage = 0
+
+	// Enable cost attribution by the "team" label. PastGracePeriod defaults to 0 (disabled),
+	// so the lagging sample is accepted.
+	limits := defaultLimitsTestConfig()
+	limits.MaxCostAttributionCardinality = 100
+	limits.CostAttributionBaseTrackers = costattributionmodel.TrackerConfigs{
+		costattributionmodel.DefaultTrackerName: {Labels: costattributionmodel.Labels{{Input: "team", Output: "team"}}},
+	}
+	limits.CostAttributionBaseTrackers.Canonicalize()
+	limits.ComputeCostAttributionConfigHash()
+	overrides := validation.NewOverrides(limits, nil)
+
+	reg := prometheus.NewRegistry()
+	caReg := prometheus.NewRegistry()
+	cam, err := costattribution.NewManager(5*time.Second, 10*time.Second, log.NewNopLogger(), overrides, reg, caReg)
+	require.NoError(t, err)
+
+	ingester, r, err := prepareIngesterWithBlockStorageOverridesAndCostAttribution(t, cfg, overrides, nil, "", "", reg, cam)
+	require.NoError(t, err)
+	startAndWaitHealthy(t, ingester, r)
+
+	// Push a series whose sample is already older than the idle timeout, ingested now.
+	require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+		Labels:  labels.FromStrings(model.MetricNameLabel, "metric_1", "team", "foo"),
+		Samples: []util_test.Sample{{TS: laggingSampleTS.UnixMilli(), Val: 1}},
+	}}))
+
+	// It is active (ingested now) and attributed.
+	require.NoError(t, testutil.GatherAndCompare(caReg, strings.NewReader(`
+		# HELP cortex_ingester_attributed_active_series The total number of active series per user and attribution.
+		# TYPE cortex_ingester_attributed_active_series gauge
+		cortex_ingester_attributed_active_series{team="foo",tenant="1",tracker="cost-attribution"} 1
+	`), "cortex_ingester_attributed_active_series"))
+
+	// Trigger early head compaction now. It purges active series first (head intact), but our
+	// series is still active by wall-clock, so it is NOT decremented. Then it truncates the head
+	// at now-idleTimeout (sample-time), dropping the series (its only sample is older than that).
+	ingester.compactBlocksToReduceInMemorySeries(ctx, now)
+	require.Equal(t, uint64(0), ingester.getTSDB(userID).Head().NumSeries())
+
+	// Time passes; the series finally becomes inactive by wall-clock. The active-series update
+	// purges it. The head index can no longer resolve its ref, but the labels captured when the
+	// series was deleted from the head are used to decrement the cost-attribution tracker.
+	ingester.updateActiveSeries(now.Add(idleTimeout + time.Minute))
+
+	// Plain active is 0.
+	active, _, _, _ := ingester.getTSDB(userID).activeSeries.Active()
+	assert.Equal(t, 0, active)
+
+	// No decrement failed: the labels stored on deletion were used.
+	assert.Equal(t, float64(0), testutil.ToFloat64(ingester.metrics.attributedActiveSeriesFailuresPerUser.WithLabelValues(userID)))
+
+	// Cost-attribution active series is 0, consistent with the active series count.
+	assert.NoError(t, testutil.GatherAndCompare(caReg, strings.NewReader(``), "cortex_ingester_attributed_active_series"))
 }
 
 // pickOwnedAndNonOwnedSeries returns two single-label series with distinct secondary hashes,


### PR DESCRIPTION
#### What this PR does

Under some circumstances, a series may be deleted from the head but its ref may still be alive in active series tracking.

In such cases, when updating cost attribution tracking for those series, we look up the series labelset by ref, which fails:

``` go
if err := idx.Series(ref, &buf, nil); err != nil {
    s.activeSeriesAttributionFailureCounter.Add(1)
```

But we don't really need to do this lookup. When a series is deleted from the head index, we add a copy of its labelset to `seriesStripe.deleted.keys`:

```go
key := string(lbls.Bytes(ds.buf))
ds.keys[ref] = key
```

While `lbls.Bytes` is supposed to be an opaque encoding of `labels.Labels`, in practice, under stringlabels, it's just a copy of the labels's underlying string, and thus can be transmuted back to `labels.Labels`.

We can take advantage of this fact to store the series as a `labels.Labels` where we previously stored them as `string`, without an additional copy:

```diff
-ds.refs[key] = deletedSeriesRef{ref, key}
+// deletedSeriesLbls transmutes key from string to labels.Labels if possible.
+// So under stringlabels, this is byte-equivalent to the previous version.
+// Under !stringlabels, this makes a new copy of lbls instead.
+ds.refs[key] = deletedSeriesRef{ref: ref, lbls: deletedSeriesLbls(key, lbls)}
```

Then we can fallback to looking up a series labelset from `seriesStripe.deleted` if `idx.Series(ref, &buf, nil)` fails.

This doesn't fix the root cause of having series tracked as active while they are gone from the head, but it makes it a non-issue, at least for the purposes of cost attribution tracking.

#### Which issue(s) this PR fixes or relates to

Fixes #16259

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
