### PR TITLE
chore(scripts): use env for bash/sh shebangs in dev and CI scripts

### DIFF
--- a/.github/workflows/scripts/install-docker.sh
+++ b/.github/workflows/scripts/install-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -x

--- a/.github/workflows/scripts/install-gh.sh
+++ b/.github/workflows/scripts/install-gh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -o errexit

--- a/.github/workflows/scripts/run-integration-tests-group.sh
+++ b/.github/workflows/scripts/run-integration-tests-group.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 set -o pipefail
 

--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 set -o pipefail
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Block-builder-scheduler: Fail startup instead of silently switching to normal operation without assigning any jobs when probing the initial consumption offsets fails. #16028
 * [BUGFIX] Querier: Return HTTP 413 instead of 500 from the cardinality `label_names` and `label_values` endpoints when the merged response exceeds `-querier.label-names-and-values-results-max-size-bytes`. #16452
 * [BUGFIX] Querier: Return HTTP 413 instead of 500 from the active series endpoint's framed response format when a single series' JSON exceeds the maximum frame size. #16452
+* [BUGFIX] Build: Use `#!/usr/bin/env bash`/`#!/usr/bin/env sh` instead of hardcoded interpreter paths in development and CI scripts, fixing failures on systems where those interpreters aren't at that exact path, such as NixOS. #16425
 
 ### Mixin
 

--- a/development/mimir-compartments/compose-down.sh
+++ b/development/mimir-compartments/compose-down.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # newer compose is a subcommand of `docker`, not a hyphenated standalone command

--- a/development/mimir-compartments/compose-up.sh
+++ b/development/mimir-compartments/compose-up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/development/mimir-ingest-storage/compose-down.sh
+++ b/development/mimir-ingest-storage/compose-down.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # newer compose is a subcommand of `docker`, not a hyphenated standalone command

--- a/development/mimir-ingest-storage/compose-up.sh
+++ b/development/mimir-ingest-storage/compose-up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/development/mimir-ingest-storage/compose-update-mimir.sh
+++ b/development/mimir-ingest-storage/compose-update-mimir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/development/mimir-microservices-mode/compose-down.sh
+++ b/development/mimir-microservices-mode/compose-down.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/development/tsdb-blocks-storage-s3/compose-down.sh
 # Provenance-includes-license: Apache-2.0

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/development/tsdb-blocks-storage-s3/compose-up.sh
 # Provenance-includes-license: Apache-2.0

--- a/development/mimir-microservices-mode/ruler.sh
+++ b/development/mimir-microservices-mode/ruler.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # SPDX-License-Identifier: AGPL-3.0-only
 
 export MIMIR_ADDRESS=http://localhost:8022/

--- a/development/mimir-monolithic-mode-with-swift-storage/compose-down.sh
+++ b/development/mimir-monolithic-mode-with-swift-storage/compose-down.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/development/tsdb-blocks-storage-swift-single-binary/compose-down.sh
 # Provenance-includes-license: Apache-2.0

--- a/development/mimir-monolithic-mode-with-swift-storage/compose-up.sh
+++ b/development/mimir-monolithic-mode-with-swift-storage/compose-up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/development/tsdb-blocks-storage-swift-single-binary/compose-up.sh
 # Provenance-includes-license: Apache-2.0

--- a/operations/compare-helm-with-jsonnet/compare-helm-with-jsonnet.sh
+++ b/operations/compare-helm-with-jsonnet/compare-helm-with-jsonnet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/operations/compare-helm-with-jsonnet/compare-kustomize-outputs.sh
+++ b/operations/compare-helm-with-jsonnet/compare-kustomize-outputs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/operations/compare-helm-with-jsonnet/plugins/k8s-defaults.sh
+++ b/operations/compare-helm-with-jsonnet/plugins/k8s-defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # Here we use kubectl's server-side dry run feature to apply all k8s default values

--- a/operations/compare-helm-with-jsonnet/plugins/resolve-config/run.sh
+++ b/operations/compare-helm-with-jsonnet/plugins/resolve-config/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 cd "$(dirname "$0")"

--- a/operations/helm/charts/mimir-distributed/scripts/recreate-templates
+++ b/operations/helm/charts/mimir-distributed/scripts/recreate-templates
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 declare -A COMPONENTARGS
 COMPONENTARGS["admin-api"]="-e -g"

--- a/operations/helm/scripts/run-conftest.sh
+++ b/operations/helm/scripts/run-conftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/operations/helm/scripts/update-helm-dependencies.sh
+++ b/operations/helm/scripts/update-helm-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/operations/mimir-tests/run-conftest.sh
+++ b/operations/mimir-tests/run-conftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e

--- a/tools/migrate-ingester-statefulsets.sh
+++ b/tools/migrate-ingester-statefulsets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/tools/migrate-ingester-statefulsets.sh
 # Provenance-includes-license: Apache-2.0

--- a/tools/release/check-changelog.sh
+++ b/tools/release/check-changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/tools/release/check-changelog.sh
 # Provenance-includes-license: Apache-2.0


### PR DESCRIPTION
## What's Changed

- use `#!/usr/bin/env bash` or `#!/usr/bin/env sh` instead of hardcoded interpreter paths
- fixes `bad interpreter` failures on systems without `/bin/bash`, e.g. NixOS
- covers development compose scripts, CI workflow scripts, and operations tooling scripts
- leaves scripts unchanged that only run inside built container images or as packaging maintainer scripts
- I've never seen this change introduce a problem in other projects. 