### PR TITLE
Update rollout-operator in helm/jsonnet to v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 * [CHANGE] Memberlist: Set the default `-memberlist.rejoin-interval` to 60s in Jsonnet configurations. #16332
 * [ENHANCEMENT] Add `multi_zone_ingester_zpdb_cross_zone_eviction_delay` config option to set `crossZoneEvictionDelay` on the ingester `ZoneAwarePodDisruptionBudget`. Defaults to `20m` when `ingest_storage_enabled` is true, and to unset otherwise. #16271
 * [ENHANCEMENT] Compactor: Allow the drain autoscaler's speed estimates to be read from recording rules. #16283
-* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.39.0. #16439
+* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.39.0. #16440
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [CHANGE] Memberlist: Set the default `-memberlist.rejoin-interval` to 60s in Jsonnet configurations. #16332
 * [ENHANCEMENT] Add `multi_zone_ingester_zpdb_cross_zone_eviction_delay` config option to set `crossZoneEvictionDelay` on the ingester `ZoneAwarePodDisruptionBudget`. Defaults to `20m` when `ingest_storage_enabled` is true, and to unset otherwise. #16271
 * [ENHANCEMENT] Compactor: Allow the drain autoscaler's speed estimates to be read from recording rules. #16283
+* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.39.0. #16439
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 
 ### Mixin

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,7 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Set default memberlist `rejoin_interval` to 60s so that a member evicted from the gossip ring by a transient network fault periodically rejoins the cluster instead of staying isolated until restart. #16332
 * [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the Grafana Agent meta-monitoring resources by setting `metaMonitoring.grafanaAgent.serviceAccount.create` to true in the values. #16389
-* [ENHANCEMENT] Upgrade rollout-operator chart for v0.39.0. #16439
+* [ENHANCEMENT] Upgrade rollout-operator chart for v0.39.0. #16440
 
 
 ## 6.2.0

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Set default memberlist `rejoin_interval` to 60s so that a member evicted from the gossip ring by a transient network fault periodically rejoins the cluster instead of staying isolated until restart. #16332
 * [ENHANCEMENT] Memcached: update the default `memcached` and `memcached-exporter` images to `1.6.42-alpine` and `v0.16.0` respectively. #16372
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the Grafana Agent meta-monitoring resources by setting `metaMonitoring.grafanaAgent.serviceAccount.create` to true in the values. #16389
+* [ENHANCEMENT] Upgrade rollout-operator chart for v0.39.0. #16439
 
 
 ## 6.2.0

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.5.2
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.50.1
-digest: sha256:edeb3f3bda29c1e3488e4b7defc1b75f297caaca79828883dbcd7098614a2614
-generated: "2026-07-17T16:44:02.558247672Z"
+  version: 0.51.1
+digest: sha256:b461b5fa1fb43df3753bd641c3e05577375604ed4a8d0a41016ddb316438b17a
+generated: "2026-08-20T18:41:29.453320343Z"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   - name: rollout-operator
     alias: rollout_operator
     repository: https://grafana.github.io/helm-charts
-    version: 0.50.1
+    version: 0.51.1
     condition: rollout_operator.enabled

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -26,7 +26,7 @@ Kubernetes: `^1.32.0-0`
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.4.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.2 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.50.1 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.51.1 |
 
 # Contributing and releasing
 

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-volume-attributes-class-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.38.1
+          image: docker.io/grafana/rollout-operator:v0.39.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-volume-attributes-class-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-volume-attributes-class-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-volume-attributes-class-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-volume-attributes-class-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-volume-attributes-class-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.50.1
+    helm.sh/chart: rollout-operator-0.51.1
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-volume-attributes-class-values
-    app.kubernetes.io/version: "v0.38.1"
+    app.kubernetes.io/version: "v0.39.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1153,7 +1153,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
@@ -1094,7 +1094,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -861,7 +861,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -861,7 +861,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -3240,7 +3240,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1463,7 +1463,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
@@ -1327,7 +1327,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -1393,7 +1393,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -1317,7 +1317,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -1317,7 +1317,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -1310,7 +1310,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1381,7 +1381,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1370,7 +1370,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1370,7 +1370,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
@@ -1370,7 +1370,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1389,7 +1389,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1400,7 +1400,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1399,7 +1399,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1399,7 +1399,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1399,7 +1399,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1330,7 +1330,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1334,7 +1334,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1334,7 +1334,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1311,7 +1311,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1393,7 +1393,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -2344,7 +2344,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -1787,7 +1787,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -3176,7 +3176,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -3225,7 +3225,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -3225,7 +3225,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -3225,7 +3225,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -3225,7 +3225,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -3225,7 +3225,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -3202,7 +3202,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -3202,7 +3202,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -3202,7 +3202,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -3202,7 +3202,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -3264,7 +3264,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -3264,7 +3264,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -3233,7 +3233,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -2545,7 +2545,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -2545,7 +2545,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-generated.yaml
@@ -1328,7 +1328,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
@@ -1459,7 +1459,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1170,7 +1170,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1238,7 +1238,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1170,7 +1170,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1104,7 +1104,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -2428,7 +2428,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-replica-template-generated.yaml
+++ b/operations/mimir-tests/test-replica-template-generated.yaml
@@ -317,7 +317,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.1
+        image: grafana/rollout-operator:v0.39.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir/jsonnetfile.json
+++ b/operations/mimir/jsonnetfile.json
@@ -35,7 +35,7 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "v0.38.1"
+      "version": "v0.39.0"
     },
     {
       "source": {

--- a/operations/mimir/jsonnetfile.lock.json
+++ b/operations/mimir/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "0e952cd1cb19c8edb8d4173d350349d3c0901a27",
-      "sum": "4pYLZ+qmS226f9wDqjNLB8Uj5BtRUGr3I/xdKELIWkI="
+      "version": "205ec04550b27aca475a95c7aab791c24c2e2535",
+      "sum": "73u130NBrdFbOmn5wmBEosq+1Lx9Wvch6iU1zVHl27o="
     },
     {
       "source": {


### PR DESCRIPTION
#### What this PR does

Updates rollout-operator to `v0.39.0` in helm/jsonnet: https://github.com/grafana/rollout-operator/releases/tag/v0.39.0

#### Which issue(s) this PR fixes or relates to

Fixes: N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
