### PR TITLE
MQE: Fix grouping in binary operations with ignore and group left/right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
+* [BUGFIX] MQE: Fix an issue where series were joined in binary operations using the wrong labels when `group_left()`/`group_right()` were used in combination with `ignoring()`. This bug manifested as valid queries returning an error `grouping labels must ensure unique matches`. #16387
 
 ### Mixin
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -495,14 +495,22 @@ func (g *GroupedVectorVectorBinaryOperation) manySideGroupKeyFunc() func(manySid
 		}
 	}
 
-	labelsToRemove := g.VectorMatching.Include
+	labelsToRemove := make([]string, 0, len(g.VectorMatching.Include)+1)
+	for _, l := range g.VectorMatching.Include {
+		// Remove the include labels from the key of the many side when the grouping is `on(label)`.
+		// When it's `ignore(label)` we need to keep the include labels that aren't part of the matching
+		// set otherwise the series is non-unique. __name__ is never part of the key when used as an
+		// include label.
+		if l == model.MetricNameLabel || g.VectorMatching.On || slices.Contains(g.VectorMatching.MatchingLabels, l) {
+			labelsToRemove = append(labelsToRemove, l)
+		}
+	}
 
 	if g.shouldRemoveMetricNameFromManySide() {
-		labelsToRemove = make([]string, 0, len(g.VectorMatching.Include)+1)
 		labelsToRemove = append(labelsToRemove, model.MetricNameLabel)
-		labelsToRemove = append(labelsToRemove, g.VectorMatching.Include...)
-		slices.Sort(labelsToRemove)
 	}
+
+	slices.Sort(labelsToRemove)
 
 	return func(manySideLabels labels.Labels) []byte {
 		buf = manySideLabels.BytesWithoutLabels(buf, labelsToRemove...)

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1513,6 +1513,41 @@ eval range from 0 to 18m step 6m one_side - on(group) group_right(pod, env) many
 
 clear
 
+# Many-to-one regression test for an issue where the include labels weren't present
+# in the ignoring() clause and thus weren't used as part of key for the many side.
+
+load 1m
+  many_side{cluster="c1", pod="1", disk="a"} 2 2 2
+  many_side{cluster="c1", pod="2", disk="a"} 3 3 3
+  many_side{cluster="c2", pod="1", disk="a"} 4 4 4
+  one_side{cluster="c1", pod="1"} 1 1 1
+  one_side{cluster="c1", pod="2"} 1 1 1
+  one_side{cluster="c2", pod="1"} 1 1 1
+
+eval instant at 2m one_side * ignoring(disk) group_right(cluster, pod) many_side
+  {cluster="c1", pod="1", disk="a"} 2
+  {cluster="c1", pod="2", disk="a"} 3
+  {cluster="c2", pod="1", disk="a"} 4
+
+clear
+
+# Another test for the regression above but we make sure that __name__ is never used
+# as part of the key for the many side even when present as an include label.
+
+load 1m
+  one_side{cluster="c1"} 2 2 2
+  many_side_1{cluster="c1", disk="a"} 1 1 1
+  many_side_2{cluster="c1", disk="a"} 1 1 1
+  many_side_3{cluster="c1", disk="a"} 1 1 1
+
+eval_fail instant at 2m one_side == ignoring(disk) group_right(__name__) {__name__=~"many_side_.+"}
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+eval_fail instant at 2m one_side * ignoring(disk) group_right(__name__) {__name__=~"many_side_.+"}
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+clear
+
 # Binary operations on native histograms with group_left.
 # We don't bother testing all the combinations of label matching, group_right etc. given that's covered by floats above.
 load 5m


### PR DESCRIPTION
#### What this PR does

Fixes an issue in binary operations using group_left/group_right where the labels included would not be used in the unique key for the many side of the binary operation when using `ignore(label)` to join instead of `on(label)`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
