### PR TITLE
Vendor mimir-prometheus head chunk access optimization (2.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [ENHANCEMENT] Ingester: Optimize TSDB head chunk access during compaction to avoid O(n²) linked-list walks. #16373
 * [BUGFIX] Update to Go v1.26.3 to address high-severity CVEs [CVE-2026-42501](https://pkg.go.dev/vuln/GO-2026-4984), [CVE-2026-39836](https://pkg.go.dev/vuln/GO-2026-4971), [CVE-2026-33811](https://pkg.go.dev/vuln/GO-2026-4981), [CVE-2026-33814](https://pkg.go.dev/vuln/GO-2026-4918), [CVE-2026-42499](https://pkg.go.dev/vuln/GO-2026-4977), [CVE-2026-39820](https://pkg.go.dev/vuln/GO-2026-4986) and other lower-severity CVEs. #15401
 * [BUGFIX] Ingester: Fix out-of-order queries blocking TSDB head truncation/compaction. #16366
 

--- a/go.mod
+++ b/go.mod
@@ -345,7 +345,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260812165702-847d1e06c085
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,8 @@ github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700 h1:0t7iOQ5ZkB
 github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700/go.mod h1:Ri9p/tRShbjYnpNf4FFPXG7wxEGY4Nrcn6E7jrVa//4=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250703083430-c31a9568ad96 h1:kq5zJVW9LyFOB5xCeQPTON2HNjwwEkefhegZXGIhQPk=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250703083430-c31a9568ad96/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260812165702-847d1e06c085 h1:fgBw2EqRnKn5MQPYdVFxcwqD7UMmbHJYbr+g/oWqzTE=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260812165702-847d1e06c085/go.mod h1:51sCkEHDpexFCGizYi1W4omiFaKThWThkquNPOxhwxQ=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8 h1:dFCkiw+kLZeXmHrfF60Di/TwH4YekGoI+OknHnXaQ2A=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8/go.mod h1:51sCkEHDpexFCGizYi1W4omiFaKThWThkquNPOxhwxQ=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/vendor/github.com/prometheus/prometheus/tsdb/compact.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/compact.go
@@ -1087,6 +1087,9 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 		}
 		closers = append(closers, chunkr)
 
+		// Enable the head-chunk cache for compaction.
+		enableChunkCache(chunkr)
+
 		tombsr, err := b.Tombstones()
 		if err != nil {
 			return fmt.Errorf("open tombstone reader for block %+v: %w", b.Meta(), err)

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -22,8 +22,10 @@ import (
 	"math"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"sync"
+	stdatomic "sync/atomic" //nolint:depguard
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -992,7 +994,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			// The head chunk was completed and was m-mapped after taking the snapshot.
 			// Hence remove this chunk.
 			ms.nextAt = 0
-			ms.headChunks = nil
+			ms.setHeadChunks(nil, 0)
 			ms.app = nil
 		}
 		return nil
@@ -1820,26 +1822,25 @@ func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labe
 	return s, true, nil
 }
 
-// mmapHeadChunks will iterate all memSeries stored on Head and call mmapHeadChunks() on each of them.
+// mmapHeadChunks iterates all memSeries stored on Head ready for m-mapping and calls
+// mmapChunks() on each of them.
 //
 // There are two types of chunks that store samples for each memSeries:
 // A) Head chunk - stored on Go heap, when new samples are appended they go there.
 // B) M-mapped chunks - memory mapped chunks, kernel manages the memory for us on-demand, these chunks
+// are read-only.
 //
-//	are read-only.
-//
-// Calling mmapHeadChunks() will iterate all memSeries and m-mmap all chunks that should be m-mapped.
-// The m-mapping operation is needs to be serialised and so it goes via central lock.
-// If there are multiple concurrent memSeries that need to m-map some chunk then they can block each-other.
-//
-// To minimise the effect of locking on TSDB operations m-mapping is serialised and done away from
-// sample append path, since waiting on a lock inside an append would lock the entire memSeries for
-// (potentially) a long time, since that could eventually delay next scrape and/or cause query timeouts.
+// M-mapping is serialised via the per-series lock and done away from the sample append path,
+// since holding the lock during an append could delay the next scrape or cause query timeouts.
 func (h *Head) mmapHeadChunks() {
 	var count int
-	for i := 0; i < h.series.size; i++ {
+	for i := range h.series.size {
 		h.series.locks[i].RLock()
 		for _, series := range h.series.series[i] {
+			if series.headChunkCount.Load() < 2 { // < 2 means 0 or 1 head chunks, nothing to mmap.
+				continue
+			}
+
 			series.Lock()
 			count += series.mmapChunks(h.chunkDiskMapper)
 			series.Unlock()
@@ -2206,8 +2207,9 @@ type memSeries struct {
 	// pN is the pointer to the mmappedChunk referred to by HeadChunkID=N
 	mmappedChunks []*mmappedChunk
 	// Most recent chunks in memory that are still being built or waiting to be mmapped.
-	// This is a linked list, headChunks points to the most recent chunk, headChunks.next points
+	// This is a linked list, headChunks points to the most recent chunk, headChunks.prev points
 	// to older chunk and so on.
+	// Please note the headChunkCount field tracking the number of headChunks.
 	headChunks   *memChunk
 	firstChunkID chunks.HeadChunkID // HeadChunkID for mmappedChunks[0]
 
@@ -2222,6 +2224,12 @@ type memSeries struct {
 	nextAt                           int64 // Timestamp at which to cut the next chunk.
 	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
 	pendingCommit                    bool  // Whether there are samples waiting to be committed to this series.
+	// headChunkCount tracks the number of head chunks. All mutations of the
+	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks.
+	// Chunk counts are bounded by the 3-byte field in HeadChunkRef, so cannot overflow uint32.
+	// Explicitly uses sync/atomic.Uint32 (4 bytes) to fit in the existing padding
+	// between two bools and a float64.
+	headChunkCount stdatomic.Uint32
 
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
 	lastValue float64
@@ -2284,13 +2292,33 @@ func (s *memSeries) maxTime() int64 {
 	return math.MinInt64
 }
 
+// pushHeadChunk prepends chk to the head-chunk list, keeping headChunkCount in
+// sync with the list length. The invariant is that headChunkCount equals the
+// list length whenever the series lock is released; direct prev unlinks
+// (mmapChunks, truncateChunksBefore) must be immediately paired with a
+// setHeadChunks call.
+func (s *memSeries) pushHeadChunk(chk *memChunk) *memChunk {
+	chk.prev = s.headChunks
+	s.headChunks = chk
+	s.headChunkCount.Add(1)
+	return chk
+}
+
+// setHeadChunks replaces the head-chunk list with head, which must be a list
+// of count chunks, keeping headChunkCount in sync with the list length. See
+// pushHeadChunk for the invariant.
+func (s *memSeries) setHeadChunks(head *memChunk, count uint32) {
+	s.headChunks = head
+	s.headChunkCount.Store(count)
+}
+
 // truncateChunksBefore removes all chunks from the series that
 // have no timestamp at or after mint.
 // Chunk IDs remain unchanged.
 func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) int {
 	var removedInOrder int
 	if s.headChunks != nil {
-		var i int
+		var i uint32
 		var nextChk *memChunk
 		chk := s.headChunks
 		for chk != nil {
@@ -2300,10 +2328,11 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
-					s.headChunks = nil
+					s.setHeadChunks(nil, 0)
 				} else {
 					// This is NOT the first chunk, unlink it from parent.
 					nextChk.prev = nil
+					s.setHeadChunks(s.headChunks, i)
 				}
 				s.mmappedChunks = nil
 				break
@@ -2371,6 +2400,26 @@ func (mc *memChunk) len() (count int) {
 	return count
 }
 
+// collectHeadChunks walks the headChunks linked list once and returns a slice
+// in oldest-first order (matching mmappedChunks ordering).
+// For example, given head{t4} -> t3 -> t2 -> t1 -> t0, it returns [t0, t1, t2, t3, t4].
+// buf must have length 0 but may have non-zero capacity for reuse; the
+// returned slice's tail beyond its length is zeroed, so a reused, shrinking
+// buffer does not pin chunks from a previous, longer collection.
+func collectHeadChunks(head *memChunk, buf []*memChunk) []*memChunk {
+	// Single walk: append newest-to-oldest (following prev pointers), then
+	// reverse to oldest-to-newest. Pointer-chasing the linked list is the
+	// expensive part; slices.Reverse on a contiguous array is essentially
+	// free by comparison.
+	hc := buf
+	for elem := head; elem != nil; elem = elem.prev {
+		hc = append(hc, elem)
+	}
+	slices.Reverse(hc)
+	clear(hc[len(hc):cap(hc)])
+	return hc
+}
+
 // oldest returns the oldest element on the list.
 // For single element list this will be the same memChunk oldest() was called on.
 func (mc *memChunk) oldest() (elem *memChunk) {
@@ -2380,30 +2429,6 @@ func (mc *memChunk) oldest() (elem *memChunk) {
 	elem = mc
 	for elem.prev != nil {
 		elem = elem.prev
-	}
-	return elem
-}
-
-// atOffset returns a memChunk that's Nth element on the linked list.
-func (mc *memChunk) atOffset(offset int) (elem *memChunk) {
-	if offset == 0 {
-		return mc
-	}
-	if offset == 1 {
-		return mc.prev
-	}
-	if offset < 0 {
-		return nil
-	}
-
-	var i int
-	elem = mc
-	for i < offset {
-		i++
-		elem = elem.prev
-		if elem == nil {
-			break
-		}
 	}
 	return elem
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
@@ -1636,12 +1636,11 @@ func (s *memSeries) appendHistogram(t int64, h *histogram.Histogram, appendID ui
 		return true, false
 	}
 
-	s.headChunks = &memChunk{
+	s.pushHeadChunk(&memChunk{
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
-		prev:    s.headChunks,
-	}
+	})
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -1693,12 +1692,11 @@ func (s *memSeries) appendFloatHistogram(t int64, fh *histogram.FloatHistogram, 
 		return true, false
 	}
 
-	s.headChunks = &memChunk{
+	s.pushHeadChunk(&memChunk{
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
-		prev:    s.headChunks,
-	}
+	})
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -1894,32 +1892,31 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible
 	// so this is a single element list most of the time.
-	s.headChunks = &memChunk{
+	chk := s.pushHeadChunk(&memChunk{
 		minTime: mint,
 		maxTime: math.MinInt64,
-		prev:    s.headChunks,
-	}
+	})
 
 	if chunkenc.IsValidEncoding(e) {
 		var err error
-		s.headChunks.chunk, err = chunkenc.NewEmptyChunk(e)
+		chk.chunk, err = chunkenc.NewEmptyChunk(e)
 		if err != nil {
 			panic(err) // This should never happen.
 		}
 	} else {
-		s.headChunks.chunk = chunkenc.NewXORChunk()
+		chk.chunk = chunkenc.NewXORChunk()
 	}
 
 	// Set upper bound on when the next chunk must be started. An earlier timestamp
 	// may be chosen dynamically at a later point.
 	s.nextAt = rangeForTimestamp(mint, chunkRange)
 
-	app, err := s.headChunks.chunk.Appender()
+	app, err := chk.chunk.Appender()
 	if err != nil {
 		panic(err)
 	}
 	s.app = app
-	return s.headChunks
+	return chk
 }
 
 // cutNewOOOHeadChunk cuts a new OOO chunk and m-maps the old chunk.
@@ -1966,18 +1963,16 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(chunkDiskMapper *chunks.ChunkDiskMap
 	return chunkRefs
 }
 
-// mmapChunks will m-map all but first chunk on s.headChunks list.
+// mmapChunks will m-map all but first chunk on s.headChunks list and update headChunkCount.
 func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int) {
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		// There is none or only one head chunk, so nothing to m-map here.
-		return
+		return count
 	}
 
-	// Write chunks starting from the oldest one and stop before we get to current s.headChunks.
-	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
-	// then we need to write chunks t0 to t3, but skip s.headChunks.
-	for i := s.headChunks.len() - 1; i > 0; i-- {
-		chk := s.headChunks.atOffset(i)
+	// Collect head chunks in oldest-first order, then write all except the newest.
+	hc := collectHeadChunks(s.headChunks, make([]*memChunk, 0, s.headChunkCount.Load()))
+	for _, chk := range hc[:len(hc)-1] {
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
 			ref:        chunkRef,
@@ -1988,8 +1983,9 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 		count++
 	}
 
-	// Once we've written out all chunks except s.headChunks we need to unlink these from s.headChunk.
+	// Remove the tail of the list, leaving only the most recent head chunk.
 	s.headChunks.prev = nil
+	s.setHeadChunks(s.headChunks, 1)
 
 	return count
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
@@ -28,6 +28,11 @@ import (
 	"github.com/prometheus/prometheus/tsdb/index"
 )
 
+// headChunksBufMaxCap is the maximum capacity retained for reusable []*memChunk
+// buffers. If a buffer grows beyond this, it is released to avoid holding
+// oversized backing arrays across series iterations.
+const headChunksBufMaxCap = 256
+
 func (h *Head) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
 	return h.exemplars.ExemplarQuerier(ctx)
 }
@@ -44,9 +49,14 @@ func (h *Head) indexRange(mint, maxt int64) *headIndexReader {
 	return &headIndexReader{head: h, mint: mint, maxt: maxt}
 }
 
+// headIndexReader provides index reading for the head block.
+// Not safe for concurrent use from multiple goroutines.
 type headIndexReader struct {
 	head       *Head
 	mint, maxt int64
+	// Reusable buffer for collectHeadChunks inside appendSeriesChunks,
+	// avoiding a per-series allocation during iteration.
+	headChunksBuf []*memChunk
 }
 
 func (h *headIndexReader) Close() error {
@@ -211,12 +221,18 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 	defer s.Unlock()
 
 	*chks = (*chks)[:0]
-	*chks = appendSeriesChunks(s, h.mint, h.maxt, *chks)
+	*chks, h.headChunksBuf = appendSeriesChunks(s, h.mint, h.maxt, *chks, h.headChunksBuf)
+	if cap(h.headChunksBuf) > headChunksBufMaxCap {
+		h.headChunksBuf = nil
+	}
 
 	return nil
 }
 
-func appendSeriesChunks(s *memSeries, mint, maxt int64, chks []chunks.Meta) []chunks.Meta {
+// appendSeriesChunks appends chunk metadata for s to chks.
+// headChunksBuf is a reusable buffer for collectHeadChunks; the (possibly grown) buffer is returned
+// so callers can pass it back on the next call to avoid per-series allocations.
+func appendSeriesChunks(s *memSeries, mint, maxt int64, chks []chunks.Meta, headChunksBuf []*memChunk) ([]chunks.Meta, []*memChunk) {
 	for i, c := range s.mmappedChunks {
 		// Do not expose chunks that are outside of the specified range.
 		if !c.OverlapsClosedInterval(mint, maxt) {
@@ -229,28 +245,38 @@ func appendSeriesChunks(s *memSeries, mint, maxt int64, chks []chunks.Meta) []ch
 		})
 	}
 
-	if s.headChunks != nil {
-		var maxTime int64
-		var i, j int
-		for i = s.headChunks.len() - 1; i >= 0; i-- {
-			chk := s.headChunks.atOffset(i)
-			if i == 0 {
-				// Set the head chunk as open (being appended to) for the first headChunk.
-				maxTime = math.MaxInt64
-			} else {
-				maxTime = chk.maxTime
-			}
-			if chk.OverlapsClosedInterval(mint, maxt) {
-				chks = append(chks, chunks.Meta{
-					MinTime: chk.minTime,
-					MaxTime: maxTime,
-					Ref:     chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.headChunkID(len(s.mmappedChunks)+j))),
-				})
-			}
-			j++
+	if s.headChunks == nil {
+		return chks, headChunksBuf
+	}
+
+	// Fast path: single head chunk — no allocation, no linked-list walk.
+	if s.headChunks.prev == nil {
+		if s.headChunks.OverlapsClosedInterval(mint, maxt) {
+			chks = append(chks, chunks.Meta{
+				MinTime: s.headChunks.minTime,
+				MaxTime: math.MaxInt64,
+				Ref:     chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.headChunkID(len(s.mmappedChunks)))),
+			})
+		}
+		return chks, headChunksBuf
+	}
+
+	// Multiple head chunks: collect once O(N), iterate O(N).
+	headChunksBuf = collectHeadChunks(s.headChunks, headChunksBuf[:0])
+	for i, chk := range headChunksBuf {
+		maxTime := chk.maxTime
+		if i == len(headChunksBuf)-1 {
+			maxTime = math.MaxInt64 // Open (newest) chunk.
+		}
+		if chk.OverlapsClosedInterval(mint, maxt) {
+			chks = append(chks, chunks.Meta{
+				MinTime: chk.minTime,
+				MaxTime: maxTime,
+				Ref:     chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.headChunkID(len(s.mmappedChunks)+i))),
+			})
 		}
 	}
-	return chks
+	return chks, headChunksBuf
 }
 
 // headChunkID returns the HeadChunkID referred to by the given position.
@@ -344,17 +370,88 @@ func (h *Head) chunksRange(mint, maxt int64, is *isolationState) (*headChunkRead
 	}, nil
 }
 
+// headChunkReader provides chunk reading for the head block.
+// Not safe for concurrent use from multiple goroutines.
 type headChunkReader struct {
 	head       *Head
 	mint, maxt int64
 	isoState   *isolationState
+	// When true, enables the head-chunks cache. Range queries benefit from
+	// caching because they look up every chunk of a series; instant queries
+	// only need one chunk per series, so the cache is wasted overhead.
+	enableCache bool
+	// Cache for head chunks — avoids O(n²) linked-list walks when
+	// iterating all chunks of a series oldest-to-newest.
+	cachedKey        headChunkCacheKey
+	cachedHeadChunks []*memChunk
+}
+
+// headChunkCacheKey identifies the chunk-layout state of a series at
+// collection time; any layout change (append, mmapping, truncation) alters at
+// least one field, invalidating the cached slice.
+type headChunkCacheKey struct {
+	ref          storage.SeriesRef
+	head         *memChunk          // Head pointer; detects head-chunk replacement.
+	mmapLen      int                // len(s.mmappedChunks); detects mmap events.
+	firstChunkID chunks.HeadChunkID // Detects truncation.
+}
+
+// headChunkCacheKeyFor returns the cache key for the current chunk layout of s.
+// The series lock must be held.
+func headChunkCacheKeyFor(s *memSeries) headChunkCacheKey {
+	return headChunkCacheKey{
+		ref:          storage.SeriesRef(s.ref),
+		head:         s.headChunks,
+		mmapLen:      len(s.mmappedChunks),
+		firstChunkID: s.firstChunkID,
+	}
 }
 
 func (h *headChunkReader) Close() error {
 	if h.isoState != nil {
 		h.isoState.Close()
 	}
+	// Release the cache so a closed reader retains no chunk data.
+	h.cachedKey = headChunkCacheKey{}
+	h.cachedHeadChunks = nil
 	return nil
+}
+
+// EnableChunkCache enables the head-chunk cache for sequential chunk access
+// patterns (range queries, compaction), which look up every chunk of a series.
+// The cache is invalidated whenever the series' chunk layout changes (a
+// parallel append, mmapping, or truncation), falling back to O(n) for that
+// lookup.
+func (h *headChunkReader) EnableChunkCache() {
+	h.enableCache = true
+}
+
+// getOrCollectHeadChunks returns the cached head-chunk slice for s, collecting
+// it first if the cache does not match the series' current chunk layout.
+// The series lock must be held; the fingerprint comparison is only consistent
+// against concurrent appends, mmapping, and truncation under that lock.
+func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
+	// Skip if the cache is disabled (instant queries) or there are no head chunks or there's only one.
+	if !h.enableCache || s.headChunks == nil || s.headChunks.prev == nil {
+		return nil
+	}
+
+	key := headChunkCacheKeyFor(s)
+	if key == h.cachedKey {
+		return h.cachedHeadChunks
+	}
+
+	buf := h.cachedHeadChunks[:0]
+	// Pre-size the first collection, and do not carry oversized backing arrays
+	// from one series to the next (the headChunksBufMaxCap policy used for
+	// headChunksBuf) — but keep a large array while it still serves the same
+	// series.
+	if c := cap(buf); c == 0 || (c > headChunksBufMaxCap && key.ref != h.cachedKey.ref) {
+		buf = make([]*memChunk, 0, s.headChunkCount.Load())
+	}
+	h.cachedHeadChunks = collectHeadChunks(s.headChunks, buf)
+	h.cachedKey = key
+	return h.cachedHeadChunks
 }
 
 // ChunkOrIterable returns the chunk for the reference number.
@@ -388,7 +485,11 @@ func (h *headChunkReader) chunk(meta chunks.Meta, copyLastChunk bool) (chunkenc.
 
 	s.Lock()
 	defer s.Unlock()
-	return h.head.chunkFromSeries(s, cid, isOOO, h.mint, h.maxt, h.isoState, copyLastChunk)
+	var headChunks []*memChunk
+	if !isOOO {
+		headChunks = h.getOrCollectHeadChunks(s)
+	}
+	return h.head.chunkFromSeries(s, cid, isOOO, h.mint, h.maxt, h.isoState, copyLastChunk, headChunks)
 }
 
 // Dumb thing to defeat chunk pool.
@@ -397,12 +498,12 @@ type wrapOOOHeadChunk struct {
 }
 
 // Call with s locked.
-func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool, mint, maxt int64, isoState *isolationState, copyLastChunk bool) (chunkenc.Chunk, int64, error) {
+func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool, mint, maxt int64, isoState *isolationState, copyLastChunk bool, headChunks []*memChunk) (chunkenc.Chunk, int64, error) {
 	if isOOO {
 		chk, maxTime, err := s.oooChunk(cid, h.chunkDiskMapper, &h.memChunkPool)
 		return wrapOOOHeadChunk{chk}, maxTime, err
 	}
-	c, headChunk, isOpen, err := s.chunk(cid, h.chunkDiskMapper, &h.memChunkPool)
+	c, headChunk, isOpen, err := s.chunk(cid, h.chunkDiskMapper, &h.memChunkPool, headChunks)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -446,27 +547,22 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 // If headChunk is false, it means that the returned *memChunk
 // (and not the chunkenc.Chunk inside it) can be garbage collected after its usage.
 // if isOpen is true, it means that the returned *memChunk is used for appends.
-func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, memChunkPool *sync.Pool) (chunk *memChunk, headChunk, isOpen bool, err error) {
-	// ix represents the index of chunk in the s.mmappedChunks slice. The chunk id's are
-	// incremented by 1 when new chunk is created, hence (id - firstChunkID) gives the slice index.
-	// The max index for the s.mmappedChunks slice can be len(s.mmappedChunks)-1, hence if the ix
-	// is >= len(s.mmappedChunks), it represents one of the chunks on s.headChunks linked list.
-	// The order of elements is different for slice and linked list.
-	// For s.mmappedChunks slice newer chunks are appended to it.
-	// For s.headChunks list newer chunks are prepended to it.
+func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, memChunkPool *sync.Pool, headChunks []*memChunk) (chunk *memChunk, headChunk, isOpen bool, err error) {
+	// ix is the chunk's oldest-first position in the logical sequence. Chunk IDs
+	// increase by one when a chunk is created, so id-firstChunkID yields that position.
+	// s.mmappedChunks is stored oldest-first, while the s.headChunks linked list is
+	// stored newest-first:
 	//
 	// memSeries {
 	//   mmappedChunks: [t0, t1, t2]
-	//   headChunk:     {t5}->{t4}->{t3}
+	//   headChunks:    {t5}->{t4}->{t3}
 	// }
+	//
+	// Values below len(s.mmappedChunks) index the slice directly. Remaining values
+	// index head chunks oldest-first; the pre-collected headChunks slice already uses
+	// this order, while the linked-list fallback reverses the index.
 	ix := int(id) - int(s.firstChunkID)
-
-	var headChunksLen int
-	if s.headChunks != nil {
-		headChunksLen = s.headChunks.len()
-	}
-
-	if ix < 0 || ix > len(s.mmappedChunks)+headChunksLen-1 {
+	if ix < 0 {
 		return nil, false, false, storage.ErrNotFound
 	}
 
@@ -486,17 +582,35 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 		return mc, false, false, nil
 	}
 
+	// Head chunk lookup.
 	ix -= len(s.mmappedChunks)
 
+	// Fast path: use pre-collected slice for O(1) indexed lookup.
+	if headChunks != nil {
+		if ix >= len(headChunks) {
+			return nil, false, false, storage.ErrNotFound
+		}
+		return headChunks[ix], true, ix == len(headChunks)-1, nil
+	}
+
+	// Fallback: walk the linked list.
+	headChunksLen := int(s.headChunkCount.Load())
+	if ix >= headChunksLen {
+		return nil, false, false, storage.ErrNotFound
+	}
+	// Walk from newest (offset 0) to target. The list is newest-first,
+	// but ix is oldest-first, so reverse the offset.
 	offset := headChunksLen - ix - 1
-	// headChunks is a linked list where first element is the most recent one and the last one is the oldest.
-	// This order is reversed when compared with mmappedChunks, since mmappedChunks[0] is the oldest chunk,
-	// while headChunk.atOffset(0) would give us the most recent chunk.
-	// So when calling headChunk.atOffset() we need to reverse the value of ix.
-	elem := s.headChunks.atOffset(offset)
+	elem := s.headChunks
+	for range offset {
+		if elem == nil {
+			break
+		}
+		elem = elem.prev
+	}
 	if elem == nil {
-		// This should never really happen and would mean that headChunksLen value is NOT equal
-		// to the length of the headChunks list.
+		// Defensive: headChunkCount disagreed with the actual list length.
+		// This only catches walks that run off the end of the list.
 		return nil, false, false, storage.ErrNotFound
 	}
 	return elem, true, offset == 0, nil
@@ -532,7 +646,7 @@ func (c *safeHeadChunk) Iterator(reuseIter chunkenc.Iterator) chunkenc.Iterator 
 	return it
 }
 
-// iterator returns a chunk iterator for the requested chunkID, or a NopIterator if the requested ID is out of range.
+// iterator returns a chunk iterator for the requested chunk ID, or a NopIterator if it is out of range.
 // It is unsafe to call this concurrently with s.append(...) without holding the series lock.
 func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *isolationState, it chunkenc.Iterator) chunkenc.Iterator {
 	ix := int(id) - int(s.firstChunkID)
@@ -551,20 +665,20 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 			}
 		}
 
-		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
-			// Iterate all head chunks from the oldest to the newest.
-			headChunksLen := s.headChunks.len()
-			for j := headChunksLen - 1; j >= 0; j-- {
-				chk := s.headChunks.atOffset(j)
-				chkSamples := chk.chunk.NumSamples()
+			// Reset ix, so its base is 0 (oldest non-mmapped head chunk).
+			ix -= len(s.mmappedChunks)
+
+			// Head chunks are indexed oldest-first, matching chunk ID order, but the list is walked newest-first,
+			// so j starts at the highest (newest) index and counts down.
+			j := int(s.headChunkCount.Load()) - 1
+			for elem := s.headChunks; elem != nil; elem = elem.prev {
+				chkSamples := elem.chunk.NumSamples()
 				totalSamples += chkSamples
-				// Chunk ID is len(s.mmappedChunks) + $(headChunks list position).
-				// Where $(headChunks list position) is zero for the oldest chunk and $(s.headChunks.len() - 1)
-				// for the newest (open) chunk.
-				if headChunksLen-1-j < ix {
+				if j < ix {
 					previousSamples += chkSamples
 				}
+				j--
 			}
 		}
 

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
@@ -599,7 +599,7 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	// We do not reset oooHeadChunk because that is being replayed from a different WAL
 	// and has not been replayed here.
 	mSeries.nextAt = 0
-	mSeries.headChunks = nil
+	mSeries.setHeadChunks(nil, 0)
 	mSeries.app = nil
 	return
 }
@@ -1645,7 +1645,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 					continue
 				}
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
-				series.headChunks = csr.mc
+				series.setHeadChunks(csr.mc, uint32(csr.mc.len()))
 				series.lastValue = csr.lastValue
 				series.lastHistogramValue = csr.lastHistogramValue
 				series.lastFloatHistogramValue = csr.lastFloatHistogramValue

--- a/vendor/github.com/prometheus/prometheus/tsdb/ooo_head_read.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/ooo_head_read.go
@@ -77,18 +77,23 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 	*chks = (*chks)[:0]
 
 	if s.ooo != nil {
-		return getOOOSeriesChunks(s, oh.mint, oh.maxt, oh.lastGarbageCollectedMmapRef, 0, true, oh.inoMint, chks)
+		oh.headChunksBuf = getOOOSeriesChunks(s, oh.mint, oh.maxt, oh.lastGarbageCollectedMmapRef, 0, true, oh.inoMint, chks, oh.headChunksBuf)
+	} else {
+		*chks, oh.headChunksBuf = appendSeriesChunks(s, oh.inoMint, oh.maxt, *chks, oh.headChunksBuf)
 	}
-	*chks = appendSeriesChunks(s, oh.inoMint, oh.maxt, *chks)
+	if cap(oh.headChunksBuf) > headChunksBufMaxCap {
+		oh.headChunksBuf = nil
+	}
 	return nil
 }
 
+// getOOOSeriesChunks collects chunk metadata for OOO (and optionally in-order) data.
 // lastGarbageCollectedMmapRef gives the last mmap chunk that may be being garbage collected and so
 // any chunk at or before this ref will not be considered. 0 disables this check.
-//
-// maxMmapRef tells upto what max m-map chunk that we can consider. If it is non-0, then
+// maxMmapRef tells up to what max m-map chunk that we can consider. If it is non-0, then
 // the oooHeadChunk will not be considered.
-func getOOOSeriesChunks(s *memSeries, mint, maxt int64, lastGarbageCollectedMmapRef, maxMmapRef chunks.ChunkDiskMapperRef, includeInOrder bool, inoMint int64, chks *[]chunks.Meta) error {
+// headChunksBuf is a reusable buffer for collectHeadChunks; the (possibly grown) buffer is returned.
+func getOOOSeriesChunks(s *memSeries, mint, maxt int64, lastGarbageCollectedMmapRef, maxMmapRef chunks.ChunkDiskMapperRef, includeInOrder bool, inoMint int64, chks *[]chunks.Meta, headChunksBuf []*memChunk) []*memChunk {
 	tmpChks := make([]chunks.Meta, 0, len(s.ooo.oooMmappedChunks))
 
 	addChunk := func(minT, maxT int64, ref chunks.ChunkRef, chunk chunkenc.Chunk) {
@@ -109,7 +114,7 @@ func getOOOSeriesChunks(s *memSeries, mint, maxt int64, lastGarbageCollectedMmap
 				chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(c.minTime, c.maxTime)
 				if err != nil {
 					handleChunkWriteError(err)
-					return nil
+					return headChunksBuf
 				}
 				for _, chk := range chks {
 					addChunk(chk.minTime, chk.maxTime, ref, chk.chunk)
@@ -129,12 +134,12 @@ func getOOOSeriesChunks(s *memSeries, mint, maxt int64, lastGarbageCollectedMmap
 	}
 
 	if includeInOrder {
-		tmpChks = appendSeriesChunks(s, inoMint, maxt, tmpChks)
+		tmpChks, headChunksBuf = appendSeriesChunks(s, inoMint, maxt, tmpChks, headChunksBuf)
 	}
 
 	// There is nothing to do if we did not collect any chunk.
 	if len(tmpChks) == 0 {
-		return nil
+		return headChunksBuf
 	}
 
 	// Next we want to sort all the collected chunks by min time so we can find
@@ -165,7 +170,7 @@ func getOOOSeriesChunks(s *memSeries, mint, maxt int64, lastGarbageCollectedMmap
 	}
 	*chks = append(*chks, toBeMerged)
 
-	return nil
+	return headChunksBuf
 }
 
 // PostingsForMatchers needs to be overridden so that the right IndexReader
@@ -213,11 +218,12 @@ func lessByMinTimeAndMinRef(a, b chunks.Meta) int {
 }
 
 type HeadAndOOOChunkReader struct {
-	head        *Head
-	mint, maxt  int64
-	cr          *headChunkReader // If nil, only read OOO chunks.
-	maxMmapRef  chunks.ChunkDiskMapperRef
-	oooIsoState *oooIsolationState
+	head          *Head
+	mint, maxt    int64
+	cr            *headChunkReader // If nil, only read OOO chunks.
+	maxMmapRef    chunks.ChunkDiskMapperRef
+	oooIsoState   *oooIsolationState
+	headChunksBuf []*memChunk // Reusable buffer for collectHeadChunks when cr is nil.
 }
 
 func NewHeadAndOOOChunkReader(head *Head, mint, maxt int64, cr *headChunkReader, oooIsoState *oooIsolationState, maxMmapRef chunks.ChunkDiskMapperRef) *HeadAndOOOChunkReader {
@@ -258,7 +264,11 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 	defer s.Unlock()
 
 	if meta.Chunk == nil {
-		c, maxt, err := cr.head.chunkFromSeries(s, cid, isOOO, meta.MinTime, meta.MaxTime, isoState, copyLastChunk)
+		var headChunks []*memChunk
+		if !isOOO {
+			headChunks = cr.collectOrGetHeadChunks(s)
+		}
+		c, maxt, err := cr.head.chunkFromSeries(s, cid, isOOO, meta.MinTime, meta.MaxTime, isoState, copyLastChunk, headChunks)
 		return c, nil, maxt, err
 	}
 	mm, ok := meta.Chunk.(*multiMeta)
@@ -267,13 +277,17 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 	}
 	// We have a composite meta: construct a composite iterable.
 	mc := &mergedOOOChunks{}
+	var headChunks []*memChunk
 	for _, m := range mm.metas {
 		switch {
 		case m.Chunk != nil:
 			mc.chunkIterables = append(mc.chunkIterables, m.Chunk)
 		default:
 			_, cid, isOOO := unpackHeadChunkRef(m.Ref)
-			iterable, _, err := cr.head.chunkFromSeries(s, cid, isOOO, m.MinTime, m.MaxTime, isoState, copyLastChunk)
+			if !isOOO && headChunks == nil {
+				headChunks = cr.collectOrGetHeadChunks(s)
+			}
+			iterable, _, err := cr.head.chunkFromSeries(s, cid, isOOO, m.MinTime, m.MaxTime, isoState, copyLastChunk, headChunks)
 			if err != nil {
 				return nil, nil, 0, fmt.Errorf("invalid head chunk: %w", err)
 			}
@@ -283,14 +297,46 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 	return nil, mc, meta.MaxTime, nil
 }
 
+// collectOrGetHeadChunks returns the pre-collected head chunks for s. When the
+// underlying headChunkReader exists, it delegates to the per-series cache there.
+// Otherwise it collects directly into cr.headChunksBuf — this does not cache
+// across series, it only reuses the backing array to avoid per-call allocations.
+func (cr *HeadAndOOOChunkReader) collectOrGetHeadChunks(s *memSeries) []*memChunk {
+	if cr.cr != nil {
+		return cr.cr.getOrCollectHeadChunks(s)
+	}
+
+	// Defensive: in current callers, cr.cr is nil only for OOO compaction
+	// (OOOCompactionHead.Chunks), which only requests OOO chunks, so this
+	// branch is not reached. It is kept for correctness if callers change.
+	cr.headChunksBuf = collectHeadChunks(s.headChunks, cr.headChunksBuf[:0])
+	hc := cr.headChunksBuf
+	if cap(cr.headChunksBuf) > headChunksBufMaxCap {
+		cr.headChunksBuf = nil
+	}
+	return hc
+}
+
+// EnableChunkCache enables the head-chunk cache on the underlying
+// headChunkReader; see its documentation for the caching semantics.
+func (cr *HeadAndOOOChunkReader) EnableChunkCache() {
+	if cr.cr != nil {
+		cr.cr.EnableChunkCache()
+	}
+}
+
 func (cr *HeadAndOOOChunkReader) Close() error {
-	if cr.cr != nil && cr.cr.isoState != nil {
-		cr.cr.isoState.Close()
+	var err error
+	if cr.cr != nil {
+		err = cr.cr.Close()
 	}
 	if cr.oooIsoState != nil {
 		cr.oooIsoState.Close()
 	}
-	return nil
+	// Release the fallback collection buffer so a closed reader retains no
+	// chunk data.
+	cr.headChunksBuf = nil
+	return err
 }
 
 type OOOCompactionHead struct {
@@ -497,7 +543,8 @@ func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *l
 		return nil
 	}
 
-	return getOOOSeriesChunks(s, ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks)
+	getOOOSeriesChunks(s, ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks, nil)
+	return nil
 }
 
 func (ir *OOOCompactionHeadIndexReader) SortedLabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, error) {
@@ -569,11 +616,11 @@ func (q *HeadAndOOOQuerier) LabelNames(ctx context.Context, hints *storage.Label
 }
 
 func (q *HeadAndOOOQuerier) Close() error {
-	q.chunkr.Close()
+	err := q.chunkr.Close()
 	if q.querier == nil {
-		return nil
+		return err
 	}
-	return q.querier.Close()
+	return errors.Join(err, q.querier.Close())
 }
 
 func (q *HeadAndOOOQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
@@ -621,11 +668,11 @@ func (q *HeadAndOOOChunkQuerier) LabelNames(ctx context.Context, hints *storage.
 }
 
 func (q *HeadAndOOOChunkQuerier) Close() error {
-	q.chunkr.Close()
+	err := q.chunkr.Close()
 	if q.querier == nil {
-		return nil
+		return err
 	}
-	return q.querier.Close()
+	return errors.Join(err, q.querier.Close())
 }
 
 func (q *HeadAndOOOChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {

--- a/vendor/github.com/prometheus/prometheus/tsdb/querier.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/querier.go
@@ -118,11 +118,30 @@ func (q *blockQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	return selectSeriesSet(ctx, sortSeries, hints, ms, q.index, q.chunks, q.tombstones, q.mint, q.maxt)
 }
 
+// chunkCacheEnabler is an optional interface implemented by chunk readers that
+// support an in-memory head-chunk cache. The cache is beneficial when every
+// chunk of a series is accessed sequentially, such as range queries and compaction.
+type chunkCacheEnabler interface {
+	EnableChunkCache()
+}
+
+// enableChunkCache enables the head-chunk cache on cr if it supports one.
+func enableChunkCache(cr ChunkReader) {
+	if enabler, ok := cr.(chunkCacheEnabler); ok {
+		enabler.EnableChunkCache()
+	}
+}
+
 func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.SelectHints, ms []*labels.Matcher,
 	index IndexReader, chunks ChunkReader, tombstones tombstones.Reader, mint, maxt int64,
 ) storage.SeriesSet {
 	disableTrimming := false
 	sharded := hints != nil && hints.ShardCount > 0
+
+	if hints != nil && hints.Step > 0 {
+		enableChunkCache(chunks)
+	}
+
 	p, err := index.PostingsForMatchers(ctx, sharded, ms...)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
@@ -170,6 +189,10 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 ) storage.ChunkSeriesSet {
 	disableTrimming := false
 	sharded := hints != nil && hints.ShardCount > 0
+
+	if hints != nil && hints.Step > 0 {
+		enableChunkCache(chunks)
+	}
 
 	if hints != nil {
 		mint = hints.Start

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1208,7 +1208,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260812165702-847d1e06c085
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -2158,7 +2158,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260812165702-847d1e06c085
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
## Summary

Vendor the mimir-prometheus `mimir-release-2.17` tip so GEM/Mimir 2.17 picks up the head-chunk access optimization from grafana/mimir-prometheus#1272 (prometheus/prometheus#18300), cutting the O(n²) `memChunk.len` cost seen during ingester `PopulateBlock`.

- Bump replace to `mimir-prometheus` `9bc72b19` (includes grafana/mimir-prometheus#1272 plus the supporting head-chunk cache/#19139 stack already on that branch)
- Enables the head-chunk cache during compaction and uses tracked `headChunkCount` / pre-collected head chunks for lookups

### Context

Ingester CPU profiles on fat heads showed ~21% flat time in `memChunk.len` under `compactHead` → `PopulateBlock`. That path walks the in-memory head-chunk linked list on every chunk lookup; the vendored fix replaces those walks with O(1)/cached access on the first compaction after deploy.


```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M3 Pro
                                                          │ before-6.txt │           after-6.txt            │
                                                          │    sec/op    │   sec/op     vs base             │
HeadChunkCompaction/baseline/series=50000,chunks=1-11         459.6m ±20%   418.6m ±12%   -8.91% (p=0.041 n=6)
HeadChunkCompaction/moderate/series=1000,chunks=50-11         312.7m ±12%   301.9m ±10%        ~ (p=0.589 n=6)
HeadChunkCompaction/pathological/series=10,chunks=5000-11    1194.6m ± 3%   303.9m ±17%  -74.56% (p=0.002 n=6)
HeadChunkCompaction/heavy/series=10,chunks=20000-11         19347.3m ± 0%   300.7m ±15%  -98.45% (p=0.002 n=6)
geomean                                                        1.350       327.8m        -75.72%

                                                          │ before-6.txt │          after-6.txt           │
                                                          │     B/op     │    B/op      vs base           │
HeadChunkCompaction/baseline/series=50000,chunks=1-11       158.7Mi ±0%   158.7Mi ±0%       ~ (p=0.818 n=6)
HeadChunkCompaction/moderate/series=1000,chunks=50-11       41.37Mi ±0%   41.37Mi ±0%       ~ (p=0.909 n=6)
HeadChunkCompaction/pathological/series=10,chunks=5000-11   41.23Mi ±0%   43.10Mi ±0%  +4.53% (p=0.002 n=6)
HeadChunkCompaction/heavy/series=10,chunks=20000-11         88.95Mi ±0%   97.77Mi ±0%  +9.91% (p=0.002 n=6)
geomean                                                     70.05Mi       72.52Mi       +3.52%

                                                          │ before-6.txt │         after-6.txt          │
                                                          │  allocs/op   │ allocs/op   vs base          │
HeadChunkCompaction/baseline/series=50000,chunks=1-11       1.551M ±0%   1.551M ±0%       ~ (p=0.937 n=6)
HeadChunkCompaction/moderate/series=1000,chunks=50-11       86.46k ±0%   86.47k ±0%  +0.01% (p=0.026 n=6)
HeadChunkCompaction/pathological/series=10,chunks=5000-11   50.85k ±0%   51.02k ±0%  +0.34% (p=0.002 n=6)
HeadChunkCompaction/heavy/series=10,chunks=20000-11         200.9k ±0%   201.1k ±0%  +0.11% (p=0.002 n=6)
geomean                                                     192.4k       192.6k       +0.11%
```