### PR TITLE
[operations]: update memcached and memcachedExporter images

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
 
 
 ## 6.2.0

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2586,7 +2586,7 @@ memcached:
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
-    tag: 1.6.39-alpine
+    tag: 1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
 
@@ -2609,7 +2609,7 @@ memcachedExporter:
 
   image:
     repository: prom/memcached-exporter
-    tag: v0.15.3
+    tag: v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
     pullPolicy: IfNotPresent
 
   resources:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.39-alpine
+          image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -75,7 +75,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.15.3
+          image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1307,7 +1307,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1322,7 +1322,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1367,7 +1367,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1382,7 +1382,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1427,7 +1427,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1442,7 +1442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1307,7 +1307,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1322,7 +1322,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1367,7 +1367,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1382,7 +1382,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1427,7 +1427,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1442,7 +1442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
@@ -1256,7 +1256,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1271,7 +1271,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1316,7 +1316,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1331,7 +1331,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1376,7 +1376,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1391,7 +1391,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1436,7 +1436,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1451,7 +1451,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-with-deletion-protection-and-custom-priority-classes-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-deletion-protection-and-custom-priority-classes-generated.yaml
@@ -1248,7 +1248,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1263,7 +1263,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1308,7 +1308,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1323,7 +1323,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1368,7 +1368,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1383,7 +1383,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1428,7 +1428,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1443,7 +1443,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1249,7 +1249,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1264,7 +1264,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1309,7 +1309,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1324,7 +1324,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1369,7 +1369,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1384,7 +1384,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1429,7 +1429,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1444,7 +1444,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
@@ -1219,7 +1219,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1234,7 +1234,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1279,7 +1279,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1294,7 +1294,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1339,7 +1339,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1354,7 +1354,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1399,7 +1399,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1414,7 +1414,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1893,7 +1893,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1908,7 +1908,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1953,7 +1953,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1968,7 +1968,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2013,7 +2013,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2028,7 +2028,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2073,7 +2073,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2088,7 +2088,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1622,7 +1622,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1637,7 +1637,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1682,7 +1682,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1697,7 +1697,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1742,7 +1742,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1757,7 +1757,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1802,7 +1802,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1817,7 +1817,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1622,7 +1622,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1637,7 +1637,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1682,7 +1682,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1697,7 +1697,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1742,7 +1742,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1757,7 +1757,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1802,7 +1802,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1817,7 +1817,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
@@ -1820,7 +1820,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1835,7 +1835,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1880,7 +1880,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1895,7 +1895,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1940,7 +1940,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1955,7 +1955,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2000,7 +2000,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2015,7 +2015,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-block-builder-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-block-builder-autoscaling-generated.yaml
@@ -1768,7 +1768,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1783,7 +1783,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1828,7 +1828,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1843,7 +1843,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1888,7 +1888,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1903,7 +1903,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1948,7 +1948,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1963,7 +1963,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-block-builder-generated.yaml
+++ b/operations/mimir-tests/test-block-builder-generated.yaml
@@ -1769,7 +1769,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1784,7 +1784,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1829,7 +1829,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1844,7 +1844,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1889,7 +1889,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1904,7 +1904,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1949,7 +1949,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1964,7 +1964,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-block-builder-ingester-shipment-disabled-generated.yaml
+++ b/operations/mimir-tests/test-block-builder-ingester-shipment-disabled-generated.yaml
@@ -1770,7 +1770,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1785,7 +1785,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1830,7 +1830,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1845,7 +1845,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1890,7 +1890,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1905,7 +1905,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1950,7 +1950,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1965,7 +1965,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -1126,7 +1126,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1141,7 +1141,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1186,7 +1186,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1201,7 +1201,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1246,7 +1246,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1261,7 +1261,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1306,7 +1306,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1321,7 +1321,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -1126,7 +1126,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1141,7 +1141,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1186,7 +1186,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1201,7 +1201,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1246,7 +1246,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1261,7 +1261,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1306,7 +1306,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1321,7 +1321,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compactor-scheduler-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-compactor-scheduler-autoscaling-generated.yaml
@@ -1113,7 +1113,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1128,7 +1128,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1173,7 +1173,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1188,7 +1188,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1233,7 +1233,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1248,7 +1248,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1293,7 +1293,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1308,7 +1308,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules-generated.yaml
+++ b/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules-generated.yaml
@@ -1113,7 +1113,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1128,7 +1128,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1173,7 +1173,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1188,7 +1188,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1233,7 +1233,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1248,7 +1248,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1293,7 +1293,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1308,7 +1308,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compactor-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-compactor-scheduler-generated.yaml
@@ -1114,7 +1114,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1129,7 +1129,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1174,7 +1174,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1189,7 +1189,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1234,7 +1234,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1249,7 +1249,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1294,7 +1294,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1309,7 +1309,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -5561,7 +5561,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5576,7 +5576,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5634,7 +5634,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5649,7 +5649,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5707,7 +5707,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5722,7 +5722,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5780,7 +5780,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5795,7 +5795,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5853,7 +5853,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5868,7 +5868,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5926,7 +5926,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5941,7 +5941,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6000,7 +6000,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6015,7 +6015,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6074,7 +6074,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6089,7 +6089,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6147,7 +6147,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6162,7 +6162,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6220,7 +6220,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6235,7 +6235,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6293,7 +6293,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6308,7 +6308,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6366,7 +6366,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6381,7 +6381,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1617,7 +1617,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1632,7 +1632,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1677,7 +1677,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1692,7 +1692,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1737,7 +1737,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1752,7 +1752,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1797,7 +1797,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1812,7 +1812,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2156,7 +2156,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2171,7 +2171,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2216,7 +2216,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2231,7 +2231,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2276,7 +2276,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2291,7 +2291,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2336,7 +2336,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2351,7 +2351,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1486,7 +1486,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1501,7 +1501,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1546,7 +1546,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1561,7 +1561,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1606,7 +1606,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1621,7 +1621,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1666,7 +1666,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1681,7 +1681,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1046,7 +1046,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1061,7 +1061,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1106,7 +1106,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1121,7 +1121,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1166,7 +1166,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1181,7 +1181,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1226,7 +1226,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1241,7 +1241,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -992,7 +992,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1007,7 +1007,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1052,7 +1052,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1067,7 +1067,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1112,7 +1112,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1127,7 +1127,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1172,7 +1172,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1187,7 +1187,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1251,7 +1251,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1266,7 +1266,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1311,7 +1311,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1326,7 +1326,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1371,7 +1371,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1386,7 +1386,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1431,7 +1431,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1446,7 +1446,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1295,7 +1295,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1310,7 +1310,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1355,7 +1355,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1370,7 +1370,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1415,7 +1415,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1430,7 +1430,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1475,7 +1475,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1490,7 +1490,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1350,7 +1350,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1365,7 +1365,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1410,7 +1410,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1425,7 +1425,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1470,7 +1470,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1485,7 +1485,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1530,7 +1530,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1545,7 +1545,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
@@ -2366,7 +2366,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2381,7 +2381,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2426,7 +2426,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2441,7 +2441,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2486,7 +2486,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2501,7 +2501,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2546,7 +2546,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2561,7 +2561,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -2463,7 +2463,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2478,7 +2478,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2523,7 +2523,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2538,7 +2538,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2583,7 +2583,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2598,7 +2598,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2643,7 +2643,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2658,7 +2658,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -2387,7 +2387,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2402,7 +2402,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2447,7 +2447,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2462,7 +2462,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2507,7 +2507,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2522,7 +2522,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2567,7 +2567,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2582,7 +2582,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -2387,7 +2387,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2402,7 +2402,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2447,7 +2447,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2462,7 +2462,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2507,7 +2507,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2522,7 +2522,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2567,7 +2567,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2582,7 +2582,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -2311,7 +2311,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2326,7 +2326,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2371,7 +2371,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2386,7 +2386,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2431,7 +2431,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2446,7 +2446,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2491,7 +2491,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2506,7 +2506,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -2825,7 +2825,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2840,7 +2840,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2885,7 +2885,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2900,7 +2900,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2945,7 +2945,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2960,7 +2960,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -3005,7 +3005,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3020,7 +3020,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -2296,7 +2296,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2311,7 +2311,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2356,7 +2356,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2371,7 +2371,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2416,7 +2416,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2431,7 +2431,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2476,7 +2476,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2491,7 +2491,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -2300,7 +2300,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2315,7 +2315,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2360,7 +2360,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2375,7 +2375,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2420,7 +2420,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2435,7 +2435,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2480,7 +2480,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2495,7 +2495,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
@@ -2298,7 +2298,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2313,7 +2313,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2358,7 +2358,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2373,7 +2373,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2418,7 +2418,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2433,7 +2433,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2478,7 +2478,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2493,7 +2493,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -2840,7 +2840,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2855,7 +2855,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2900,7 +2900,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2915,7 +2915,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2960,7 +2960,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2975,7 +2975,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -3020,7 +3020,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3035,7 +3035,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -2862,7 +2862,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2877,7 +2877,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2922,7 +2922,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2937,7 +2937,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2982,7 +2982,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2997,7 +2997,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -3042,7 +3042,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3057,7 +3057,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -2860,7 +2860,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2875,7 +2875,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2920,7 +2920,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2935,7 +2935,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2980,7 +2980,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2995,7 +2995,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -3040,7 +3040,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3055,7 +3055,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -2860,7 +2860,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2875,7 +2875,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2920,7 +2920,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2935,7 +2935,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2980,7 +2980,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2995,7 +2995,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -3040,7 +3040,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3055,7 +3055,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -2860,7 +2860,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2875,7 +2875,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2920,7 +2920,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2935,7 +2935,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2980,7 +2980,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2995,7 +2995,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -3040,7 +3040,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3055,7 +3055,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -2389,7 +2389,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2404,7 +2404,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2449,7 +2449,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2464,7 +2464,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2509,7 +2509,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2524,7 +2524,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2569,7 +2569,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2584,7 +2584,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -2412,7 +2412,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2427,7 +2427,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2472,7 +2472,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2487,7 +2487,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2532,7 +2532,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2547,7 +2547,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2592,7 +2592,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2607,7 +2607,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -2412,7 +2412,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2427,7 +2427,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2472,7 +2472,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2487,7 +2487,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2532,7 +2532,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2547,7 +2547,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2592,7 +2592,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2607,7 +2607,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -2237,7 +2237,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2252,7 +2252,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2297,7 +2297,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2312,7 +2312,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2357,7 +2357,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2372,7 +2372,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2417,7 +2417,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2432,7 +2432,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -2463,7 +2463,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2478,7 +2478,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2523,7 +2523,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2538,7 +2538,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2583,7 +2583,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2598,7 +2598,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2643,7 +2643,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2658,7 +2658,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1307,7 +1307,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1322,7 +1322,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1367,7 +1367,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1382,7 +1382,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1427,7 +1427,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1442,7 +1442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1253,7 +1253,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1268,7 +1268,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1313,7 +1313,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1328,7 +1328,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1373,7 +1373,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1388,7 +1388,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1433,7 +1433,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1448,7 +1448,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1259,7 +1259,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1274,7 +1274,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1319,7 +1319,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1334,7 +1334,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1379,7 +1379,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1394,7 +1394,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1439,7 +1439,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1454,7 +1454,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1253,7 +1253,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1268,7 +1268,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1313,7 +1313,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1328,7 +1328,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1373,7 +1373,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1388,7 +1388,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1433,7 +1433,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1448,7 +1448,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1617,7 +1617,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1632,7 +1632,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1677,7 +1677,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1692,7 +1692,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1737,7 +1737,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1752,7 +1752,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1797,7 +1797,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1812,7 +1812,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1703,7 +1703,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1718,7 +1718,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1763,7 +1763,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1778,7 +1778,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1823,7 +1823,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1838,7 +1838,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1883,7 +1883,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1898,7 +1898,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1703,7 +1703,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1718,7 +1718,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1763,7 +1763,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1778,7 +1778,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1823,7 +1823,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1838,7 +1838,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1883,7 +1883,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1898,7 +1898,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1703,7 +1703,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1718,7 +1718,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1763,7 +1763,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1778,7 +1778,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1823,7 +1823,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1838,7 +1838,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1883,7 +1883,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1898,7 +1898,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1703,7 +1703,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1718,7 +1718,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1763,7 +1763,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1778,7 +1778,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1823,7 +1823,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1838,7 +1838,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1883,7 +1883,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1898,7 +1898,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1250,7 +1250,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1265,7 +1265,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1310,7 +1310,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1325,7 +1325,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1370,7 +1370,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1385,7 +1385,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1430,7 +1430,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1445,7 +1445,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1307,7 +1307,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1322,7 +1322,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1367,7 +1367,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1382,7 +1382,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1427,7 +1427,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1442,7 +1442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -3939,7 +3939,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3954,7 +3954,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4012,7 +4012,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4027,7 +4027,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4085,7 +4085,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4100,7 +4100,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4158,7 +4158,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4173,7 +4173,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4232,7 +4232,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4247,7 +4247,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4306,7 +4306,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4321,7 +4321,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4379,7 +4379,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4394,7 +4394,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4452,7 +4452,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4467,7 +4467,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -2849,7 +2849,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2864,7 +2864,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2909,7 +2909,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2924,7 +2924,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2969,7 +2969,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2984,7 +2984,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -3029,7 +3029,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -3044,7 +3044,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -4917,7 +4917,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4932,7 +4932,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4977,7 +4977,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4992,7 +4992,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5045,7 +5045,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5060,7 +5060,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5118,7 +5118,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5133,7 +5133,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5183,7 +5183,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5198,7 +5198,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5251,7 +5251,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5266,7 +5266,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5324,7 +5324,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5339,7 +5339,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5389,7 +5389,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5404,7 +5404,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5458,7 +5458,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5473,7 +5473,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5532,7 +5532,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5547,7 +5547,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5605,7 +5605,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5620,7 +5620,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5678,7 +5678,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5693,7 +5693,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -4969,7 +4969,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4984,7 +4984,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5029,7 +5029,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5044,7 +5044,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5097,7 +5097,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5112,7 +5112,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5170,7 +5170,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5185,7 +5185,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5235,7 +5235,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5250,7 +5250,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5303,7 +5303,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5318,7 +5318,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5376,7 +5376,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5391,7 +5391,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5441,7 +5441,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5456,7 +5456,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5510,7 +5510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5525,7 +5525,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5584,7 +5584,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5599,7 +5599,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5657,7 +5657,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5672,7 +5672,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5730,7 +5730,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5745,7 +5745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -4969,7 +4969,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4984,7 +4984,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5029,7 +5029,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5044,7 +5044,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5097,7 +5097,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5112,7 +5112,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5170,7 +5170,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5185,7 +5185,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5235,7 +5235,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5250,7 +5250,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5303,7 +5303,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5318,7 +5318,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5376,7 +5376,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5391,7 +5391,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5441,7 +5441,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5456,7 +5456,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5510,7 +5510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5525,7 +5525,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5584,7 +5584,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5599,7 +5599,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5657,7 +5657,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5672,7 +5672,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5730,7 +5730,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5745,7 +5745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -4969,7 +4969,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4984,7 +4984,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5029,7 +5029,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5044,7 +5044,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5097,7 +5097,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5112,7 +5112,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5170,7 +5170,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5185,7 +5185,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5235,7 +5235,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5250,7 +5250,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5303,7 +5303,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5318,7 +5318,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5376,7 +5376,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5391,7 +5391,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5441,7 +5441,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5456,7 +5456,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5510,7 +5510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5525,7 +5525,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5584,7 +5584,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5599,7 +5599,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5657,7 +5657,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5672,7 +5672,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5730,7 +5730,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5745,7 +5745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -4969,7 +4969,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4984,7 +4984,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5029,7 +5029,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5044,7 +5044,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5097,7 +5097,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5112,7 +5112,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5170,7 +5170,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5185,7 +5185,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5235,7 +5235,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5250,7 +5250,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5303,7 +5303,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5318,7 +5318,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5376,7 +5376,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5391,7 +5391,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5441,7 +5441,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5456,7 +5456,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5510,7 +5510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5525,7 +5525,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5584,7 +5584,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5599,7 +5599,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5657,7 +5657,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5672,7 +5672,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5730,7 +5730,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5745,7 +5745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -4969,7 +4969,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4984,7 +4984,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5029,7 +5029,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5044,7 +5044,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5097,7 +5097,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5112,7 +5112,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5170,7 +5170,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5185,7 +5185,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5235,7 +5235,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5250,7 +5250,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5303,7 +5303,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5318,7 +5318,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5376,7 +5376,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5391,7 +5391,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5441,7 +5441,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5456,7 +5456,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5510,7 +5510,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5525,7 +5525,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5584,7 +5584,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5599,7 +5599,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5657,7 +5657,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5672,7 +5672,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5730,7 +5730,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5745,7 +5745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -4946,7 +4946,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4961,7 +4961,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5006,7 +5006,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5021,7 +5021,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5074,7 +5074,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5089,7 +5089,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5147,7 +5147,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5162,7 +5162,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5212,7 +5212,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5227,7 +5227,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5280,7 +5280,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5295,7 +5295,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5353,7 +5353,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5368,7 +5368,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5418,7 +5418,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5433,7 +5433,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5487,7 +5487,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5502,7 +5502,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5561,7 +5561,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5576,7 +5576,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5634,7 +5634,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5649,7 +5649,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5707,7 +5707,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5722,7 +5722,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -4946,7 +4946,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4961,7 +4961,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5006,7 +5006,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5021,7 +5021,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5074,7 +5074,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5089,7 +5089,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5147,7 +5147,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5162,7 +5162,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5212,7 +5212,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5227,7 +5227,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5280,7 +5280,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5295,7 +5295,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5353,7 +5353,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5368,7 +5368,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5418,7 +5418,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5433,7 +5433,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5487,7 +5487,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5502,7 +5502,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5561,7 +5561,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5576,7 +5576,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5634,7 +5634,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5649,7 +5649,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5707,7 +5707,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5722,7 +5722,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -4959,7 +4959,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4974,7 +4974,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5019,7 +5019,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5034,7 +5034,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5087,7 +5087,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5102,7 +5102,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5160,7 +5160,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5175,7 +5175,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5225,7 +5225,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5240,7 +5240,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5293,7 +5293,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5308,7 +5308,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5366,7 +5366,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5381,7 +5381,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5431,7 +5431,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5446,7 +5446,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5500,7 +5500,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5515,7 +5515,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5574,7 +5574,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5589,7 +5589,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5647,7 +5647,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5662,7 +5662,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5720,7 +5720,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5735,7 +5735,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -4959,7 +4959,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4974,7 +4974,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5019,7 +5019,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5034,7 +5034,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5087,7 +5087,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5102,7 +5102,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5160,7 +5160,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5175,7 +5175,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5225,7 +5225,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5240,7 +5240,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5293,7 +5293,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5308,7 +5308,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5366,7 +5366,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5381,7 +5381,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5431,7 +5431,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5446,7 +5446,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5500,7 +5500,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5515,7 +5515,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5574,7 +5574,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5589,7 +5589,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5647,7 +5647,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5662,7 +5662,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5720,7 +5720,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5735,7 +5735,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -5275,7 +5275,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5290,7 +5290,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5335,7 +5335,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5350,7 +5350,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5403,7 +5403,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5418,7 +5418,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5476,7 +5476,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5491,7 +5491,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5541,7 +5541,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5556,7 +5556,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5609,7 +5609,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5624,7 +5624,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5682,7 +5682,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5697,7 +5697,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5747,7 +5747,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5762,7 +5762,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5816,7 +5816,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5831,7 +5831,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5890,7 +5890,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5905,7 +5905,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5963,7 +5963,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5978,7 +5978,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6036,7 +6036,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6051,7 +6051,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -5275,7 +5275,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5290,7 +5290,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5335,7 +5335,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5350,7 +5350,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5403,7 +5403,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5418,7 +5418,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5476,7 +5476,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5491,7 +5491,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5541,7 +5541,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5556,7 +5556,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5609,7 +5609,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5624,7 +5624,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5682,7 +5682,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5697,7 +5697,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5747,7 +5747,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5762,7 +5762,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5816,7 +5816,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5831,7 +5831,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5890,7 +5890,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5905,7 +5905,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5963,7 +5963,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5978,7 +5978,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -6036,7 +6036,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -6051,7 +6051,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -5131,7 +5131,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5146,7 +5146,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5191,7 +5191,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5206,7 +5206,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5259,7 +5259,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5274,7 +5274,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5332,7 +5332,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5347,7 +5347,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5397,7 +5397,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5412,7 +5412,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5465,7 +5465,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5480,7 +5480,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5538,7 +5538,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5553,7 +5553,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5603,7 +5603,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5618,7 +5618,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5672,7 +5672,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5687,7 +5687,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5746,7 +5746,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5761,7 +5761,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5819,7 +5819,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5834,7 +5834,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -5892,7 +5892,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -5907,7 +5907,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -4159,7 +4159,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4174,7 +4174,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4232,7 +4232,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4247,7 +4247,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4305,7 +4305,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4320,7 +4320,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4378,7 +4378,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4393,7 +4393,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4452,7 +4452,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4467,7 +4467,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4526,7 +4526,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4541,7 +4541,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4599,7 +4599,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4614,7 +4614,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4672,7 +4672,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4687,7 +4687,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -4159,7 +4159,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4174,7 +4174,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4232,7 +4232,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4247,7 +4247,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4305,7 +4305,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4320,7 +4320,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4378,7 +4378,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4393,7 +4393,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4452,7 +4452,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4467,7 +4467,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4526,7 +4526,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4541,7 +4541,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4599,7 +4599,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4614,7 +4614,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4672,7 +4672,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4687,7 +4687,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-generated.yaml
@@ -2053,7 +2053,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2068,7 +2068,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2113,7 +2113,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2128,7 +2128,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2173,7 +2173,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2188,7 +2188,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2233,7 +2233,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2248,7 +2248,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
@@ -2183,7 +2183,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2198,7 +2198,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2243,7 +2243,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2258,7 +2258,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2303,7 +2303,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2318,7 +2318,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2363,7 +2363,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2378,7 +2378,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1896,7 +1896,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1911,7 +1911,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1956,7 +1956,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1971,7 +1971,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2016,7 +2016,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2031,7 +2031,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2076,7 +2076,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2091,7 +2091,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -2063,7 +2063,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2078,7 +2078,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2123,7 +2123,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2138,7 +2138,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2183,7 +2183,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2198,7 +2198,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2243,7 +2243,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2258,7 +2258,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1896,7 +1896,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1911,7 +1911,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1956,7 +1956,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1971,7 +1971,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2016,7 +2016,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2031,7 +2031,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2076,7 +2076,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2091,7 +2091,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -992,7 +992,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1007,7 +1007,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1052,7 +1052,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1067,7 +1067,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1112,7 +1112,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1127,7 +1127,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1172,7 +1172,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1187,7 +1187,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -1086,7 +1086,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1101,7 +1101,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1148,7 +1148,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1163,7 +1163,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1210,7 +1210,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1225,7 +1225,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1272,7 +1272,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1287,7 +1287,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1635,7 +1635,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1650,7 +1650,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1695,7 +1695,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1710,7 +1710,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1755,7 +1755,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1770,7 +1770,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1815,7 +1815,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1830,7 +1830,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1627,7 +1627,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1642,7 +1642,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1687,7 +1687,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1702,7 +1702,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1747,7 +1747,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1762,7 +1762,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1807,7 +1807,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1822,7 +1822,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1694,7 +1694,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1709,7 +1709,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1754,7 +1754,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1769,7 +1769,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1814,7 +1814,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1829,7 +1829,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1874,7 +1874,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1889,7 +1889,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1278,7 +1278,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1293,7 +1293,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1338,7 +1338,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1353,7 +1353,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1398,7 +1398,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1413,7 +1413,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1458,7 +1458,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1473,7 +1473,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1266,7 +1266,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1281,7 +1281,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1326,7 +1326,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1341,7 +1341,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1386,7 +1386,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1401,7 +1401,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1446,7 +1446,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1461,7 +1461,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1307,7 +1307,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1322,7 +1322,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1367,7 +1367,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1382,7 +1382,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1427,7 +1427,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1442,7 +1442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-range-vector-splitting-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-generated.yaml
@@ -1289,7 +1289,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1304,7 +1304,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1349,7 +1349,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1364,7 +1364,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1409,7 +1409,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1424,7 +1424,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1469,7 +1469,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1484,7 +1484,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1529,7 +1529,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1544,7 +1544,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -4043,7 +4043,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4058,7 +4058,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4116,7 +4116,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4131,7 +4131,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4189,7 +4189,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4204,7 +4204,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4262,7 +4262,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4277,7 +4277,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4336,7 +4336,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4351,7 +4351,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4410,7 +4410,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4425,7 +4425,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4483,7 +4483,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4498,7 +4498,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4556,7 +4556,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4571,7 +4571,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4629,7 +4629,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4644,7 +4644,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -4702,7 +4702,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -4717,7 +4717,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-range-vector-splitting-regular-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-regular-path-disabled-generated.yaml
@@ -1675,7 +1675,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1690,7 +1690,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1735,7 +1735,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1750,7 +1750,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1795,7 +1795,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1810,7 +1810,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1855,7 +1855,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1870,7 +1870,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1915,7 +1915,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1930,7 +1930,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-range-vector-splitting-ruler-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-ruler-path-disabled-generated.yaml
@@ -1675,7 +1675,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1690,7 +1690,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1735,7 +1735,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1750,7 +1750,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1795,7 +1795,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1810,7 +1810,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1855,7 +1855,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1870,7 +1870,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1915,7 +1915,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1930,7 +1930,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1633,7 +1633,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1648,7 +1648,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1693,7 +1693,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1708,7 +1708,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1753,7 +1753,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1768,7 +1768,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1813,7 +1813,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1828,7 +1828,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1631,7 +1631,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1646,7 +1646,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1691,7 +1691,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1706,7 +1706,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1751,7 +1751,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1766,7 +1766,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1811,7 +1811,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1826,7 +1826,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1347,7 +1347,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1362,7 +1362,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1407,7 +1407,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1422,7 +1422,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1467,7 +1467,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1482,7 +1482,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1527,7 +1527,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1542,7 +1542,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
@@ -1351,7 +1351,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1366,7 +1366,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1411,7 +1411,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1426,7 +1426,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1471,7 +1471,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1486,7 +1486,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1531,7 +1531,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1546,7 +1546,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1348,7 +1348,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1363,7 +1363,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1408,7 +1408,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1423,7 +1423,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1468,7 +1468,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1483,7 +1483,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1528,7 +1528,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1543,7 +1543,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-store-gateway-shard-size-per-zone-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-store-gateway-shard-size-per-zone-generated.yaml
@@ -1350,7 +1350,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1365,7 +1365,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1410,7 +1410,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1425,7 +1425,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1470,7 +1470,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1485,7 +1485,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1530,7 +1530,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1545,7 +1545,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1257,7 +1257,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1272,7 +1272,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1317,7 +1317,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1332,7 +1332,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1377,7 +1377,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1392,7 +1392,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1437,7 +1437,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1452,7 +1452,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1307,7 +1307,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1322,7 +1322,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1367,7 +1367,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1382,7 +1382,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1427,7 +1427,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1442,7 +1442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1252,7 +1252,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1267,7 +1267,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1312,7 +1312,7 @@ spec:
         - -I 25m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1327,7 +1327,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1372,7 +1372,7 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1387,7 +1387,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1432,7 +1432,7 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        image: memcached:1.6.34-alpine
+        image: memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1447,7 +1447,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
+        image: prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -1,8 +1,8 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.6.34-alpine',
-    memcachedExporter: 'prom/memcached-exporter:v0.15.3',
+    memcached: 'memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909',
+    memcachedExporter: 'prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728',
 
     // Our services.
     mimir: 'grafana/mimir:3.1.4',


### PR DESCRIPTION
#### What this PR does
This PR upgrade `memcached` and `memcachedExporter` images to `memcached:1.6.42-alpine@sha256:43a2e7f74aebfff0c9921f4d367299ced9eacaeaccdc8bb4bc122a4fba2cd909` and `prom/memcached-exporter:v0.16.0@sha256:fa03aba2f2aa6f572bf56ba07dd2960c62433805427be0fddc8b21b8074c1728` respectively.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
