### PR TITLE
fix(querier): Return 413 instead of 500 for cardinality/active-series size-limit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [BUGFIX] Store-gateway: Drain the chunks range reader before closing it so HTTP object storage connections can be reused. #16338
 * [BUGFIX] Block-builder-scheduler: Fail startup instead of silently switching to normal operation without assigning any jobs when probing the initial consumption offsets fails. #16028
 * [BUGFIX] Querier: Return HTTP 413 instead of 500 from the cardinality `label_names` and `label_values` endpoints when the merged response exceeds `-querier.label-names-and-values-results-max-size-bytes`. #16452
+* [BUGFIX] Querier: Return HTTP 413 instead of 500 from the active series endpoint's framed response format when a single series' JSON exceeds the maximum frame size. #16452
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [BUGFIX] Upgrade Go to 1.26 latest with fixes for [CVE-2026-33818](https://pkg.go.dev/vuln/GO-2026-5972), [CVE-2026-39821](https://pkg.go.dev/vuln/GO-2026-5026), [CVE-2026-46600](https://pkg.go.dev/vuln/GO-2026-5942), [CVE-2026-56853](https://pkg.go.dev/vuln/GO-2026-6089), [CVE-2026-56858](https://pkg.go.dev/vuln/GO-2026-6091), [CVE-2026-56859](https://pkg.go.dev/vuln/GO-2026-6088), [CVE-2026-56860](https://pkg.go.dev/vuln/GO-2026-6218), and [CVE-2026-56862](https://pkg.go.dev/vuln/GO-2026-6090). #16408 #16430
 * [BUGFIX] Store-gateway: Drain the chunks range reader before closing it so HTTP object storage connections can be reused. #16338
 * [BUGFIX] Block-builder-scheduler: Fail startup instead of silently switching to normal operation without assigning any jobs when probing the initial consumption offsets fails. #16028
+* [BUGFIX] Querier: Return HTTP 413 instead of 500 from the cardinality `label_names` and `label_values` endpoints when the merged response exceeds `-querier.label-names-and-values-results-max-size-bytes`. #16452
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2799,7 +2799,7 @@ func (m *labelNamesAndValuesResponseMerger) putItemsToMap(message *ingester_clie
 			if _, valueExists := values[val]; !valueExists {
 				m.currentSizeBytes += len(val)
 				if m.currentSizeBytes > m.sizeLimitBytes {
-					return ErrResponseTooLarge
+					return fmt.Errorf("size of distinct label names and values %d bytes exceeds limit %d bytes: %w", m.currentSizeBytes, m.sizeLimitBytes, ErrResponseTooLarge)
 				}
 				values[val] = struct{}{}
 			}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2799,7 +2799,7 @@ func (m *labelNamesAndValuesResponseMerger) putItemsToMap(message *ingester_clie
 			if _, valueExists := values[val]; !valueExists {
 				m.currentSizeBytes += len(val)
 				if m.currentSizeBytes > m.sizeLimitBytes {
-					return fmt.Errorf("size of distinct label names and values is greater than %v bytes", m.sizeLimitBytes)
+					return ErrResponseTooLarge
 				}
 				values[val] = struct{}{}
 			}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3994,11 +3994,11 @@ func TestDistributor_LabelNamesAndValuesLimitTest(t *testing.T) {
 	}
 	tests := map[string]struct {
 		sizeLimitBytes int
-		expectedError  string
+		expectedErr    bool
 	}{
 		"expected error if sizeLimit is reached": {
 			sizeLimitBytes: 20,
-			expectedError:  "size of distinct label names and values is greater than 20 bytes",
+			expectedErr:    true,
 		},
 		"expected no error if sizeLimit is not reached": {
 			sizeLimitBytes: 25,
@@ -4036,10 +4036,10 @@ func TestDistributor_LabelNamesAndValuesLimitTest(t *testing.T) {
 					}
 
 					_, err := ds[0].LabelNamesAndValues(ctx, []*labels.Matcher{}, cardinality.InMemoryMethod)
-					if len(testData.expectedError) == 0 {
-						require.NoError(t, err)
+					if testData.expectedErr {
+						require.ErrorIs(t, err, ErrResponseTooLarge)
 					} else {
-						require.EqualError(t, err, testData.expectedError)
+						require.NoError(t, err)
 					}
 				})
 			}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3994,11 +3994,11 @@ func TestDistributor_LabelNamesAndValuesLimitTest(t *testing.T) {
 	}
 	tests := map[string]struct {
 		sizeLimitBytes int
-		expectedErr    bool
+		expectedError  string
 	}{
 		"expected error if sizeLimit is reached": {
 			sizeLimitBytes: 20,
-			expectedErr:    true,
+			expectedError:  "exceeds limit 20 bytes",
 		},
 		"expected no error if sizeLimit is not reached": {
 			sizeLimitBytes: 25,
@@ -4036,10 +4036,11 @@ func TestDistributor_LabelNamesAndValuesLimitTest(t *testing.T) {
 					}
 
 					_, err := ds[0].LabelNamesAndValues(ctx, []*labels.Matcher{}, cardinality.InMemoryMethod)
-					if testData.expectedErr {
-						require.ErrorIs(t, err, ErrResponseTooLarge)
-					} else {
+					if testData.expectedError == "" {
 						require.NoError(t, err)
+					} else {
+						require.ErrorIs(t, err, ErrResponseTooLarge)
+						require.ErrorContains(t, err, testData.expectedError)
 					}
 				})
 			}

--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -52,6 +52,10 @@ func LabelNamesCardinalityHandler(d Distributor, limits *validation.Overrides) h
 		}
 		response, err := d.LabelNamesAndValues(ctx, cardinalityRequest.Matchers, cardinalityRequest.CountMethod)
 		if err != nil {
+			if errors.Is(err, distributor.ErrResponseTooLarge) {
+				http.Error(w, fmt.Errorf("%w: try narrowing the label selector", err).Error(), http.StatusRequestEntityTooLarge)
+				return
+			}
 			respondFromError(err, w)
 			return
 		}
@@ -61,7 +65,7 @@ func LabelNamesCardinalityHandler(d Distributor, limits *validation.Overrides) h
 }
 
 // LabelValuesCardinalityHandler creates handler for label values cardinality endpoint.
-func LabelValuesCardinalityHandler(distributor Distributor, limits *validation.Overrides) http.Handler {
+func LabelValuesCardinalityHandler(d Distributor, limits *validation.Overrides) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		// Guarantee request's context is for a single tenant id
@@ -81,8 +85,12 @@ func LabelValuesCardinalityHandler(distributor Distributor, limits *validation.O
 			return
 		}
 
-		seriesCountTotal, cardinalityResponse, err := distributor.LabelValuesCardinality(ctx, cardinalityRequest.LabelNames, cardinalityRequest.Matchers, cardinalityRequest.CountMethod)
+		seriesCountTotal, cardinalityResponse, err := d.LabelValuesCardinality(ctx, cardinalityRequest.LabelNames, cardinalityRequest.Matchers, cardinalityRequest.CountMethod)
 		if err != nil {
+			if errors.Is(err, distributor.ErrResponseTooLarge) {
+				http.Error(w, fmt.Errorf("%w: try narrowing the label selector", err).Error(), http.StatusRequestEntityTooLarge)
+				return
+			}
 			respondFromError(err, w)
 			return
 		}

--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -185,7 +185,7 @@ func writeActiveSeriesFramedResponse(w http.ResponseWriter, series []labels.Labe
 		if len(obj) > api.MaxActiveSeriesFrameSize {
 			err := fmt.Errorf("active series frame size %d exceeds maximum %d", len(obj), api.MaxActiveSeriesFrameSize)
 			if !wroteFrame {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 			}
 			return err
 		}

--- a/pkg/querier/cardinality_analysis_handler_test.go
+++ b/pkg/querier/cardinality_analysis_handler_test.go
@@ -979,6 +979,27 @@ func TestActiveSeriesCardinalityHandler_framedResponse(t *testing.T) {
 		resp = serve(t, api.ContentTypeActiveSeriesFramed+";q=0")
 		require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	})
+
+	t.Run("returns request entity too large when a single series exceeds the max frame size", func(t *testing.T) {
+		// Spread the size across many labels, well under any single label's own size limit, rather
+		// than one huge value: only the marshaled series as a whole needs to exceed
+		// api.MaxActiveSeriesFrameSize.
+		const numLabels = api.MaxActiveSeriesFrameSize/1000 + 1000
+		pairs := make([]string, 0, numLabels*2)
+		for i := 0; i < numLabels; i++ {
+			pairs = append(pairs, fmt.Sprintf("label_%06d", i), strings.Repeat("a", 990))
+		}
+		oversized := []labels.Labels{labels.FromStrings(pairs...)}
+
+		d := &mockDistributor{}
+		d.On("ActiveSeries", mock.Anything, mock.Anything).Return(oversized, error(nil))
+		handler := createEnabledHandler(t, activeSeriesCardinalityHandler, d)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, newRequest(t, api.ContentTypeActiveSeriesFramed))
+		resp := recorder.Result()
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+	})
 }
 
 func framedFrames(t *testing.T, body []byte) [][]byte {

--- a/pkg/querier/cardinality_analysis_handler_test.go
+++ b/pkg/querier/cardinality_analysis_handler_test.go
@@ -208,6 +208,11 @@ func TestLabelNamesCardinalityHandler_DistributorError(t *testing.T) {
 			expectedHTTPStatusCode: 500,
 			expectedHTTPBody:       "non httpgrpc error\n",
 		},
+		"should return request entity too large if the distributor returns ErrResponseTooLarge": {
+			distributorError:       pkg_distributor.ErrResponseTooLarge,
+			expectedHTTPStatusCode: http.StatusRequestEntityTooLarge,
+			expectedHTTPBody:       "response too large: try narrowing the label selector\n",
+		},
 	}
 
 	for testName, testData := range tests {
@@ -772,6 +777,11 @@ func TestLabelValuesCardinalityHandler_DistributorError(t *testing.T) {
 			distributorError:       fmt.Errorf("non httpgrpc error"),
 			expectedHTTPStatusCode: 500,
 			expectedHTTPBody:       "non httpgrpc error\n",
+		},
+		"should return request entity too large if the distributor returns ErrResponseTooLarge": {
+			distributorError:       pkg_distributor.ErrResponseTooLarge,
+			expectedHTTPStatusCode: http.StatusRequestEntityTooLarge,
+			expectedHTTPBody:       "response too large: try narrowing the label selector\n",
 		},
 	}
 


### PR DESCRIPTION
Two response paths respond `500` when they hit a size limit that should be a client-facing `413`. 
This is inconsistent with sibling handlers in the same file that already do this correctly.