### PR TITLE
perf(store-gateway): Expose experimental force-attempt-http2 flag for object storage clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Ruler: Split oversized remote distributor writes to keep resulting calls within the configured gRPC maximum send size, and expose the number of generated requests in `cortex_ruler_remote_distributor_requests_per_write_request`. #16160
 * [ENHANCEMENT] Alerts: Don't fire `MimirMemberlistZoneAwareRoutingAutoFailover` while the node is still joining the cluster. #16315
 * [ENHANCEMENT] Store-gateway: added a `route` label to the `cortex_bucket_store_series_request_stage_duration_seconds` metric to match the `route` label of `cortex_request_duration_seconds`. #16374
+* [ENHANCEMENT] Store-gateway: Add `force_attempt_http2` option to block storage client config to enable HTTP/2. #16385
 * [FEATURE] Querier: Add experimental per-tenant limit `-querier.max-blocks-per-store-request` to cap the number of blocks a single store-gateway request may reference. Disabled by default. #16292
 * [BUGFIX] Query-frontend: Wait for the querier ring to be populated during startup, up to 30 seconds, before reporting the query-frontend as ready. Previously a query-frontend could become ready before it had seen any querier in the ring and fail every query it received until the ring was populated. Only applies when remote execution is enabled, and can be disabled with the experimental `-query-frontend.wait-for-querier-ring-on-startup=false`. #16333
 * [BUGFIX] Query-frontend: Fail queries with a clear error, rather than planning them against an invalid maximum supported query plan version, when the querier ring contains only unhealthy queriers. #16333

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -10405,6 +10405,17 @@
                 },
                 {
                   "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "blocks-storage.s3.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
                   "name": "tls_ca_path",
                   "required": false,
                   "desc": "Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.",
@@ -10617,6 +10628,17 @@
                   "fieldFlag": "blocks-storage.gcs.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "blocks-storage.gcs.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",
@@ -10841,6 +10863,17 @@
                   "fieldFlag": "blocks-storage.azure.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "blocks-storage.azure.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",
@@ -17995,6 +18028,17 @@
                 },
                 {
                   "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "ruler-storage.s3.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
                   "name": "tls_ca_path",
                   "required": false,
                   "desc": "Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.",
@@ -18207,6 +18251,17 @@
                   "fieldFlag": "ruler-storage.gcs.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "ruler-storage.gcs.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",
@@ -18431,6 +18486,17 @@
                   "fieldFlag": "ruler-storage.azure.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "ruler-storage.azure.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",
@@ -20308,6 +20374,17 @@
                 },
                 {
                   "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "alertmanager-storage.s3.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
                   "name": "tls_ca_path",
                   "required": false,
                   "desc": "Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.",
@@ -20520,6 +20597,17 @@
                   "fieldFlag": "alertmanager-storage.gcs.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "alertmanager-storage.gcs.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",
@@ -20744,6 +20832,17 @@
                   "fieldFlag": "alertmanager-storage.azure.max-connections-per-host",
                   "fieldType": "int",
                   "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "force_attempt_http2",
+                  "required": false,
+                  "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "alertmanager-storage.azure.http.force-attempt-http2",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",
@@ -23396,6 +23495,17 @@
                     },
                     {
                       "kind": "field",
+                      "name": "force_attempt_http2",
+                      "required": false,
+                      "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "common.storage.s3.http.force-attempt-http2",
+                      "fieldType": "boolean",
+                      "fieldCategory": "experimental"
+                    },
+                    {
+                      "kind": "field",
                       "name": "tls_ca_path",
                       "required": false,
                       "desc": "Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.",
@@ -23608,6 +23718,17 @@
                       "fieldFlag": "common.storage.gcs.max-connections-per-host",
                       "fieldType": "int",
                       "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "force_attempt_http2",
+                      "required": false,
+                      "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "common.storage.gcs.http.force-attempt-http2",
+                      "fieldType": "boolean",
+                      "fieldCategory": "experimental"
                     },
                     {
                       "kind": "field",
@@ -23832,6 +23953,17 @@
                       "fieldFlag": "common.storage.azure.max-connections-per-host",
                       "fieldType": "int",
                       "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "force_attempt_http2",
+                      "required": false,
+                      "desc": "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "common.storage.azure.http.force-attempt-http2",
+                      "fieldType": "boolean",
+                      "fieldCategory": "experimental"
                     },
                     {
                       "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -15,6 +15,8 @@ Usage of ./cmd/mimir/mimir:
     	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
   -alertmanager-storage.azure.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -alertmanager-storage.azure.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -alertmanager-storage.azure.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -alertmanager-storage.azure.http.insecure-skip-verify
@@ -51,6 +53,8 @@ Usage of ./cmd/mimir/mimir:
     	Enable automatic retries for GCS uploads using the RetryAlways policy. Uploads will be retried on transient errors. Note: this does not guarantee idempotency. (default true)
   -alertmanager-storage.gcs.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -alertmanager-storage.gcs.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -alertmanager-storage.gcs.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -alertmanager-storage.gcs.http.insecure-skip-verify
@@ -91,6 +95,8 @@ Usage of ./cmd/mimir/mimir:
     	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
   -alertmanager-storage.s3.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -alertmanager-storage.s3.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -alertmanager-storage.s3.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -alertmanager-storage.s3.http.insecure-skip-verify
@@ -395,6 +401,8 @@ Usage of ./cmd/mimir/mimir:
     	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
   -blocks-storage.azure.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -blocks-storage.azure.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -blocks-storage.azure.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -blocks-storage.azure.http.insecure-skip-verify
@@ -695,6 +703,8 @@ Usage of ./cmd/mimir/mimir:
     	Enable automatic retries for GCS uploads using the RetryAlways policy. Uploads will be retried on transient errors. Note: this does not guarantee idempotency. (default true)
   -blocks-storage.gcs.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -blocks-storage.gcs.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -blocks-storage.gcs.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -blocks-storage.gcs.http.insecure-skip-verify
@@ -733,6 +743,8 @@ Usage of ./cmd/mimir/mimir:
     	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
   -blocks-storage.s3.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -blocks-storage.s3.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -blocks-storage.s3.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -blocks-storage.s3.http.insecure-skip-verify
@@ -935,6 +947,8 @@ Usage of ./cmd/mimir/mimir:
     	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
   -common.storage.azure.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -common.storage.azure.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -common.storage.azure.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -common.storage.azure.http.insecure-skip-verify
@@ -971,6 +985,8 @@ Usage of ./cmd/mimir/mimir:
     	Enable automatic retries for GCS uploads using the RetryAlways policy. Uploads will be retried on transient errors. Note: this does not guarantee idempotency. (default true)
   -common.storage.gcs.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -common.storage.gcs.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -common.storage.gcs.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -common.storage.gcs.http.insecure-skip-verify
@@ -1009,6 +1025,8 @@ Usage of ./cmd/mimir/mimir:
     	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
   -common.storage.s3.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -common.storage.s3.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -common.storage.s3.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -common.storage.s3.http.insecure-skip-verify
@@ -3121,6 +3139,8 @@ Usage of ./cmd/mimir/mimir:
     	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
   -ruler-storage.azure.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -ruler-storage.azure.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -ruler-storage.azure.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -ruler-storage.azure.http.insecure-skip-verify
@@ -3199,6 +3219,8 @@ Usage of ./cmd/mimir/mimir:
     	Enable automatic retries for GCS uploads using the RetryAlways policy. Uploads will be retried on transient errors. Note: this does not guarantee idempotency. (default true)
   -ruler-storage.gcs.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -ruler-storage.gcs.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -ruler-storage.gcs.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -ruler-storage.gcs.http.insecure-skip-verify
@@ -3239,6 +3261,8 @@ Usage of ./cmd/mimir/mimir:
     	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
   -ruler-storage.s3.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -ruler-storage.s3.http.force-attempt-http2
+    	[experimental] If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.
   -ruler-storage.s3.http.idle-conn-timeout duration
     	The time an idle connection remains idle before closing. (default 1m30s)
   -ruler-storage.s3.http.insecure-skip-verify

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -7417,6 +7417,12 @@ http:
   # CLI flag: -<prefix>.s3.max-connections-per-host
   [max_connections_per_host: <int> | default = 0]
 
+  # (experimental) If enabled, the HTTP client attempts HTTP/2 for HTTPS
+  # connections. Without this option, a client with a custom TLS configuration
+  # uses HTTP/1.1.
+  # CLI flag: -<prefix>.s3.http.force-attempt-http2
+  [force_attempt_http2: <boolean> | default = false]
+
   # (advanced) Path to the Certificate Authority (CA) certificates to validate
   # the server certificate. If not set, the host's root CA certificates are
   # used.
@@ -7524,6 +7530,12 @@ http:
   # CLI flag: -<prefix>.gcs.max-connections-per-host
   [max_connections_per_host: <int> | default = 0]
 
+  # (experimental) If enabled, the HTTP client attempts HTTP/2 for HTTPS
+  # connections. Without this option, a client with a custom TLS configuration
+  # uses HTTP/1.1.
+  # CLI flag: -<prefix>.gcs.http.force-attempt-http2
+  [force_attempt_http2: <boolean> | default = false]
+
   # (advanced) Path to the Certificate Authority (CA) certificates to validate
   # the server certificate. If not set, the host's root CA certificates are
   # used.
@@ -7629,6 +7641,12 @@ http:
   # (advanced) Maximum number of connections per host. Set to 0 for no limit.
   # CLI flag: -<prefix>.azure.max-connections-per-host
   [max_connections_per_host: <int> | default = 0]
+
+  # (experimental) If enabled, the HTTP client attempts HTTP/2 for HTTPS
+  # connections. Without this option, a client with a custom TLS configuration
+  # uses HTTP/1.1.
+  # CLI flag: -<prefix>.azure.http.force-attempt-http2
+  [force_attempt_http2: <boolean> | default = false]
 
   # (advanced) Path to the Certificate Authority (CA) certificates to validate
   # the server certificate. If not set, the host's root CA certificates are

--- a/go.mod
+++ b/go.mod
@@ -366,3 +366,5 @@ replace github.com/munnerz/goautoneg => github.com/grafana/goautoneg v0.0.0-2024
 // Use Mimir fork of prometheus/otlptranslator to allow for higher velocity of upstream development,
 // while allowing Mimir to move at a more conservative pace.
 replace github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d
+
+replace github.com/thanos-io/objstore => github.com/francoposa/objstore v0.0.0-20260730205958-44bf50474b87

--- a/go.mod
+++ b/go.mod
@@ -367,4 +367,5 @@ replace github.com/munnerz/goautoneg => github.com/grafana/goautoneg v0.0.0-2024
 // while allowing Mimir to move at a more conservative pace.
 replace github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d
 
+// Use temporary fork of objstore for `force-enable-http2` flag.
 replace github.com/thanos-io/objstore => github.com/francoposa/objstore v0.0.0-20260730205958-44bf50474b87

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ github.com/felixge/fgprof v0.9.5 h1:8+vR6yu2vvSKn08urWyEuxx75NWPEvybbkBirEpsbVY=
 github.com/felixge/fgprof v0.9.5/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZPpayhMM=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
+github.com/francoposa/objstore v0.0.0-20260730205958-44bf50474b87 h1:NqH7bhC4r38qxQ6IjgfbkmIetzDorVJkmray3Y67V/w=
+github.com/francoposa/objstore v0.0.0-20260730205958-44bf50474b87/go.mod h1:pI5Ppb4ommu4PgplxxRUyEPMMu625BpJQCkCYbHk7Ac=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
@@ -1008,8 +1010,6 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4O8IB2ozzxM=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
-github.com/thanos-io/objstore v0.0.0-20260615134008-fb6fd3a5170a h1:jZpnHlnKFgGBQzDqLvlXcXt6xl2W74U0ZTFZvTyAKwU=
-github.com/thanos-io/objstore v0.0.0-20260615134008-fb6fd3a5170a/go.mod h1:pI5Ppb4ommu4PgplxxRUyEPMMu625BpJQCkCYbHk7Ac=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
 github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
 github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=

--- a/pkg/storage/bucket/common/http.go
+++ b/pkg/storage/bucket/common/http.go
@@ -21,6 +21,7 @@ type HTTPConfig struct {
 	MaxIdleConns          int           `yaml:"max_idle_connections" category:"advanced"`
 	MaxIdleConnsPerHost   int           `yaml:"max_idle_connections_per_host" category:"advanced"`
 	MaxConnsPerHost       int           `yaml:"max_connections_per_host" category:"advanced"`
+	ForceAttemptHTTP2     bool          `yaml:"force_attempt_http2" category:"experimental"`
 
 	// Allow upstream callers to inject a round tripper
 	Transport http.RoundTripper `yaml:"-"`
@@ -37,6 +38,7 @@ func (cfg *HTTPConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxIdleConns, prefix+"max-idle-connections", 100, "Maximum number of idle (keep-alive) connections across all hosts. Set to 0 for no limit.")
 	f.IntVar(&cfg.MaxIdleConnsPerHost, prefix+"max-idle-connections-per-host", 100, "Maximum number of idle (keep-alive) connections to keep per-host. Set to 0 to use a built-in default value of 2.")
 	f.IntVar(&cfg.MaxConnsPerHost, prefix+"max-connections-per-host", 0, "Maximum number of connections per host. Set to 0 for no limit.")
+	f.BoolVar(&cfg.ForceAttemptHTTP2, prefix+"http.force-attempt-http2", false, "If enabled, the HTTP client attempts HTTP/2 for HTTPS connections. Without this option, a client with a custom TLS configuration uses HTTP/1.1.")
 	cfg.TLSConfig.RegisterFlagsWithPrefix(prefix, f)
 }
 
@@ -50,6 +52,7 @@ func (cfg *HTTPConfig) ToExtHTTP() exthttp.HTTPConfig {
 		MaxIdleConns:          cfg.MaxIdleConns,
 		MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
 		MaxConnsPerHost:       cfg.MaxConnsPerHost,
+		ForceAttemptHTTP2:     cfg.ForceAttemptHTTP2,
 		Transport:             cfg.Transport,
 		TLSConfig:             cfg.TLSConfig.ToExtHTTP(),
 	}

--- a/pkg/storage/bucket/common/http_test.go
+++ b/pkg/storage/bucket/common/http_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore/exthttp"
+)
+
+// TestHTTPConfig_ToExtHTTP_DefaultTransport makes sure that the Mimir HTTP
+// options reach the http.Transport that objstore builds.
+func TestHTTPConfig_ToExtHTTP_DefaultTransport(t *testing.T) {
+	cfg := HTTPConfig{
+		IdleConnTimeout:       time.Minute,
+		ResponseHeaderTimeout: 2 * time.Minute,
+		InsecureSkipVerify:    true,
+		TLSHandshakeTimeout:   3 * time.Minute,
+		ExpectContinueTimeout: 4 * time.Minute,
+		MaxIdleConns:          10,
+		MaxIdleConnsPerHost:   20,
+		MaxConnsPerHost:       30,
+		ForceAttemptHTTP2:     true,
+		TLSConfig: TLSConfig{
+			ServerName: "server",
+		},
+	}
+
+	transport, err := exthttp.DefaultTransport(cfg.ToExtHTTP())
+	require.NoError(t, err)
+
+	require.Equal(t, cfg.IdleConnTimeout, transport.IdleConnTimeout)
+	require.Equal(t, cfg.ResponseHeaderTimeout, transport.ResponseHeaderTimeout)
+	require.Equal(t, cfg.TLSHandshakeTimeout, transport.TLSHandshakeTimeout)
+	require.Equal(t, cfg.ExpectContinueTimeout, transport.ExpectContinueTimeout)
+	require.Equal(t, cfg.MaxIdleConns, transport.MaxIdleConns)
+	require.Equal(t, cfg.MaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	require.Equal(t, cfg.MaxConnsPerHost, transport.MaxConnsPerHost)
+	require.Equal(t, cfg.ForceAttemptHTTP2, transport.ForceAttemptHTTP2)
+	require.Equal(t, cfg.InsecureSkipVerify, transport.TLSClientConfig.InsecureSkipVerify)
+	require.Equal(t, cfg.TLSConfig.ServerName, transport.TLSClientConfig.ServerName)
+}

--- a/vendor/github.com/thanos-io/objstore/CHANGELOG.md
+++ b/vendor/github.com/thanos-io/objstore/CHANGELOG.md
@@ -63,6 +63,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#63](https://github.com/thanos-io/objstore/pull/63) Implement a `IterWithAttributes` method on the bucket client.
 - [#155](https://github.com/thanos-io/objstore/pull/155) Add a `Provider` method on `objstore.Client`.
 - [#163](https://github.com/thanos-io/objstore/pull/145) Add a `NewBucketFromConfig` constructor method for creating a client from an existing `BucketConfig` object.
+- [#266](https://github.com/thanos-io/objstore/pull/266) *: Add `force_attempt_http2` option to `http_config` to re-enable HTTP/2 for the custom transport.
 
 
 ### Changed

--- a/vendor/github.com/thanos-io/objstore/README.md
+++ b/vendor/github.com/thanos-io/objstore/README.md
@@ -207,6 +207,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
   trace:
     enable: false
@@ -405,6 +406,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
   chunk_size_bytes: 0
   max_retries: 0
@@ -511,6 +513,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
   msi_resource: ""
 prefix: ""
@@ -574,6 +577,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
 prefix: ""
 ```
@@ -609,6 +613,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
 prefix: ""
 ```
@@ -775,6 +780,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
 prefix: ""
 ```

--- a/vendor/github.com/thanos-io/objstore/exthttp/transport.go
+++ b/vendor/github.com/thanos-io/objstore/exthttp/transport.go
@@ -37,6 +37,7 @@ type HTTPConfig struct {
 	Transport http.RoundTripper `yaml:"-"`
 
 	TLSConfig          TLSConfig `yaml:"tls_config"`
+	ForceAttemptHTTP2  bool      `yaml:"force_attempt_http2"`
 	DisableCompression bool      `yaml:"disable_compression"`
 }
 
@@ -74,6 +75,7 @@ func DefaultTransport(config HTTPConfig) (*http.Transport, error) {
 		// content-encoding set to `gzip`.
 		//
 		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843.
-		TLSClientConfig: tlsConfig,
+		TLSClientConfig:   tlsConfig,
+		ForceAttemptHTTP2: config.ForceAttemptHTTP2,
 	}, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1297,7 +1297,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/assert/yaml
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/objstore v0.0.0-20260615134008-fb6fd3a5170a
+# github.com/thanos-io/objstore v0.0.0-20260615134008-fb6fd3a5170a => github.com/francoposa/objstore v0.0.0-20260730205958-44bf50474b87
 ## explicit; go 1.24.0
 github.com/thanos-io/objstore
 github.com/thanos-io/objstore/exthttp
@@ -2227,3 +2227,4 @@ sigs.k8s.io/yaml
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71
 # github.com/munnerz/goautoneg => github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce
 # github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d
+# github.com/thanos-io/objstore => github.com/francoposa/objstore v0.0.0-20260730205958-44bf50474b87


### PR DESCRIPTION
This option fixes extreme object storage tail latency in GCS due to GCS killing connections and the reconnect storm blocking the head of the line.

Unfortunately this must from my personal fork for now because Thanos is unresponsive to PRs on `thanos-io/objstore` and the Grafana GitHub org has disabled any ability to effectively use public forks - the `grafana/objstore` fork is too far out of date and cannot be synced with upstream.

Upstream PR is sitting at the same ocmmit hash ([44bf504](https://github.com/thanos-io/objstore/commit/44bf50474b877e22d56db0bd7831712122d77204)) - https://github.com/thanos-io/objstore/pull/266

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
