### PR TITLE
upgrade depedencies, CI is blocked with previous version

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   call-update-helm-repo:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@0cb44b98b41df1bc345376ac40897453fa88df93 # main
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@657512bfa4b278832766f91e69807e6ef99cfe33 # main
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
#### What this PR does

CI is failing, because an older version of `create-github-app-token` is [used](https://github.com/grafana/helm-charts/blob/0cb44b98b41df1bc345376ac40897453fa88df93/.github/workflows/update-helm-repo.yaml#L120) and is blocked at the org level. See this CI run: https://github.com/grafana/mimir/actions/runs/32369954900

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
