### PR TITLE
helm: add a dedicated ServiceAccount for Grafana Agent

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [CHANGE] Set default memberlist `rejoin_interval` to 60s so that a member evicted from the gossip ring by a transient network fault periodically rejoins the cluster instead of staying isolated until restart. #16332
 * [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
+* [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the Grafana Agent meta-monitoring resources by setting `metaMonitoring.grafanaAgent.serviceAccount.create` to true in the values. #16389
 
 
 ## 6.2.0

--- a/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
@@ -12,6 +12,8 @@ metaMonitoring:
   grafanaAgent:
     enabled: true
     installOperator: true
+    serviceAccount:
+      create: true
     metrics:
       # Leave the remote empty to use the default to send it to Mimir directly
       # remote: #

--- a/operations/helm/charts/mimir-distributed/ci/offline/openshift-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/openshift-values.yaml
@@ -19,3 +19,12 @@ rollout_operator:
     fsGroup: null
     runAsGroup: null
     runAsUser: null
+
+# Run the meta-monitoring agent under its own service account, in a namespace other than the release
+# namespace, to cover the SCC Role and RoleBinding that the chart creates alongside that account.
+metaMonitoring:
+  grafanaAgent:
+    enabled: true
+    namespace: citestns-monitoring
+    serviceAccount:
+      create: true

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -108,6 +108,21 @@ Create the name of the alertmanager service account
 {{- end -}}
 
 {{/*
+Create the name of the Grafana Agent service account
+*/}}
+{{- define "mimir.metaMonitoring.grafanaAgent.serviceAccountName" -}}
+{{- $sa := (((.Values.metaMonitoring).grafanaAgent).serviceAccount) | default dict -}}
+{{- if and $sa.create (eq ($sa.name | default "") "") -}}
+{{- $base := default (include "mimir.fullname" .) .Values.serviceAccount.name }}
+{{- printf "%s-grafana-agent" $base }}
+{{- else if $sa.create -}}
+{{- $sa.name -}}
+{{- else -}}
+{{- include "mimir.serviceAccountName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the app name for clients. Defaults to the same logic as "mimir.fullname", and default client expects "prometheus".
 */}}
 {{- define "client.name" -}}
@@ -498,6 +513,28 @@ Return if we should create a SecurityContextConstraints. Takes into account user
 */}}
 {{- define "mimir.rbac.useSecurityContextConstraints" -}}
 {{- and .Values.rbac.create (eq .Values.rbac.type "scc") -}}
+{{- end -}}
+
+{{/*
+Rules granting use of the PodSecurityPolicy or SecurityContextConstraints created by the chart.
+*/}}
+{{- define "mimir.rbac.podSecurityRules" -}}
+{{- if eq (include "mimir.rbac.usePodSecurityPolicy" .) "true" }}
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ include "mimir.resourceName" (dict "ctx" .) }}]
+{{- end }}
+{{- if eq (include "mimir.rbac.useSecurityContextConstraints" .) "true" }}
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+  verbs:
+    - use
+  resourceNames:
+    - {{ include "mimir.resourceName" (dict "ctx" .) }}
+{{- end }}
 {{- end -}}
 
 {{- define "mimir.remoteWriteUrl.inCluster" -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-cluster-role-binding.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-cluster-role-binding.yaml
@@ -12,7 +12,7 @@ roleRef:
   name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "mimir.serviceAccountName" $ }}
+    name: {{ include "mimir.metaMonitoring.grafanaAgent.serviceAccountName" $ }}
     namespace: {{ .namespace | default $.Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-role-binding.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-role-binding.yaml
@@ -1,0 +1,20 @@
+{{- $usePSP := (eq (include "mimir.rbac.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "mimir.rbac.useSecurityContextConstraints" .) "true") }}
+{{- with (.Values.metaMonitoring).grafanaAgent }}
+{{- if and .enabled (.serviceAccount).create (or $usePSP $useSCC) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+  namespace: {{ .namespace | default $.Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "mimir.metaMonitoring.grafanaAgent.serviceAccountName" $ }}
+{{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-role.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-role.yaml
@@ -1,0 +1,15 @@
+{{- $usePSP := (eq (include "mimir.rbac.usePodSecurityPolicy" .) "true") }}
+{{- $useSCC := (eq (include "mimir.rbac.useSecurityContextConstraints" .) "true") }}
+{{- with (.Values.metaMonitoring).grafanaAgent }}
+{{- if and .enabled (.serviceAccount).create (or $usePSP $useSCC) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" $ "component" "grafana-agent") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+  namespace: {{ .namespace | default $.Release.Namespace | quote }}
+rules:
+{{- include "mimir.rbac.podSecurityRules" $ }}
+{{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
@@ -1,0 +1,16 @@
+{{- with (.Values.metaMonitoring).grafanaAgent }}
+{{- if and .enabled (.serviceAccount).create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mimir.metaMonitoring.grafanaAgent.serviceAccountName" $ }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" $ "component" "meta-monitoring") | nindent 4 }}
+    {{- with (.serviceAccount).labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml (.serviceAccount).annotations | nindent 4 }}
+  namespace: {{ .namespace | default $.Release.Namespace | quote }}
+{{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  serviceAccountName: {{ include "mimir.serviceAccountName" $ }}
+  serviceAccountName: {{ include "mimir.metaMonitoring.grafanaAgent.serviceAccountName" $ }}
   {{- if $.Values.image.pullSecrets }}
   imagePullSecrets:
   {{- range $.Values.image.pullSecrets }}

--- a/operations/helm/charts/mimir-distributed/templates/role.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/role.yaml
@@ -9,20 +9,5 @@ metadata:
     {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
-{{- if $usePSP }}
-- apiGroups:      ['extensions']
-  resources:      ['podsecuritypolicies']
-  verbs:          ['use']
-  resourceNames:  [{{ include "mimir.resourceName" (dict "ctx" .) }}]
-{{- end }}
-{{- if $useSCC }}
-- apiGroups:
-    - security.openshift.io
-  resources:
-    - securitycontextconstraints
-  verbs:
-    - use
-  resourceNames:
-    - {{ include "mimir.resourceName" (dict "ctx" .) }}
-{{- end }}
+{{- include "mimir.rbac.podSecurityRules" . }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -492,7 +492,8 @@ alertmanager:
   # This service account can be used even if the default one is not set.
   serviceAccount:
     create: false
-    # -- Alertmanager specific service account name. If not set and create is set to true, the default
+    # -- Alertmanager specific service account name. Only takes effect when create is set to true;
+    # otherwise the default service account is used. If not set and create is set to true, the default
     # name will be the default mimir service account's name with the "-alertmanager" suffix.
     name: ""
     annotations: {}
@@ -1361,7 +1362,8 @@ ruler:
   # This service account can be used even if the default one is not set.
   serviceAccount:
     create: false
-    # -- Ruler specific service account name. If not set and create is set to true, the default
+    # -- Ruler specific service account name. Only takes effect when create is set to true;
+    # otherwise the default service account is used. If not set and create is set to true, the default
     # name will be the default mimir service account's name with the "-ruler" suffix.
     name: ""
     annotations: {}
@@ -3851,6 +3853,22 @@ metaMonitoring:
     # -- Annotations to add to all monitoring.grafana.com custom resources.
     # Does not affect the ServiceMonitors for kubernetes metrics; use serviceMonitor.annotations for that.
     annotations: {}
+
+    # -- Dedicated service account for Grafana Agent pods.
+    # If not set, the default service account defined at the beginning of this file will be used.
+    # This service account can be used even if the default one is not set.
+    # The service account is created in the namespace set in metaMonitoring.grafanaAgent.namespace.
+    # When rbac.create is enabled, a Role and RoleBinding granting use of the chart's
+    # PodSecurityPolicy or SecurityContextConstraints are created in that namespace as well, since a
+    # RoleBinding in the release namespace does not authorize pods running in another namespace.
+    serviceAccount:
+      create: false
+      # -- Grafana Agent specific service account name. Only takes effect when create is set to true;
+      # otherwise the default service account is used. If not set and create is set to true, the default
+      # name will be the default mimir service account's name with the "-grafana-agent" suffix.
+      name: ""
+      annotations: {}
+      labels: {}
 
     # -- SecurityContext of Grafana Agent pods. This is different from the SecurityContext that the operator pod runs with.
     # The operator pod SecurityContext is configured in the grafana-agent-operator.podSecurityContext value.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metamonitoring-values-mimir-grafana-agent
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: metamonitoring-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-cluster-role-binding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-cluster-role-binding.yaml
@@ -3,18 +3,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metamonitoring-values-mimir-grafana-agent
+  name: openshift-values-mimir-grafana-agent
   labels:
     app.kubernetes.io/name: mimir
-    app.kubernetes.io/instance: metamonitoring-values
+    app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: meta-monitoring
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metamonitoring-values-mimir-grafana-agent
+  name: openshift-values-mimir-grafana-agent
 subjects:
   - kind: ServiceAccount
-    name: metamonitoring-values-mimir-grafana-agent
-    namespace: citestns
+    name: openshift-values-mimir-grafana-agent
+    namespace: citestns-monitoring
 

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-cluster-role.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-cluster-role.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/grafana-agent-cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-values-mimir-grafana-agent
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-role-binding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-role-binding.yaml
@@ -1,0 +1,20 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/grafana-agent-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-values-mimir-grafana-agent
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns-monitoring"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-values-mimir-grafana-agent
+subjects:
+- kind: ServiceAccount
+  name: openshift-values-mimir-grafana-agent
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-role.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-role.yaml
@@ -1,0 +1,22 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/grafana-agent-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-values-mimir-grafana-agent
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns-monitoring"
+rules:
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+  verbs:
+    - use
+  resourceNames:
+    - openshift-values-mimir
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/grafana-agent-sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-values-mimir-grafana-agent
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns-monitoring"
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -3,15 +3,15 @@
 apiVersion: monitoring.grafana.com/v1alpha1
 kind: GrafanaAgent
 metadata:
-  name: metamonitoring-values-mimir-meta-monitoring
-  namespace: "citestns"
+  name: openshift-values-mimir-meta-monitoring
+  namespace: "citestns-monitoring"
   labels:
     app.kubernetes.io/name: mimir
-    app.kubernetes.io/instance: metamonitoring-values
+    app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: meta-monitoring
     app.kubernetes.io/managed-by: Helm
 spec:
-  serviceAccountName: metamonitoring-values-mimir-grafana-agent
+  serviceAccountName: openshift-values-mimir-grafana-agent
   containers:
     # The container specs here are merged with the ones in the operator using a strategic merge patch.
     - name: config-reloader
@@ -23,13 +23,13 @@ spec:
     labelSelector:
       matchLabels:
         app.kubernetes.io/name: mimir
-        app.kubernetes.io/instance: metamonitoring-values
+        app.kubernetes.io/instance: openshift-values
         app.kubernetes.io/component: meta-monitoring
   logs:
     instanceSelector:
       matchLabels:
         app.kubernetes.io/name: mimir
-        app.kubernetes.io/instance: metamonitoring-values
+        app.kubernetes.io/instance: openshift-values
         app.kubernetes.io/component: meta-monitoring
     # cluster label for logs is added in the LogsInstance
   metrics:
@@ -37,8 +37,8 @@ spec:
     instanceSelector:
       matchLabels:
         app.kubernetes.io/name: mimir
-        app.kubernetes.io/instance: metamonitoring-values
+        app.kubernetes.io/instance: openshift-values
         app.kubernetes.io/component: meta-monitoring
     externalLabels:
-      cluster: metamonitoring-values
+      cluster: openshift-values
 

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/logs-instance-usernames-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-values-mimir-logs-instance-usernames
+  namespace: "citestns-monitoring"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+data:
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/logs-instance.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/logs-instance.yaml
@@ -1,0 +1,22 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/logs-instance.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: LogsInstance
+metadata:
+  name: openshift-values-mimir-meta-monitoring
+  namespace: "citestns-monitoring"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+spec:
+
+  # Supply an empty namespace selector to look in all namespaces. Remove
+  # this to only look in the same namespace as the LogsInstance CR
+  podLogsNamespaceSelector: {}
+
+  podLogsSelector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: openshift-values

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/metrics-instance-usernames-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-values-mimir-metrics-instance-usernames
+  namespace: "citestns-monitoring"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+data:
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -1,0 +1,28 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: MetricsInstance
+metadata:
+  name: openshift-values-mimir-meta-monitoring
+  namespace: "citestns-monitoring"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+spec:
+  remoteWrite:
+      - url: http://openshift-values-mimir-gateway.citestns.svc:80/api/v1/push
+        headers:
+          X-Scope-OrgID: metamonitoring
+
+  # Supply an empty namespace selector to look in all namespaces. Remove
+  # this to only look in the same namespace as the MetricsInstance CR
+  serviceMonitorNamespaceSelector: {}
+
+  serviceMonitorSelector:
+    # Scrape ServiceMonitors from all components
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: openshift-values
+

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/pod-logs.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/metamonitoring/pod-logs.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/templates/metamonitoring/pod-logs.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: PodLogs
+metadata:
+  name: openshift-values-mimir-meta-monitoring
+  namespace: "citestns-monitoring"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: meta-monitoring
+    app.kubernetes.io/managed-by: Helm
+spec:
+  pipelineStages:
+    - cri: { }
+  relabelings:
+    - action: replace # For consistency with metrics
+      replacement: $1
+      separator: /
+      sourceLabels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_container_name
+      targetLabel: job
+    - action: replace # Necessary for slow queries dashboard
+      sourceLabels:
+        - __meta_kubernetes_pod_container_name
+      targetLabel: name
+    - targetLabel: cluster
+      replacement: "openshift-values"
+
+  namespaceSelector:
+    matchNames:
+      - "citestns"
+
+  selector:
+    matchLabels:
+      # Scrape logs from all components
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: openshift-values


### PR DESCRIPTION
#### What this PR does

The Grafana Agent meta-monitoring resources ran under the chart-wide ServiceAccount. That coupling has two downsides. The agent ClusterRole grants cluster-wide read on nodes, nodes/proxy, nodes/metrics, pods, endpoints, services, events and ingresses, and binding it to the shared account extends that reach to every Mimir component pod. It also means any account-level configuration the agent needs, such as IRSA or Workload Identity annotations for remote-write to a cloud endpoint or extra RoleBindings, has to be applied to the account the whole cluster shares.

Add metaMonitoring.grafanaAgent.serviceAccount following the existing ruler and alertmanager blocks, so the agent identity and its RBAC can drift from the generic one. It is opt-in and defaults to create: false, where the name helper falls back to mimir.serviceAccountName and rendering is unchanged.

Unlike the ruler account, this one is created in the namespace set by metaMonitoring.grafanaAgent.namespace. The GrafanaAgent CR and the ClusterRoleBinding subject already resolve that namespace, so the account has to exist where the agent pods run.

Give it the PSP/SCC access the agent has today through the shared account by rendering a Role and RoleBinding of its own in that same namespace, rather than by adding it as a subject of the chart-wide RoleBinding. PSP and SCC admission both authorize use against the pod's namespace, and a RoleBinding only grants its Role inside its own namespace, so a subject in the release-namespace binding would leave agent pods running elsewhere without the policy. The rules are now shared with the chart-wide Role through a mimir.rbac.podSecurityRules helper so that the two cannot drift.

Exercise the new resources from the OpenShift test values, the only ci values that render SCC, with the agent namespace deliberately set apart from the release namespace.

Document that name only takes effect when create is true. All three of these helpers discard a configured name and fall back to the chart-wide account when create is false, which was previously unstated, so note the constraint on the existing ruler and alertmanager values as well rather than only on the new ones.

#### Which issue(s) this PR fixes or relates to

Relates to #16127 discussion.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.