### PR TITLE
ci: bump create-github-app-token to 0.3.1

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: mimir-github-bot
 


### PR DESCRIPTION
#### What this PR does

Following https://github.com/grafana/mimir/pull/15385

This PR bumps the `create-github-app-token` CI action in the backport workflow.

Also, as it's turned out, this was a blind-spot in our renovate setup. That is, renovate needs a `<action-name>/v<semver>` pragma comment in order to resolve the dependency (ref [renovate config][1]). The "backport" CI workflow didn't have one, so renovate didn't propose an auto-update here for the past several months.

[1]: https://github.com/grafana/mimir/blob/7c08a8993d378f8ba33e2b9e530c662c20a669b4/renovate.json5#L199-L213