### PR TITLE
git: mark generated files as such

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 **/*.pb.go linguist-generated=true
 vendor/**/* linguist-generated=true
+operations/helm/tests/*-values-generated/** linguist-generated=true
+operations/mimir-mixin-compiled*/** linguist-generated=true
+operations/mimir-tests/*-generated.yaml linguist-generated=true
 # Resolve conflicts in changelogs by merging both sides together.
 # This can cause misleading resolutions, with duplicated records in the changelog. But it allows the bakporting CI job to pass
 # and let the human to resolve it later, rather than failing.


### PR DESCRIPTION
#### What this PR does

Whenever a PR touches jsonnet or helm manifests, the author needs to regenerate the testing assets. Often, these generated files occupy large portion of the PR's diff, and make review more complicated.

This PR updates the `.gitattributes`, marking the generated files as such, similar to how we handle vendored files. Should there be any issues with the generated files, the CI (and possibly AIs agents) will flag those more reliably than a human will.