### PR TITLE
MQE: Fix subquery cardinality estimation error when range is shorter than step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
 * [BUGFIX] MQE: Fix an issue where series were joined in binary operations using the wrong labels when `group_left()`/`group_right()` were used in combination with `ignoring()`. This bug manifested as valid queries returning an error `grouping labels must ensure unique matches`. #16387
+* [BUGFIX] MQE: Fix queries and rules containing a subquery whose range is shorter than its step (e.g. `foo[10m:3d]`) failing with `last bucket must not be before first bucket`. #TODO
 * [BUGFIX] Upgrade Go to 1.26 latest with fixes for [CVE-2026-33818](https://pkg.go.dev/vuln/GO-2026-5972), [CVE-2026-39821](https://pkg.go.dev/vuln/GO-2026-5026), [CVE-2026-46600](https://pkg.go.dev/vuln/GO-2026-5942), [CVE-2026-56853](https://pkg.go.dev/vuln/GO-2026-6089), [CVE-2026-56858](https://pkg.go.dev/vuln/GO-2026-6091), [CVE-2026-56859](https://pkg.go.dev/vuln/GO-2026-6088), [CVE-2026-56860](https://pkg.go.dev/vuln/GO-2026-6218), and [CVE-2026-56862](https://pkg.go.dev/vuln/GO-2026-6090). #16408 #16430
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
 * [BUGFIX] MQE: Fix an issue where series were joined in binary operations using the wrong labels when `group_left()`/`group_right()` were used in combination with `ignoring()`. This bug manifested as valid queries returning an error `grouping labels must ensure unique matches`. #16387
-* [BUGFIX] MQE: Fix queries and rules containing a subquery whose range is shorter than its step (e.g. `foo[10m:3d]`) failing with `last bucket must not be before first bucket`. #TODO
+* [BUGFIX] MQE: Fix queries and rules containing a subquery whose range is shorter than its step (e.g. `foo[10m:3d]`) failing with `last bucket must not be before first bucket`. #16442
 * [BUGFIX] Upgrade Go to 1.26 latest with fixes for [CVE-2026-33818](https://pkg.go.dev/vuln/GO-2026-5972), [CVE-2026-39821](https://pkg.go.dev/vuln/GO-2026-5026), [CVE-2026-46600](https://pkg.go.dev/vuln/GO-2026-5942), [CVE-2026-56853](https://pkg.go.dev/vuln/GO-2026-6089), [CVE-2026-56858](https://pkg.go.dev/vuln/GO-2026-6091), [CVE-2026-56859](https://pkg.go.dev/vuln/GO-2026-6088), [CVE-2026-56860](https://pkg.go.dev/vuln/GO-2026-6218), and [CVE-2026-56862](https://pkg.go.dev/vuln/GO-2026-6090). #16408 #16430
 
 ### Mixin

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
@@ -558,7 +558,19 @@ func selectorCardinalityCacheKeys(ctx context.Context, cfg streamingpromql.Cardi
 	firstBucket := (minT + offset) / bucketMs
 	lastBucket := (maxT + offset) / bucketMs
 	if lastBucket < firstBucket {
-		return nil, fmt.Errorf("last bucket must not be before first bucket, but got minT=%d and maxT=%d", minT, maxT)
+		// minT > maxT means this selector's queried time range is empty/inverted - e.g. a subquery
+		// whose range is shorter than its step (see SubqueryChildrenTimeRange) can produce this.
+		// This mirrors types.NewRangeQueryTimeRange's handling of StartT > EndT: there's no data to
+		// estimate cardinality for, so return no cache keys rather than erroring. The caller already
+		// treats a selector with zero cache keys as "no cardinality estimate available", which lets
+		// the query proceed (without a sharding hint for this selector) instead of failing outright.
+		logger.DebugLog(
+			"msg", "selector's queried time range is empty; no cardinality estimate will be used for it",
+			"selector", canonicalSelector,
+			"minT", minT,
+			"maxT", maxT,
+		)
+		return nil, nil
 	}
 
 	desiredBucketCount := lastBucket - firstBucket + 1

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation_test.go
@@ -4,6 +4,7 @@ package sharding
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"math"
 	"slices"
@@ -144,6 +145,66 @@ func TestCollectSelectorTimeRanges(t *testing.T) {
 		require.Equal(t, startT-(time.Hour-time.Minute+7*time.Minute).Milliseconds()+1, ranges[0].minT)
 		require.Equal(t, endT, ranges[0].maxT)
 	})
+}
+
+// TestSubqueryRangeShorterThanStepCanInvertQueriedTimeRange is a regression test for a production
+// incident where a tenant had sibling rules evaluating the same metric with a `[10m:X]` subquery for
+// several values of X (5m, 30m, 1h, 2h, 6h, 1d, 3d) - a multi-window burn-rate pattern. Every one of
+// them evaluated successfully except the longest, [10m:3d], which failed every tick with:
+//
+//	last bucket must not be before first bucket, but got minT=... and maxT=...
+//
+// Root cause: SubqueryChildrenTimeRange (pkg/streamingpromql/planning/core/subquery.go) aligns the
+// subquery's child time range to the step's epoch-aligned grid. When the step is much larger than the
+// range, there may be no grid point inside [end-range, end], so the aligned start ends up *after* the
+// parent query's end. types.NewRangeQueryTimeRange documents that a start-after-end range is legitimate
+// (it means the subquery selects no points), and selectorCardinalityCacheKeys now handles that case the
+// same way: it returns no cache keys (and no error) for an inverted range, so the query proceeds without
+// a cardinality estimate for that selector instead of failing outright.
+func TestSubqueryRangeShorterThanStepCanInvertQueriedTimeRange(t *testing.T) {
+	// Chosen as an exact multiple of 1 day so it also lands exactly on a step boundary for every step
+	// below except 3d, isolating the step length as the only variable that determines whether the
+	// range inverts - matching what was observed in the incident, where only the 3d-step sibling rule
+	// failed.
+	instant := types.NewInstantQueryTimeRange(timestamp.Time(20 * 24 * time.Hour.Milliseconds()))
+	lookbackDelta := 5 * time.Minute
+
+	testCases := map[string]struct {
+		step           string
+		expectInverted bool
+	}{
+		"[10m:5m]":  {step: "5m", expectInverted: false},
+		"[10m:30m]": {step: "30m", expectInverted: false},
+		"[10m:1h]":  {step: "1h", expectInverted: false},
+		"[10m:2h]":  {step: "2h", expectInverted: false},
+		"[10m:6h]":  {step: "6h", expectInverted: false},
+		"[10m:1d]":  {step: "1d", expectInverted: false},
+		"[10m:3d]":  {step: "3d", expectInverted: true}, // The one that caused the incident.
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			queryExpr := fmt.Sprintf("sum_over_time(foo[10m:%s])", testCase.step)
+			expr, err := promqlext.NewPromQLParser().ParseExpr(queryExpr)
+			require.NoError(t, err)
+
+			ranges := collectSelectorTimeRanges(expr, instant, lookbackDelta)
+			require.Len(t, ranges, 1)
+			minT, maxT := ranges[0].minT, ranges[0].maxT
+
+			_, cfg := setupCardinalityEstimationTest()
+			keys, err := selectorCardinalityCacheKeys(context.Background(), cfg, queryExpr, "foo", minT, maxT, true, newNoOpSpanLogger(t))
+			require.NoError(t, err, "an inverted/empty queried time range must not cause an error - it should just mean no cardinality estimate is available")
+
+			if testCase.expectInverted {
+				require.Greater(t, minT, maxT, "expected this subquery's step to be large enough relative to its 10m range to produce an inverted time range")
+				require.Empty(t, keys, "an inverted time range should yield no cache keys")
+			} else {
+				require.LessOrEqual(t, minT, maxT, "expected this subquery's step to be small enough relative to its 10m range to produce a valid time range")
+				require.NotEmpty(t, keys, "a valid time range should yield at least one cache key")
+			}
+		})
+	}
 }
 
 func TestCacheCardinalityEstimator(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

The recently added `selectorCardinalityCacheKeys` treated an inverted queried time range (minT > maxT) as a hard error. 

This is a legitimate case for subqueries whose range is shorter than their step (e.g. foo[10m:3d]), where SubqueryChildrenTimeRange's step-aligned child range can start after the parent query's evaluation instant. types.NewRangeQueryTimeRange already treats this as "no data queried"; selectorCardinalityCacheKeys now does the same, returning no cache keys instead of erroring, so the query proceeds without a cardinality estimate for that selector rather than failing outright.

This PR ensures that this is not treated as an error in the cardinality estimation/tracking.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
