### PR TITLE
helm: support external memcached for object and results caches

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Set default memberlist `rejoin_interval` to 60s so that a member evicted from the gossip ring by a transient network fault periodically rejoins the cluster instead of staying isolated until restart. #16332
 * [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the Grafana Agent meta-monitoring resources by setting `metaMonitoring.grafanaAgent.serviceAccount.create` to true in the values. #16389
+* [FEATURE] Add support for pointing the chunks, index, metadata and results caches at an existing external memcached via the new `<cache>.addresses` value. When set, the chart configures Mimir to use those addresses and does not deploy the bundled memcached for that cache. #16396
 
 
 ## 6.2.0

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -194,19 +194,39 @@ Alertmanager cluster bind address
 {{- end -}}
 
 {{- define "mimir.chunksCacheAddress" -}}
-dnssrvnoa+{{ template "mimir.fullname" . }}-chunks-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "chunks-cache").port }}
+{{- $cache := index .Values "chunks-cache" -}}
+{{- if $cache.addresses -}}
+{{- tpl $cache.addresses . -}}
+{{- else -}}
+dnssrvnoa+{{ template "mimir.fullname" . }}-chunks-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ $cache.port }}
+{{- end -}}
 {{- end -}}
 
 {{- define "mimir.indexCacheAddress" -}}
-dnssrvnoa+{{ template "mimir.fullname" . }}-index-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "index-cache").port }}
+{{- $cache := index .Values "index-cache" -}}
+{{- if $cache.addresses -}}
+{{- tpl $cache.addresses . -}}
+{{- else -}}
+dnssrvnoa+{{ template "mimir.fullname" . }}-index-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ $cache.port }}
+{{- end -}}
 {{- end -}}
 
 {{- define "mimir.metadataCacheAddress" -}}
-dnssrvnoa+{{ template "mimir.fullname" . }}-metadata-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "metadata-cache").port }}
+{{- $cache := index .Values "metadata-cache" -}}
+{{- if $cache.addresses -}}
+{{- tpl $cache.addresses . -}}
+{{- else -}}
+dnssrvnoa+{{ template "mimir.fullname" . }}-metadata-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ $cache.port }}
+{{- end -}}
 {{- end -}}
 
 {{- define "mimir.resultsCacheAddress" -}}
-dnssrvnoa+{{ template "mimir.fullname" . }}-results-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "results-cache").port }}
+{{- $cache := index .Values "results-cache" -}}
+{{- if $cache.addresses -}}
+{{- tpl $cache.addresses . -}}
+{{- else -}}
+dnssrvnoa+{{ template "mimir.fullname" . }}-results-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ $cache.port }}
+{{- end -}}
 {{- end -}}
 
 {{- define "mimir.adminCacheAddress" -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -151,7 +151,7 @@ mimir:
     blocks_storage:
       backend: s3
       bucket_store:
-        {{- if index .Values "chunks-cache" "enabled" }}
+        {{- if or (index .Values "chunks-cache" "enabled") (index .Values "chunks-cache" "addresses") }}
         chunks_cache:
           backend: memcached
           memcached:
@@ -160,7 +160,7 @@ mimir:
             timeout: 750ms
             max_idle_connections: 150
         {{- end }}
-        {{- if index .Values "index-cache" "enabled" }}
+        {{- if or (index .Values "index-cache" "enabled") (index .Values "index-cache" "addresses") }}
         index_cache:
           backend: memcached
           memcached:
@@ -169,7 +169,7 @@ mimir:
             timeout: 750ms
             max_idle_connections: 150
         {{- end }}
-        {{- if index .Values "metadata-cache" "enabled" }}
+        {{- if or (index .Values "metadata-cache" "enabled") (index .Values "metadata-cache" "addresses") }}
         metadata_cache:
           backend: memcached
           memcached:
@@ -214,7 +214,7 @@ mimir:
 
     frontend:
       parallelize_shardable_queries: true
-      {{- if index .Values "results-cache" "enabled" }}
+      {{- if or (index .Values "results-cache" "enabled") (index .Values "results-cache" "addresses") }}
       results_cache:
         backend: memcached
         memcached:
@@ -297,7 +297,7 @@ mimir:
         address: dns:///{{ template "mimir.fullname" . }}-ruler-query-frontend.{{ .Release.Namespace }}.svc:{{ include "mimir.serverGrpcListenPort" .  }}
       {{- end }}
 
-    {{- if or (.Values.minio.enabled) (index .Values "metadata-cache" "enabled") }}
+    {{- if or (.Values.minio.enabled) (index .Values "metadata-cache" "enabled") (index .Values "metadata-cache" "addresses") }}
     ruler_storage:
       {{- if .Values.minio.enabled }}
       backend: s3
@@ -308,7 +308,7 @@ mimir:
         secret_access_key: {{ .Values.minio.rootPassword }}
         insecure: true
       {{- end }}
-      {{- if index .Values "metadata-cache" "enabled" }}
+      {{- if or (index .Values "metadata-cache" "enabled") (index .Values "metadata-cache" "addresses") }}
       cache:
         backend: memcached
         memcached:
@@ -2644,6 +2644,11 @@ chunks-cache:
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: false
 
+  # -- Comma-separated list of addresses of an existing memcached to use for the chunks-cache instead of the one bundled with the chart.
+  # When set, the chart does not deploy the bundled chunks-cache and Mimir is configured to use these addresses. Templated. Set enabled to false when using this.
+  # Example: "dns+chunks-cache.memcached.svc:11211"
+  addresses: ""
+
   # -- How long each pod must be ready for before the next one is started/restarted
   minReadySeconds: 60
 
@@ -2751,6 +2756,11 @@ chunks-cache:
 index-cache:
   # -- Specifies whether memcached based index-cache should be enabled
   enabled: false
+
+  # -- Comma-separated list of addresses of an existing memcached to use for the index-cache instead of the one bundled with the chart.
+  # When set, the chart does not deploy the bundled index-cache and Mimir is configured to use these addresses. Templated. Set enabled to false when using this.
+  # Example: "dns+index-cache.memcached.svc:11211"
+  addresses: ""
 
   # -- How long each pod must be ready for before the next one is started/restarted
   minReadySeconds: 60
@@ -2860,6 +2870,11 @@ metadata-cache:
   # -- Specifies whether memcached based metadata-cache should be enabled
   enabled: false
 
+  # -- Comma-separated list of addresses of an existing memcached to use for the metadata-cache instead of the one bundled with the chart.
+  # When set, the chart does not deploy the bundled metadata-cache and Mimir is configured to use these addresses. Templated. Set enabled to false when using this.
+  # Example: "dns+metadata-cache.memcached.svc:11211"
+  addresses: ""
+
   # -- How long each pod must be ready for before the next one is started/restarted
   minReadySeconds: 60
 
@@ -2967,6 +2982,11 @@ metadata-cache:
 results-cache:
   # -- Specifies whether memcached based results-cache should be enabled
   enabled: false
+
+  # -- Comma-separated list of addresses of an existing memcached to use for the results-cache instead of the one bundled with the chart.
+  # When set, the chart does not deploy the bundled results-cache and Mimir is configured to use these addresses. Templated. Set enabled to false when using this.
+  # Example: "dns+results-cache.memcached.svc:11211"
+  addresses: ""
 
   # -- How long each pod must be ready for before the next one is started/restarted
   minReadySeconds: 60


### PR DESCRIPTION
Adds a `<cache>.addresses` value so the mimir-distributed chart can point Mimir at an existing memcached instead of forcing you to run the bundled subcharts, closing #16324.

Today the only options for the chunks/index/metadata/results caches are to enable the bundled memcached subchart or to disable the cache entirely and hand-write the memcached config in `structuredConfig`. tempo-distributed already lets you supply an external address, so this mirrors that for Mimir.

Each cache block (`chunks-cache`, `index-cache`, `metadata-cache`, `results-cache`) gets a new `addresses` field, empty by default. When it is set, the cache address helper returns that value (templated, so you can reference other values), the relevant section of `mimir.config` is rendered, and the bundled memcached StatefulSet/Service/etc. for that cache is not deployed since those stay gated on `enabled`. Set `enabled: false` alongside `addresses` to use an external cluster.

Defaults are untouched: with `addresses` empty the helper falls back to the same `dnssrvnoa+...` bundled service address as before.

Testing: `helm lint` passes. Rendered the chart with default values and with `small.yaml` and diffed against the pristine chart, output is byte-identical, so nothing changes for existing users. With an override that sets `addresses` on all four caches and `enabled: false`, the rendered Mimir config carries the external addresses (`blocks_storage.bucket_store.*_cache`, `frontend.results_cache`, `ruler_storage.cache`) and no `*-cache` StatefulSets or Services are emitted. The existing `ci` values files do not set `addresses`, so the golden records are unaffected.