### PR TITLE
Use strings.SplitSeq where possible

### DIFF
--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -61,7 +61,7 @@ func assertServiceMetricsPrefixes(t *testing.T, serviceType ServiceType, service
 	blacklist := getBlacklistedMetricsPrefixesByService(serviceType)
 
 	// Ensure no metric name matches the blacklisted prefixes.
-	for _, metricLine := range strings.Split(metrics, "\n") {
+	for metricLine := range strings.SplitSeq(metrics, "\n") {
 		metricLine = strings.TrimSpace(metricLine)
 		if metricLine == "" || strings.HasPrefix(metricLine, "#") {
 			continue
@@ -131,7 +131,7 @@ func isRawMetricsContainingMetricName(metricName string, metrics string) bool {
 	metricNameRegex := regexp.MustCompile("^[^ \\{]+")
 
 	// Ensure no metric name matches the input one.
-	for _, metricLine := range strings.Split(metrics, "\n") {
+	for metricLine := range strings.SplitSeq(metrics, "\n") {
 		metricLine = strings.TrimSpace(metricLine)
 		if metricLine == "" || strings.HasPrefix(metricLine, "#") {
 			continue

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -412,8 +412,9 @@ func TestRateLimitedReader(t *testing.T) {
 
 // requireLineContaining requires that some line in the output contains all the given substrings.
 func requireLineContaining(t *testing.T, output string, substrs ...string) {
+	lines := strings.SplitSeq(output, "\n")
 linesLoop:
-	for line := range strings.SplitSeq(output, "\n") {
+	for line := range lines {
 		for _, substr := range substrs {
 			if !strings.Contains(line, substr) {
 				continue linesLoop

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -412,9 +412,8 @@ func TestRateLimitedReader(t *testing.T) {
 
 // requireLineContaining requires that some line in the output contains all the given substrings.
 func requireLineContaining(t *testing.T, output string, substrs ...string) {
-	lines := strings.Split(output, "\n")
 linesLoop:
-	for _, line := range lines {
+	for line := range strings.SplitSeq(output, "\n") {
 		for _, substr := range substrs {
 			if !strings.Contains(line, substr) {
 				continue linesLoop

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -380,7 +380,7 @@ func parsePreviousImageVersionOverrides(env string, logger testingLogger) (map[s
 	overrides := map[string]e2emimir.FlagMapper{}
 	if strings.TrimSpace(env)[0] != '{' {
 		logger.Logf("Overriding previous images with comma separated image names: %s", env)
-		for _, image := range strings.Split(env, ",") {
+		for image := range strings.SplitSeq(env, ",") {
 			overrides[image] = e2emimir.NoopFlagMapper
 		}
 		return overrides, nil

--- a/pkg/alertmanager/alertmanager_config_test.go
+++ b/pkg/alertmanager/alertmanager_config_test.go
@@ -147,9 +147,10 @@ inhibit_rules:
 		t.Run(test.name, func(t *testing.T) {
 			buf := bytes.Buffer{}
 			validateMatchersInConfigDesc(log.NewLogfmtLogger(&buf), "test", test.config)
+			allLines := strings.SplitSeq(strings.Trim(buf.String(), "\n"), "\n")
 			// Filter out the SlogFromGoKit probe line.
 			var lines []string
-			for l := range strings.SplitSeq(strings.Trim(buf.String(), "\n"), "\n") {
+			for l := range allLines {
 				if !strings.Contains(l, "probe=") {
 					lines = append(lines, stripSlogFields(l))
 				}

--- a/pkg/alertmanager/alertmanager_config_test.go
+++ b/pkg/alertmanager/alertmanager_config_test.go
@@ -147,10 +147,9 @@ inhibit_rules:
 		t.Run(test.name, func(t *testing.T) {
 			buf := bytes.Buffer{}
 			validateMatchersInConfigDesc(log.NewLogfmtLogger(&buf), "test", test.config)
-			allLines := strings.Split(strings.Trim(buf.String(), "\n"), "\n")
 			// Filter out the SlogFromGoKit probe line.
 			var lines []string
-			for _, l := range allLines {
+			for l := range strings.SplitSeq(strings.Trim(buf.String(), "\n"), "\n") {
 				if !strings.Contains(l, "probe=") {
 					lines = append(lines, stripSlogFields(l))
 				}

--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -261,9 +261,10 @@ func parseLaneRequests(configuredLanes flagext.StringSliceCSV) ([][]*compactorsc
 			return nil, fmt.Errorf("invalid lane configuration: %q", workerLane)
 		}
 		laneCount := strings.Count(workerLane, "+") + 1
+		split := strings.SplitSeq(workerLane, "+")
 		requests := make([]*compactorschedulerpb.LaneRequest, 0, laneCount)
 		seen := make(map[string]struct{}, laneCount)
-		for lane := range strings.SplitSeq(workerLane, "+") {
+		for lane := range split {
 			if _, ok := seen[lane]; ok {
 				return nil, fmt.Errorf("duplicate job type %q in lane configuration: %q", lane, workerLane)
 			}

--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -260,10 +260,10 @@ func parseLaneRequests(configuredLanes flagext.StringSliceCSV) ([][]*compactorsc
 		if workerLane == "" {
 			return nil, fmt.Errorf("invalid lane configuration: %q", workerLane)
 		}
-		split := strings.Split(workerLane, "+")
-		requests := make([]*compactorschedulerpb.LaneRequest, 0, len(split))
-		seen := make(map[string]struct{}, len(split))
-		for _, lane := range split {
+		laneCount := strings.Count(workerLane, "+") + 1
+		requests := make([]*compactorschedulerpb.LaneRequest, 0, laneCount)
+		seen := make(map[string]struct{}, laneCount)
+		for lane := range strings.SplitSeq(workerLane, "+") {
 			if _, ok := seen[lane]; ok {
 				return nil, fmt.Errorf("duplicate job type %q in lane configuration: %q", lane, workerLane)
 			}

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -1128,7 +1128,7 @@ func TestHandler_QueryStringLoggedLast(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
 	var sawSlowQuery, sawQueryStats bool
-	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(logs.String()), "\n") {
 		switch {
 		case strings.Contains(line, `msg="slow query detected"`):
 			sawSlowQuery = true

--- a/pkg/ingester/activeseries/model/custom_trackers_config.go
+++ b/pkg/ingester/activeseries/model/custom_trackers_config.go
@@ -134,8 +134,9 @@ func (c *CustomTrackersConfig) Set(s string) error {
 
 func customTrackerFlagValueToMap(s string) (map[string]string, error) {
 	source := map[string]string{}
+	pairs := strings.SplitSeq(s, ";")
 	i := 0
-	for p := range strings.SplitSeq(s, ";") {
+	for p := range pairs {
 		split := strings.SplitN(p, ":", 2)
 		if len(split) != 2 {
 			return nil, fmt.Errorf("value should be <name>:<matcher>[;<name>:<matcher>]*, but colon was not found in the value %d: %q", i, p)

--- a/pkg/ingester/activeseries/model/custom_trackers_config.go
+++ b/pkg/ingester/activeseries/model/custom_trackers_config.go
@@ -134,8 +134,8 @@ func (c *CustomTrackersConfig) Set(s string) error {
 
 func customTrackerFlagValueToMap(s string) (map[string]string, error) {
 	source := map[string]string{}
-	pairs := strings.Split(s, ";")
-	for i, p := range pairs {
+	i := 0
+	for p := range strings.SplitSeq(s, ";") {
 		split := strings.SplitN(p, ":", 2)
 		if len(split) != 2 {
 			return nil, fmt.Errorf("value should be <name>:<matcher>[;<name>:<matcher>]*, but colon was not found in the value %d: %q", i, p)
@@ -148,6 +148,7 @@ func customTrackerFlagValueToMap(s string) (map[string]string, error) {
 			return nil, fmt.Errorf("matcher %q for active series custom trackers is provided twice", name)
 		}
 		source[name] = matcher
+		i++
 	}
 	return source, nil
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -305,7 +305,7 @@ func (cfg *Config) getIgnoreSeriesLimitForMetricNamesMap() map[string]struct{} {
 
 	result := map[string]struct{}{}
 
-	for _, s := range strings.Split(cfg.IgnoreSeriesLimitForMetricNames, ",") {
+	for s := range strings.SplitSeq(cfg.IgnoreSeriesLimitForMetricNames, ",") {
 		tr := strings.TrimSpace(s)
 		if tr != "" {
 			result[tr] = struct{}{}

--- a/pkg/ingester/lookupplan/testing/benchmarks_test.go
+++ b/pkg/ingester/lookupplan/testing/benchmarks_test.go
@@ -227,9 +227,10 @@ func parseQueryIDs(queryIDsStr string) ([]int, error) {
 		return nil, nil
 	}
 
+	parts := strings.SplitSeq(queryIDsStr, ",")
 	queryIDs := make([]int, 0, strings.Count(queryIDsStr, ",")+1)
 
-	for part := range strings.SplitSeq(queryIDsStr, ",") {
+	for part := range parts {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue

--- a/pkg/ingester/lookupplan/testing/benchmarks_test.go
+++ b/pkg/ingester/lookupplan/testing/benchmarks_test.go
@@ -227,10 +227,9 @@ func parseQueryIDs(queryIDsStr string) ([]int, error) {
 		return nil, nil
 	}
 
-	parts := strings.Split(queryIDsStr, ",")
-	queryIDs := make([]int, 0, len(parts))
+	queryIDs := make([]int, 0, strings.Count(queryIDsStr, ",")+1)
 
-	for _, part := range parts {
+	for part := range strings.SplitSeq(queryIDsStr, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue

--- a/pkg/labelaccess/propagation.go
+++ b/pkg/labelaccess/propagation.go
@@ -149,7 +149,7 @@ func ExtractLabelMatchersSlice(values []string) (LabelPolicySet, error) {
 	// Iterate through each set header value
 	for _, headerValue := range values {
 		// Split the header value on a comma and iterate through each policy.
-		for _, v := range strings.Split(headerValue, ",") {
+		for v := range strings.SplitSeq(headerValue, ",") {
 			instanceName, policy, err := policyFromHeaderValue(v)
 			if err != nil {
 				return nil, err

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -329,9 +329,9 @@ func (a *AlertCommand) verifyConfig(logger log.Logger) error {
 	var empty interface{}
 	if a.IgnoreString != "" {
 		a.IgnoreAlerts = make(map[string]interface{})
-		chunks := strings.Split(a.IgnoreString, ",")
+		chunks := strings.SplitSeq(a.IgnoreString, ",")
 
-		for _, name := range chunks {
+		for name := range chunks {
 			a.IgnoreAlerts[name] = empty
 			level.Info(logger).Log("msg", "Ignoring alerts with name", "name", name)
 		}

--- a/pkg/mimirtool/commands/config.go
+++ b/pkg/mimirtool/commands/config.go
@@ -92,7 +92,7 @@ func (c *ConfigCommand) prepareInputs() ([]byte, []string, error) {
 		return nil, nil, errors.Wrap(err, "could not read flags-file")
 	}
 	if len(flagsContents) > 1 {
-		for _, flag := range strings.Split(string(flagsContents), "\n") {
+		for flag := range strings.SplitSeq(string(flagsContents), "\n") {
 			flag = strings.TrimSpace(flag)
 			if len(flag) > 0 {
 				flags = append(flags, flag)

--- a/pkg/mimirtool/commands/partition_ring.go
+++ b/pkg/mimirtool/commands/partition_ring.go
@@ -322,7 +322,7 @@ func parsePartitionState(stateStr string) (ring.PartitionState, error) {
 func parsePartitionIDs(input string) ([]int32, error) {
 	seen := map[int32]struct{}{}
 	var ids []int32
-	for _, s := range strings.Split(input, ",") {
+	for s := range strings.SplitSeq(input, ",") {
 		s = strings.TrimSpace(s)
 		if s == "" {
 			continue
@@ -714,7 +714,7 @@ func removeAllOwnersAndPartitions(ctx context.Context, kvClient kv.Client, ringK
 func parseOwnerIDs(input string) ([]string, error) {
 	seen := map[string]struct{}{}
 	var ids []string
-	for _, s := range strings.Split(input, ",") {
+	for s := range strings.SplitSeq(input, ",") {
 		s = strings.TrimSpace(s)
 		if s == "" {
 			continue

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -464,7 +464,7 @@ func (c *RemoteReadCommand) stats(_ *kingpin.ParseContext) error {
 		return err
 	}
 
-	for _, line := range strings.Split(output.String(), "\n") {
+	for line := range strings.SplitSeq(output.String(), "\n") {
 		if len(line) != 0 {
 			level.Info(c.logger).Log("msg", line)
 		}

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -335,7 +335,7 @@ func (r *RuleCommand) setupArgs() error {
 	// Set up ignored namespaces map for sync/diff command
 	if r.IgnoredNamespaces != "" {
 		r.ignoredNamespacesMap = map[string]struct{}{}
-		for _, ns := range strings.Split(r.IgnoredNamespaces, ",") {
+		for ns := range strings.SplitSeq(r.IgnoredNamespaces, ",") {
 			if ns != "" {
 				r.ignoredNamespacesMap[ns] = struct{}{}
 			}
@@ -345,7 +345,7 @@ func (r *RuleCommand) setupArgs() error {
 	// Set up allowed namespaces map for sync/diff command
 	if r.Namespaces != "" {
 		r.namespacesMap = map[string]struct{}{}
-		for _, ns := range strings.Split(r.Namespaces, ",") {
+		for ns := range strings.SplitSeq(r.Namespaces, ",") {
 			if ns != "" {
 				r.namespacesMap[ns] = struct{}{}
 			}
@@ -354,13 +354,13 @@ func (r *RuleCommand) setupArgs() error {
 
 	// Set up rule groups excluded from label aggregation.
 	r.aggregationLabelExcludedRuleGroupsList = map[string]struct{}{}
-	for _, name := range strings.Split(r.AggregationLabelExcludedRuleGroups, ",") {
+	for name := range strings.SplitSeq(r.AggregationLabelExcludedRuleGroups, ",") {
 		if name = strings.TrimSpace(name); name != "" {
 			r.aggregationLabelExcludedRuleGroupsList[name] = struct{}{}
 		}
 	}
 
-	for _, dir := range strings.Split(r.RuleFilesPath, ",") {
+	for dir := range strings.SplitSeq(r.RuleFilesPath, ",") {
 		if dir != "" {
 			err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 				if err != nil {

--- a/pkg/mimirtool/printer/printer.go
+++ b/pkg/mimirtool/printer/printer.go
@@ -158,14 +158,12 @@ func (p *Printer) PrintComparisonResult(results []rules.NamespaceChange, verbose
 				// Print the full diff of the rules if verbose is set
 				if verbose {
 					newYaml, _ := yaml.Marshal(c.New)
-					separated := strings.Split(string(newYaml), "\n")
-					for _, l := range separated {
+					for l := range strings.SplitSeq(string(newYaml), "\n") {
 						p.Printf("[green]+ %v\n", l)
 					}
 
 					oldYaml, _ := yaml.Marshal(c.Original)
-					separated = strings.Split(string(oldYaml), "\n")
-					for _, l := range separated {
+					for l := range strings.SplitSeq(string(oldYaml), "\n") {
 						p.Printf("[red]- %v\n", l)
 					}
 				}

--- a/pkg/mimirtool/printer/printer.go
+++ b/pkg/mimirtool/printer/printer.go
@@ -158,12 +158,14 @@ func (p *Printer) PrintComparisonResult(results []rules.NamespaceChange, verbose
 				// Print the full diff of the rules if verbose is set
 				if verbose {
 					newYaml, _ := yaml.Marshal(c.New)
-					for l := range strings.SplitSeq(string(newYaml), "\n") {
+					separated := strings.SplitSeq(string(newYaml), "\n")
+					for l := range separated {
 						p.Printf("[green]+ %v\n", l)
 					}
 
 					oldYaml, _ := yaml.Marshal(c.Original)
-					for l := range strings.SplitSeq(string(oldYaml), "\n") {
+					separated = strings.SplitSeq(string(oldYaml), "\n")
+					for l := range separated {
 						p.Printf("[red]- %v\n", l)
 					}
 				}

--- a/pkg/mimirtool/rules/compare.go
+++ b/pkg/mimirtool/rules/compare.go
@@ -304,14 +304,12 @@ func PrintComparisonResult(results []NamespaceChange, verbose bool) error {
 				// Print the full diff of the rules if verbose is set
 				if verbose {
 					newYaml, _ := yaml.Marshal(c.New)
-					separated := strings.Split(string(newYaml), "\n")
-					for _, l := range separated {
+					for l := range strings.SplitSeq(string(newYaml), "\n") {
 						colorstring.Printf("[green]+ %v\n", l)
 					}
 
 					oldYaml, _ := yaml.Marshal(c.Original)
-					separated = strings.Split(string(oldYaml), "\n")
-					for _, l := range separated {
+					for l := range strings.SplitSeq(string(oldYaml), "\n") {
 						colorstring.Printf("[red]- %v\n", l)
 					}
 				}

--- a/pkg/mimirtool/rules/compare.go
+++ b/pkg/mimirtool/rules/compare.go
@@ -304,12 +304,14 @@ func PrintComparisonResult(results []NamespaceChange, verbose bool) error {
 				// Print the full diff of the rules if verbose is set
 				if verbose {
 					newYaml, _ := yaml.Marshal(c.New)
-					for l := range strings.SplitSeq(string(newYaml), "\n") {
+					separated := strings.SplitSeq(string(newYaml), "\n")
+					for l := range separated {
 						colorstring.Printf("[green]+ %v\n", l)
 					}
 
 					oldYaml, _ := yaml.Marshal(c.Original)
-					for l := range strings.SplitSeq(string(oldYaml), "\n") {
+					separated = strings.SplitSeq(string(oldYaml), "\n")
+					for l := range separated {
 						colorstring.Printf("[red]- %v\n", l)
 					}
 				}

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -433,8 +433,9 @@ func (p EncodedOffsets) lookupV2(readCompartment int, partitionID int32) (kmeta.
 
 	// Parse the ";"-separated per-Kafka-cluster offsets.
 	serializedOffsets := string(p[start:end])
+	parts := strings.SplitSeq(serializedOffsets, ";")
 	clusterOffsets := make([]int64, 0, strings.Count(serializedOffsets, ";")+1)
-	for part := range strings.SplitSeq(serializedOffsets, ";") {
+	for part := range parts {
 		offset, err := strconv.ParseInt(part, 10, 64)
 		if err != nil {
 			return kmeta.PartitionOffsets{}, false

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -432,9 +432,9 @@ func (p EncodedOffsets) lookupV2(readCompartment int, partitionID int32) (kmeta.
 	}
 
 	// Parse the ";"-separated per-Kafka-cluster offsets.
-	parts := strings.Split(string(p[start:end]), ";")
-	clusterOffsets := make([]int64, 0, len(parts))
-	for _, part := range parts {
+	serializedOffsets := string(p[start:end])
+	clusterOffsets := make([]int64, 0, strings.Count(serializedOffsets, ";")+1)
+	for part := range strings.SplitSeq(serializedOffsets, ";") {
 		offset, err := strconv.ParseInt(part, 10, 64)
 		if err != nil {
 			return kmeta.PartitionOffsets{}, false

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -138,9 +138,8 @@ func (d *DurationList) String() string {
 
 // Set implements the flag.Value interface
 func (d *DurationList) Set(s string) error {
-	values := strings.Split(s, ",")
-	*d = make([]time.Duration, 0, len(values)) // flag.Parse may be called twice, so overwrite instead of append
-	for _, v := range values {
+	*d = make([]time.Duration, 0, strings.Count(s, ",")+1) // flag.Parse may be called twice, so overwrite instead of append
+	for v := range strings.SplitSeq(s, ",") {
 		t, err := time.ParseDuration(v)
 		if err != nil {
 			return err

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -138,8 +138,9 @@ func (d *DurationList) String() string {
 
 // Set implements the flag.Value interface
 func (d *DurationList) Set(s string) error {
+	values := strings.SplitSeq(s, ",")
 	*d = make([]time.Duration, 0, strings.Count(s, ",")+1) // flag.Parse may be called twice, so overwrite instead of append
-	for v := range strings.SplitSeq(s, ",") {
+	for v := range values {
 		t, err := time.ParseDuration(v)
 		if err != nil {
 			return err

--- a/pkg/util/gziphandler/gzip.go
+++ b/pkg/util/gziphandler/gzip.go
@@ -527,7 +527,7 @@ func parseEncodings(s string) (codings, error) {
 	c := make(codings)
 	var e []string
 
-	for _, ss := range strings.Split(s, ",") {
+	for ss := range strings.SplitSeq(s, ",") {
 		coding, qvalue, err := parseCoding(ss)
 
 		if err != nil {
@@ -550,7 +550,8 @@ func parseEncodings(s string) (codings, error) {
 // as might appear in an Accept-Encoding header. It attempts to forgive minor
 // formatting errors.
 func parseCoding(s string) (coding string, qvalue float64, err error) {
-	for n, part := range strings.Split(s, ";") {
+	n := 0
+	for part := range strings.SplitSeq(s, ";") {
 		part = strings.TrimSpace(part)
 		qvalue = DefaultQValue
 
@@ -565,6 +566,7 @@ func parseCoding(s string) (coding string, qvalue float64, err error) {
 				qvalue = 1.0
 			}
 		}
+		n++
 	}
 
 	if coding == "" {

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -275,7 +275,7 @@ func parseDocTag(f reflect.StructField) map[string]string {
 		return cfg
 	}
 
-	for _, entry := range strings.Split(tag, "|") {
+	for entry := range strings.SplitSeq(tag, "|") {
 		parts := strings.SplitN(entry, "=", 2)
 
 		switch len(parts) {

--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -337,9 +337,9 @@ func (a *app) runBenchmark(b benchmark, printBenchmarkHeader bool) error {
 	}
 
 	usage := cmd.ProcessState.SysUsage().(*syscall.Rusage)
-	outputLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	outputLines := strings.SplitSeq(strings.TrimSpace(buf.String()), "\n")
 
-	for _, l := range outputLines {
+	for l := range outputLines {
 		isBenchmarkHeaderLine := strings.HasPrefix(l, "goos") || strings.HasPrefix(l, "goarch") || strings.HasPrefix(l, "pkg") || strings.HasPrefix(l, "cpu")
 		isBenchmarkLine := strings.HasPrefix(l, benchmarkName)
 		isPassLine := l == "PASS"

--- a/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
+++ b/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
@@ -127,10 +127,12 @@ func getAllTests(testFile string) ([]disabledTest, error) {
 		return nil, err
 	}
 
+	fileContents := string(fileBytes)
+	lines := strings.SplitSeq(fileContents, "\n")
 	var disabledTests []disabledTest
 
 	lineNumber := 0
-	for line := range strings.SplitSeq(string(fileBytes), "\n") {
+	for line := range lines {
 		lineNumber++
 		if !strings.HasPrefix(line, "eval") {
 			continue

--- a/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
+++ b/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
@@ -127,18 +127,17 @@ func getAllTests(testFile string) ([]disabledTest, error) {
 		return nil, err
 	}
 
-	fileContents := string(fileBytes)
-	lines := strings.Split(fileContents, "\n")
 	var disabledTests []disabledTest
 
-	for lineIdx, line := range lines {
+	lineNumber := 0
+	for line := range strings.SplitSeq(string(fileBytes), "\n") {
+		lineNumber++
 		if !strings.HasPrefix(line, "eval") {
 			continue
 		}
 
-		testLineNumber := lineIdx + 1
 		testLine := strings.TrimSpace(strings.TrimPrefix(line, "#"))
-		test, err := parseDisabledTest(testLine, testLineNumber)
+		test, err := parseDisabledTest(testLine, lineNumber)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -651,7 +651,7 @@ func parseDocTag(f reflect.StructField) map[string]string {
 		return cfg
 	}
 
-	for _, entry := range strings.Split(tag, "|") {
+	for entry := range strings.SplitSeq(tag, "|") {
 		parts := strings.SplitN(entry, "=", 2)
 
 		switch len(parts) {

--- a/tools/doc-generator/write/writer.go
+++ b/tools/doc-generator/write/writer.go
@@ -162,13 +162,14 @@ func (w *specWriter) writeExample(example *parse.FieldExample, indent int) {
 }
 
 func (w *specWriter) writeWrappedString(s string, firstLineIndent, continuationIndent, innerIndent int) {
-	lines := strings.Split(strings.TrimSpace(s), "\n")
-	for i, line := range lines {
+	firstLine := true
+	for line := range strings.SplitSeq(strings.TrimSpace(s), "\n") {
 		indent := firstLineIndent
-		if i > 0 {
+		if !firstLine {
 			indent = continuationIndent
 		}
 		w.out.WriteString(pad(indent) + "# " + pad(innerIndent) + line + "\n")
+		firstLine = false
 	}
 }
 

--- a/tools/doc-generator/write/writer.go
+++ b/tools/doc-generator/write/writer.go
@@ -162,8 +162,9 @@ func (w *specWriter) writeExample(example *parse.FieldExample, indent int) {
 }
 
 func (w *specWriter) writeWrappedString(s string, firstLineIndent, continuationIndent, innerIndent int) {
+	lines := strings.SplitSeq(strings.TrimSpace(s), "\n")
 	firstLine := true
-	for line := range strings.SplitSeq(strings.TrimSpace(s), "\n") {
+	for line := range lines {
 		indent := firstLineIndent
 		if !firstLine {
 			indent = continuationIndent

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -263,9 +263,9 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 	}
 
 	// Parse the backend endpoints (comma separated).
-	parts := strings.Split(cfg.BackendEndpoints, ",")
-
-	for idx, part := range parts {
+	idx := -1
+	for part := range strings.SplitSeq(cfg.BackendEndpoints, ",") {
+		idx++
 		// Skip empty ones.
 		part = strings.TrimSpace(part)
 		if part == "" {

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -263,8 +263,9 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 	}
 
 	// Parse the backend endpoints (comma separated).
+	parts := strings.SplitSeq(cfg.BackendEndpoints, ",")
 	idx := -1
-	for part := range strings.SplitSeq(cfg.BackendEndpoints, ",") {
+	for part := range parts {
 		idx++
 		// Skip empty ones.
 		part = strings.TrimSpace(part)

--- a/tools/tsdb-index-header/main.go
+++ b/tools/tsdb-index-header/main.go
@@ -107,8 +107,8 @@ func main() {
 
 	// Analyze specific labels if requested.
 	if *analyzeLabels != "" {
-		labelNames := strings.Split(*analyzeLabels, ",")
-		for _, labelName := range labelNames {
+		labelNames := strings.SplitSeq(*analyzeLabels, ",")
+		for labelName := range labelNames {
 			labelName = strings.TrimSpace(labelName)
 			if labelName == "" {
 				continue


### PR DESCRIPTION
#### What this PR does

- Replaces eligible calls to strings.Split with strings.SplitSeq when consumers only iterate over the results.
- Preserves slice-producing calls where indexing, mutation, joining, variadic expansion, or slice-based APIs require them.
- Avoids intermediate slice allocations on the affected paths.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated — existing tests cover this mechanical refactor.
- [ ] Documentation added — not needed for this internal implementation change.
- [ ] CHANGELOG.md updated — not needed for this internal implementation change.
- [ ] about-versioning.md updated with experimental features — not applicable.

#### Validation

- make format
- Compile-only Go tests across every affected package, including integration
- Targeted and full package tests for affected behavior