### PR TITLE
Upgrade Go to 1.26.6.

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           # We only use this to run `go mod` commands, so it doesn't need to follow the version used in the Dockerfile.
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           # Nothing worth caching from `go mod`, and it competes for the cache quota.
           cache: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
 * [BUGFIX] MQE: Fix an issue where series were joined in binary operations using the wrong labels when `group_left()`/`group_right()` were used in combination with `ignoring()`. This bug manifested as valid queries returning an error `grouping labels must ensure unique matches`. #16387
+* [BUGFIX] Upgrade Go to 1.26.6 to address [CVE-2026-33818](https://pkg.go.dev/vuln/GO-2026-5972), [CVE-2026-39821](https://pkg.go.dev/vuln/GO-2026-5026), [CVE-2026-46600](https://pkg.go.dev/vuln/GO-2026-5942), [CVE-2026-56853](https://pkg.go.dev/vuln/GO-2026-6089), [CVE-2026-56858](https://pkg.go.dev/vuln/GO-2026-6091), [CVE-2026-56859](https://pkg.go.dev/vuln/GO-2026-6088), [CVE-2026-56860](https://pkg.go.dev/vuln/GO-2026-6218), and [CVE-2026-56862](https://pkg.go.dev/vuln/GO-2026-6090). #16408
 
 ### Mixin
 

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr16416-0c50d283cd@sha256:846da8094ed1ab24df05e2a3346f27d35f96cafb30cbb410ae8572056e27c105
+LATEST_BUILD_IMAGE_TAG ?= pr16408-39e1f739d4@sha256:bddcbf1cb27071ea7ebb68478c4f5945c01de4c67dccf4e88704895f6ad9522a
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.k8s.io/kustomize/kustomize:v5.4.3 AS kustomize
 FROM alpine/helm:4.2.3@sha256:b97ba4f9b27fe7af16ee3d37e6815783c9d4a51289b6240a9024ec471611ae9b AS helm
 FROM quay.io/skopeo/stable:v1.22.2-immutable@sha256:4a16d57b37617a04b3d643079a477a2848efe892dffcdf0ce56df4262b65f810 AS skopeo
-FROM golang:1.26.5-trixie@sha256:117e07f49461abb984fc8aef661432461ff43d06faa22c3b73af6a49ce325cb9
+FROM golang:1.26.6-trixie@sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 # Override toolchain directive in go.mod, to ensure the image's Go version is used.


### PR DESCRIPTION
#### What this PR does

Addresses 8 stdlib CVEs present in Go 1.26.5: 

- CVE-2026-33818 (encoding/asn1)
- CVE-2026-39821 (net/http)
- CVE-2026-46600 (net)
- CVE-2026-56853 (net/http)
- CVE-2026-56858 (html/template)
- CVE-2026-56859 (encoding/xml)
- CVE-2026-56860 (net/url)
- CVE-2026-56862 (crypto/tls)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
