### PR TITLE
mixin: alert on level 1 blocks per read compartment

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1175,13 +1175,13 @@ spec:
               severity: critical
           - alert: MimirHighVolumeLevel1BlocksQueried
             annotations:
-              message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
+              message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
               runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
             expr: |
               (
-              sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
+              sum by(cluster, namespace, read_compartment) (label_replace(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
               /
-              sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
+              sum by(cluster, namespace, read_compartment) (label_replace(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
               ) > 0.05
             for: 6h
             labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1149,13 +1149,13 @@ groups:
             severity: critical
         - alert: MimirHighVolumeLevel1BlocksQueried
           annotations:
-            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
+            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
             (
-            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
+            sum by(cluster, namespace, read_compartment) (label_replace(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
             /
-            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
+            sum by(cluster, namespace, read_compartment) (label_replace(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
             ) > 0.05
           for: 6h
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1163,13 +1163,13 @@ groups:
             severity: critical
         - alert: MimirHighVolumeLevel1BlocksQueried
           annotations:
-            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
+            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }}{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
             (
-            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
+            sum by(cluster, namespace, read_compartment) (label_replace(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
             /
-            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
+            sum by(cluster, namespace, read_compartment) (label_replace(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]), "read_compartment", "$1", "job", ".*-rc-([0-9]+)"))
             ) > 0.05
           for: 6h
           labels:

--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -53,7 +53,7 @@ for RING_NAME in "ingester-partitions" "compactor" "store-gateway"; do
   done
 done
 
-for ALERT in "MimirBucketIndexNotUpdated" "MimirCompactorSchedulerNotCompletingJobs" "MimirCompactorSchedulerRepeatedJobFailure" "MimirIngesterInstanceHasNoTenants"; do
+for ALERT in "MimirBucketIndexNotUpdated" "MimirCompactorSchedulerNotCompletingJobs" "MimirCompactorSchedulerRepeatedJobFailure" "MimirHighVolumeLevel1BlocksQueried" "MimirIngesterInstanceHasNoTenants"; do
   EXPR=$(ALERT="${ALERT}" yq eval '.groups[].rules[] | select(.alert == env(ALERT)) | .expr' "${ALERTS_FILE}")
 
   if [ -z "${EXPR}" ]; then

--- a/operations/mimir-mixin-tests/test-compartments-asserts.sh
+++ b/operations/mimir-mixin-tests/test-compartments-asserts.sh
@@ -63,6 +63,14 @@ for ALERT in "MimirBucketIndexNotUpdated" "MimirCompactorSchedulerNotCompletingJ
   fi
 done
 
+HIGH_VOLUME_LEVEL_1_BLOCKS_EXPR=$(yq eval '.groups[].rules[] | select(.alert == "MimirHighVolumeLevel1BlocksQueried") | .expr' "${ALERTS_FILE}")
+for SELECTOR in 'level="1"' 'component="store-gateway",out_of_order="false"'; do
+  OPERAND=$(echo "${HIGH_VOLUME_LEVEL_1_BLOCKS_EXPR}" | grep -F -- "${SELECTOR}" || true)
+  if [ -z "${OPERAND}" ] || ! echo "${OPERAND}" | grep -q -F -- 'label_replace(' || ! echo "${OPERAND}" | grep -qE -- 'sum by[[:space:]]*\([^)]*read_compartment'; then
+    assert_failed "MimirHighVolumeLevel1BlocksQueried does not derive and group the operand matched by ${SELECTOR} by read_compartment.\nBoth sides of the ratio need identical compartment labels."
+  fi
+done
+
 PARTITION_ALERT_EXPR=$(yq eval '.groups[].rules[] | select(.alert == "MimirFewerIngestersConsumingThanActivePartitions") | .expr' "${ALERTS_FILE}")
 for METRIC in "cortex_partition_ring_partitions" "cortex_ingest_storage_reader_last_consumed_offset"; do
   if ! echo "${PARTITION_ALERT_EXPR}" | grep -F -- "${METRIC}" | grep -q -F -- 'read_compartment'; then

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -256,19 +256,19 @@
           'for': '6h',
           expr: |||
             (
-            sum by(%(alert_aggregation_labels)s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",%(job)s}[%(rate_interval)s]))
+            sum by(%(alert_aggregation_labels)s, read_compartment) (%(level_1_blocks_rate)s)
             /
-            sum by(%(alert_aggregation_labels)s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",%(job)s}[%(rate_interval)s]))
+            sum by(%(alert_aggregation_labels)s, read_compartment) (%(blocks_rate)s)
             ) > 0.05
           ||| % $._config {
-            job: $.jobMatcher($._config.job_names.store_gateway),
-            rate_interval: $.rateInterval('10m'),
+            blocks_rate: $.withReadCompartmentLabel('rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",%s}[%s])' % [$.jobMatcher($._config.job_names.store_gateway), $.rateInterval('10m')]),
+            level_1_blocks_rate: $.withReadCompartmentLabel('rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",%s}[%s])' % [$.jobMatcher($._config.job_names.store_gateway), $.rateInterval('10m')]),
           },
           labels: {
             severity: 'warning',
           },
           annotations: {
-                         message: '%(product)s store-gateway in %(alert_aggregation_variables)s is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.' % $._config,
+                         message: '%(product)s store-gateway in %(alert_aggregation_variables)s{{ if $labels.read_compartment }}/rc-{{ $labels.read_compartment }}{{ end }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.' % $._config,
                        }
                        // Alternative dashboards for investigation:
                        //   - Mimir / Queries (mimir-queries.json)


### PR DESCRIPTION
#### What this PR does

Evaluates `MimirHighVolumeLevel1BlocksQueried` per read compartment so a healthy compartment cannot mask sustained level 1 block queries in another compartment.

The expression now derives `read_compartment` on both the level 1 numerator and the all-block denominator, groups the ratio by that label, and includes the compartment in the alert message. Deployments without read compartments retain the existing aggregation behavior. The compartment test independently verifies that both ratio operands derive and group by that label.

#### Which issue(s) this PR fixes or relates to

Related to #16289.

#### Testing

- `make BUILD_IN_CONTAINER=false format-mixin`
- all mixin assertion suites passed: compartments, custom labels, multi-zone write path, and scrape interval; the compartment assertion independently checks both ratio operands
- `go run -mod=vendor ./cmd/mimirtool rules check --rule-dirs operations/mimir-mixin-compiled`
- `go run -mod=vendor ./cmd/mimirtool rules check --rule-dirs operations/mimir-mixin-compiled-baremetal`
- `SED_BIN=gsed ./tools/lint-runbooks.sh`
- regenerated default, bare-metal, and Helm alert outputs compared with the committed files

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.