### PR TITLE
jsonnet: add zone specific disk class config for store-gateway and ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [ENHANCEMENT] Compactor: Allow the drain autoscaler's speed estimates to be read from recording rules. #16283
 * [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.39.0. #16440
 * [ENHANCEMENT] Add support for multi-zone query-tee. #16360
+* [ENHANCEMENT] Add `ingester_zone_(a|b|c)_data_disk_class` and `store_gateway_zone_(a|b|c|a-backup|b-backup)_data_disk_class` config. #16467
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 
 ### Documentation

--- a/operations/mimir/compartments-ingester.libsonnet
+++ b/operations/mimir/compartments-ingester.libsonnet
@@ -52,11 +52,11 @@
   newIngesterCompartmentContainer(zone, compartmentIdx, args, extraEnvVarMap={})::
     $.newIngesterZoneContainer(zone, args, extraEnvVarMap),
 
-  newIngesterCompartmentStatefulSet(zone, compartmentIdx, container, nodeAffinityMatchers=[])::
+  newIngesterCompartmentStatefulSet(zone, compartmentIdx, container, dataDiskClass, nodeAffinityMatchers=[])::
     local name = 'ingester-zone-%s-rc-%d' % [zone, compartmentIdx];
     local compartmentIdxStr = std.toString(compartmentIdx);
     local rolloutGroup = 'ingester-rc-%d' % compartmentIdx;
-    $.newIngesterZoneStatefulSet(zone, container, nodeAffinityMatchers) +
+    $.newIngesterZoneStatefulSet(zone, container, dataDiskClass, nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withName(name) +
     statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withLabelsMixin({ name: name, 'mimir-rc': compartmentIdxStr, 'rollout-group': rolloutGroup }) +
@@ -129,9 +129,9 @@
   ingester_zone_c_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newIngesterCompartmentContainer('c', compartment, $.ingester_zone_c_compartments_args['compartment_%d' % compartment], $.ingester_zone_c_env_map)),
 
   // StatefulSets.
-  ingester_zone_a_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('a', compartment, $.ingester_zone_a_containers['compartment_%d' % compartment], $.ingester_zone_a_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('a', compartment)),
-  ingester_zone_b_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('b', compartment, $.ingester_zone_b_containers['compartment_%d' % compartment], $.ingester_zone_b_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('b', compartment)),
-  ingester_zone_c_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('c', compartment, $.ingester_zone_c_containers['compartment_%d' % compartment], $.ingester_zone_c_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('c', compartment)),
+  ingester_zone_a_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('a', compartment, $.ingester_zone_a_containers['compartment_%d' % compartment], $._config.ingester_zone_a_data_disk_class, $.ingester_zone_a_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('a', compartment)),
+  ingester_zone_b_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('b', compartment, $.ingester_zone_b_containers['compartment_%d' % compartment], $._config.ingester_zone_b_data_disk_class, $.ingester_zone_b_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('b', compartment)),
+  ingester_zone_c_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('c', compartment, $.ingester_zone_c_containers['compartment_%d' % compartment], $._config.ingester_zone_c_data_disk_class, $.ingester_zone_c_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('c', compartment)),
 
   // PDBs.
   local newIngesterRolloutCompartmentPdb(compartmentIdx) =

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -56,11 +56,11 @@
   store_gateway_zone_a_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.store_gateway_zone_a_backup_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_a_caching_configs['compartment_%d' % c]),
   store_gateway_zone_b_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.store_gateway_zone_b_backup_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_b_caching_configs['compartment_%d' % c]),
 
-  newStoreGatewayCompartmentStatefulSet(zone, compartmentIdx, container, nodeAffinityMatchers=[], multiAZ=false)::
+  newStoreGatewayCompartmentStatefulSet(zone, compartmentIdx, container, dataDiskClass, nodeAffinityMatchers=[], multiAZ=false)::
     local name = 'store-gateway-zone-%s-rc-%d' % [zone, compartmentIdx];
     local compartmentIdxStr = std.toString(compartmentIdx);
     local rolloutGroup = 'store-gateway-rc-%d' % compartmentIdx;
-    $.newStoreGatewayZoneStatefulSet(zone, container, nodeAffinityMatchers, rolloutGroup) +
+    $.newStoreGatewayZoneStatefulSet(zone, container, dataDiskClass, nodeAffinityMatchers, rolloutGroup) +
     statefulSet.mixin.metadata.withName(name) +
     statefulSet.mixin.spec.withServiceName(name) +
     // Label identifying the read compartment.
@@ -95,11 +95,11 @@
 
   // StatefulSets. The per-compartment autoscaling (ScaledObjects, prepare-downscale, removeReplicasFromSpec) is
   // layered on top in store-gateway-autoscaling.libsonnet, mirroring the non-compartment store-gateway.
-  store_gateway_zone_a_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('a', c, $.store_gateway_zone_a_containers['compartment_%d' % c], $.store_gateway_zone_a_node_affinity_matchers, isZoneAMultiAZ)),
-  store_gateway_zone_b_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('b', c, $.store_gateway_zone_b_containers['compartment_%d' % c], $.store_gateway_zone_b_node_affinity_matchers, isZoneBMultiAZ)),
-  store_gateway_zone_c_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('c', c, $.store_gateway_zone_c_containers['compartment_%d' % c], $.store_gateway_zone_c_node_affinity_matchers, isZoneCMultiAZ)),
-  store_gateway_zone_a_backup_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('a-backup', c, $.store_gateway_zone_a_backup_containers['compartment_%d' % c], $.store_gateway_zone_a_backup_node_affinity_matchers, isZoneABackupMultiAZ)),
-  store_gateway_zone_b_backup_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('b-backup', c, $.store_gateway_zone_b_backup_containers['compartment_%d' % c], $.store_gateway_zone_b_backup_node_affinity_matchers, isZoneBBackupMultiAZ)),
+  store_gateway_zone_a_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('a', c, $.store_gateway_zone_a_containers['compartment_%d' % c], $._config.store_gateway_zone_a_data_disk_class, $.store_gateway_zone_a_node_affinity_matchers, isZoneAMultiAZ)),
+  store_gateway_zone_b_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('b', c, $.store_gateway_zone_b_containers['compartment_%d' % c], $._config.store_gateway_zone_b_data_disk_class, $.store_gateway_zone_b_node_affinity_matchers, isZoneBMultiAZ)),
+  store_gateway_zone_c_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('c', c, $.store_gateway_zone_c_containers['compartment_%d' % c], $._config.store_gateway_zone_c_data_disk_class, $.store_gateway_zone_c_node_affinity_matchers, isZoneCMultiAZ)),
+  store_gateway_zone_a_backup_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('a-backup', c, $.store_gateway_zone_a_backup_containers['compartment_%d' % c], $._config.store_gateway_zone_a_backup_data_disk_class, $.store_gateway_zone_a_backup_node_affinity_matchers, isZoneABackupMultiAZ)),
+  store_gateway_zone_b_backup_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('b-backup', c, $.store_gateway_zone_b_backup_containers['compartment_%d' % c], $._config.store_gateway_zone_b_backup_data_disk_class, $.store_gateway_zone_b_backup_node_affinity_matchers, isZoneBBackupMultiAZ)),
 
   // Services.
   store_gateway_zone_a_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.newStoreGatewayZoneService($.store_gateway_zone_a_statefulsets['compartment_%d' % c])),

--- a/operations/mimir/ingest-storage-migration.libsonnet
+++ b/operations/mimir/ingest-storage-migration.libsonnet
@@ -104,7 +104,7 @@
     self.newIngesterZoneContainer('a', $.ingester_partition_zone_a_args, $.ingester_partition_zone_a_env_map),
 
   ingester_partition_zone_a_statefulset: if !$._config.ingest_storage_migration_partition_ingester_zone_a_enabled then null else
-    self.newIngesterZoneStatefulSet('a-partition', $.ingester_partition_zone_a_container, $.ingester_partition_zone_a_node_affinity_matchers) +
+    self.newIngesterZoneStatefulSet('a-partition', $.ingester_partition_zone_a_container, $._config.ingester_zone_a_data_disk_class, $.ingester_partition_zone_a_node_affinity_matchers) +
     statefulSet.mixin.spec.withReplicas($._config.ingest_storage_migration_partition_ingester_zone_a_replicas) +
     partitionIngesterStatefulSetLabelsAndAnnotations +
     partitionIngesterStatefulSetPolicies +
@@ -118,7 +118,7 @@
     self.newIngesterZoneContainer('b', $.ingester_partition_zone_b_args, $.ingester_partition_zone_b_env_map),
 
   ingester_partition_zone_b_statefulset: if !$._config.ingest_storage_migration_partition_ingester_zone_b_enabled then null else
-    self.newIngesterZoneStatefulSet('b-partition', $.ingester_partition_zone_b_container, $.ingester_partition_zone_b_node_affinity_matchers) +
+    self.newIngesterZoneStatefulSet('b-partition', $.ingester_partition_zone_b_container, $._config.ingester_zone_b_data_disk_class, $.ingester_partition_zone_b_node_affinity_matchers) +
     statefulSet.mixin.spec.withReplicas($._config.ingest_storage_migration_partition_ingester_zone_b_replicas) +
     partitionIngesterStatefulSetLabelsAndAnnotations +
     partitionIngesterStatefulSetPolicies +
@@ -132,7 +132,7 @@
     self.newIngesterZoneContainer('c', $.ingester_partition_zone_c_args, $.ingester_partition_zone_c_env_map),
 
   ingester_partition_zone_c_statefulset: if !$._config.ingest_storage_migration_partition_ingester_zone_c_enabled then null else
-    self.newIngesterZoneStatefulSet('c-partition', $.ingester_partition_zone_c_container, $.ingester_partition_zone_c_node_affinity_matchers) +
+    self.newIngesterZoneStatefulSet('c-partition', $.ingester_partition_zone_c_container, $._config.ingester_zone_c_data_disk_class, $.ingester_partition_zone_c_node_affinity_matchers) +
     statefulSet.mixin.spec.withReplicas($._config.ingest_storage_migration_partition_ingester_zone_c_replicas) +
     partitionIngesterStatefulSetLabelsAndAnnotations +
     partitionIngesterStatefulSetPolicies +

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -90,22 +90,23 @@
 
   // The ingesters should persist TSDB blocks and WAL on a persistent
   // volume in order to be crash resilient.
-  local ingester_data_pvc =
+  local newIngesterDataPvc(diskClass) =
     pvc.new() +
     pvc.mixin.spec.resources.withRequests({ storage: $._config.ingester_data_disk_size }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
-    pvc.mixin.spec.withStorageClassName($._config.ingester_data_disk_class) +
+    pvc.mixin.spec.withStorageClassName(diskClass) +
     pvc.mixin.metadata.withName('ingester-data'),
 
   // When the ingester needs to flush blocks to the storage, it may take quite a lot of time.
   // For this reason, we grant an high termination period (80 minutes).
   ingester_termination_grace_period_seconds:: 1200,
 
-  newIngesterStatefulSet(name, container, withAntiAffinity=true, nodeAffinityMatchers=[])::
+  newIngesterStatefulSet(name, container, dataDiskClass, withAntiAffinity=true, nodeAffinityMatchers=[])::
     local ingesterContainer = container + $.core.v1.container.withVolumeMountsMixin([
       volumeMount.new('ingester-data', '/data'),
     ]);
 
+    local ingester_data_pvc = newIngesterDataPvc(dataDiskClass);
     $.newMimirStatefulSet(name, 3, ingesterContainer, ingester_data_pvc) +
     $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds($.ingester_termination_grace_period_seconds) +
@@ -117,6 +118,7 @@
     self.newIngesterStatefulSet(
       'ingester',
       $.ingester_container + (if std.length($.ingester_env_map) > 0 then container.withEnvMap(std.prune($.ingester_env_map)) else {}),
+      $._config.ingester_data_disk_class,
       !$._config.ingester_allow_multiple_replicas_on_same_node,
       $.ingester_node_affinity_matchers,
     ),

--- a/operations/mimir/multi-zone-ingester.libsonnet
+++ b/operations/mimir/multi-zone-ingester.libsonnet
@@ -26,6 +26,10 @@
     multi_zone_ingester_zone_a_multi_az_enabled: self.multi_zone_ingester_multi_az_enabled,
     multi_zone_ingester_zone_b_multi_az_enabled: self.multi_zone_ingester_multi_az_enabled,
     multi_zone_ingester_zone_c_multi_az_enabled: self.multi_zone_ingester_multi_az_enabled,
+
+    ingester_zone_a_data_disk_class: self.ingester_data_disk_class,
+    ingester_zone_b_data_disk_class: self.ingester_data_disk_class,
+    ingester_zone_c_data_disk_class: self.ingester_data_disk_class,
   },
 
   local container = $.core.v1.container,
@@ -84,10 +88,10 @@
     )) +
     (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}),
 
-  newIngesterZoneStatefulSet(zone, container, nodeAffinityMatchers=[])::
+  newIngesterZoneStatefulSet(zone, container, dataDiskClass, nodeAffinityMatchers=[])::
     local name = 'ingester-zone-%s' % zone;
 
-    $.newIngesterStatefulSet(name, container, withAntiAffinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
+    $.newIngesterStatefulSet(name, container, dataDiskClass, withAntiAffinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': 'ingester' }) +
     statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_ingester_max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': 'ingester' }) +
@@ -122,7 +126,7 @@
     $.newIngesterZoneContainer('a', $.ingester_zone_a_args, $.ingester_zone_a_env_map),
 
   ingester_zone_a_statefulset: if !$._config.multi_zone_ingester_enabled then null else
-    $.newIngesterZoneStatefulSet('a', $.ingester_zone_a_container, $.ingester_zone_a_node_affinity_matchers) +
+    $.newIngesterZoneStatefulSet('a', $.ingester_zone_a_container, $._config.ingester_zone_a_data_disk_class, $.ingester_zone_a_node_affinity_matchers) +
     (if isZoneAEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}),
 
   ingester_zone_a_service: if !$._config.multi_zone_ingester_enabled then null else
@@ -132,7 +136,7 @@
     $.newIngesterZoneContainer('b', $.ingester_zone_b_args, $.ingester_zone_b_env_map),
 
   ingester_zone_b_statefulset: if !$._config.multi_zone_ingester_enabled then null else
-    $.newIngesterZoneStatefulSet('b', $.ingester_zone_b_container, $.ingester_zone_b_node_affinity_matchers) +
+    $.newIngesterZoneStatefulSet('b', $.ingester_zone_b_container, $._config.ingester_zone_b_data_disk_class, $.ingester_zone_b_node_affinity_matchers) +
     (if isZoneBEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}),
 
   ingester_zone_b_service: if !$._config.multi_zone_ingester_enabled then null else
@@ -142,7 +146,7 @@
     $.newIngesterZoneContainer('c', $.ingester_zone_c_args, $.ingester_zone_c_env_map),
 
   ingester_zone_c_statefulset: if !$._config.multi_zone_ingester_enabled then null else
-    $.newIngesterZoneStatefulSet('c', $.ingester_zone_c_container, $.ingester_zone_c_node_affinity_matchers) +
+    $.newIngesterZoneStatefulSet('c', $.ingester_zone_c_container, $._config.ingester_zone_c_data_disk_class, $.ingester_zone_c_node_affinity_matchers) +
     (if isZoneCEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}),
 
   ingester_zone_c_service: if !$._config.multi_zone_ingester_enabled then null else

--- a/operations/mimir/multi-zone-store-gateway.libsonnet
+++ b/operations/mimir/multi-zone-store-gateway.libsonnet
@@ -28,6 +28,12 @@
 
     multi_zone_store_gateway_zone_a_backup_multi_az_enabled: $._config.multi_zone_store_gateway_multi_az_enabled,
     multi_zone_store_gateway_zone_b_backup_multi_az_enabled: $._config.multi_zone_store_gateway_multi_az_enabled,
+
+    store_gateway_zone_a_data_disk_class: self.store_gateway_data_disk_class,
+    store_gateway_zone_b_data_disk_class: self.store_gateway_data_disk_class,
+    store_gateway_zone_c_data_disk_class: self.store_gateway_data_disk_class,
+    store_gateway_zone_a_backup_data_disk_class: self.store_gateway_data_disk_class,
+    store_gateway_zone_b_backup_data_disk_class: self.store_gateway_data_disk_class,
   },
 
   local container = $.core.v1.container,
@@ -129,10 +135,10 @@
     )) +
     (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}),
 
-  newStoreGatewayZoneStatefulSet(zone, container, nodeAffinityMatchers=[], rolloutGroup='store-gateway')::
+  newStoreGatewayZoneStatefulSet(zone, container, dataDiskClass, nodeAffinityMatchers=[], rolloutGroup='store-gateway')::
     local name = 'store-gateway-zone-%s' % zone;
 
-    $.newStoreGatewayStatefulSet(name, container, withAntiAffinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
+    $.newStoreGatewayStatefulSet(name, container, dataDiskClass, withAntiAffinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': rolloutGroup }) +
     statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_store_gateway_max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': rolloutGroup }) +
@@ -178,25 +184,25 @@
     $.newStoreGatewayZoneContainer('b-backup', $.store_gateway_zone_b_backup_args, $.store_gateway_zone_b_backup_env_map),
 
   store_gateway_zone_b_statefulset: if !$._config.multi_zone_store_gateway_enabled then null else
-    $.newStoreGatewayZoneStatefulSet('b', $.store_gateway_zone_b_container, $.store_gateway_zone_b_node_affinity_matchers) +
+    $.newStoreGatewayZoneStatefulSet('b', $.store_gateway_zone_b_container, $._config.store_gateway_zone_b_data_disk_class, $.store_gateway_zone_b_node_affinity_matchers) +
     (if isZoneBEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}),
 
   store_gateway_zone_a_statefulset: if !$._config.multi_zone_store_gateway_enabled then null else
-    $.newStoreGatewayZoneStatefulSet('a', $.store_gateway_zone_a_container, $.store_gateway_zone_a_node_affinity_matchers) +
+    $.newStoreGatewayZoneStatefulSet('a', $.store_gateway_zone_a_container, $._config.store_gateway_zone_a_data_disk_class, $.store_gateway_zone_a_node_affinity_matchers) +
     (if isZoneAEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}),
 
   store_gateway_zone_c_statefulset: if !$._config.multi_zone_store_gateway_zone_c_enabled then null else
-    $.newStoreGatewayZoneStatefulSet('c', $.store_gateway_zone_c_container, $.store_gateway_zone_c_node_affinity_matchers) +
+    $.newStoreGatewayZoneStatefulSet('c', $.store_gateway_zone_c_container, $._config.store_gateway_zone_c_data_disk_class, $.store_gateway_zone_c_node_affinity_matchers) +
     (if isZoneCEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}),
 
   store_gateway_zone_a_backup_statefulset: if !$._config.multi_zone_store_gateway_zone_a_backup_enabled then null else
-    $.newStoreGatewayZoneStatefulSet('a-backup', $.store_gateway_zone_a_backup_container, $.store_gateway_zone_a_backup_node_affinity_matchers) +
+    $.newStoreGatewayZoneStatefulSet('a-backup', $.store_gateway_zone_a_backup_container, $._config.store_gateway_zone_a_backup_data_disk_class, $.store_gateway_zone_a_backup_node_affinity_matchers) +
     (if isBackupAMultiAZEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}) +
     // Default to 0 replicas because we expect to use autoscaling and follow other zone replicas.
     statefulSet.mixin.spec.withReplicas(0),
 
   store_gateway_zone_b_backup_statefulset: if !$._config.multi_zone_store_gateway_zone_b_backup_enabled then null else
-    $.newStoreGatewayZoneStatefulSet('b-backup', $.store_gateway_zone_b_backup_container, $.store_gateway_zone_b_backup_node_affinity_matchers) +
+    $.newStoreGatewayZoneStatefulSet('b-backup', $.store_gateway_zone_b_backup_container, $._config.store_gateway_zone_b_backup_data_disk_class, $.store_gateway_zone_b_backup_node_affinity_matchers) +
     (if isBackupBMultiAZEnabled then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}) +
     // Default to 0 replicas because we expect to use autoscaling and follow other zone replicas.
     statefulSet.mixin.spec.withReplicas(0),

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -6,11 +6,11 @@
   local envVar = $.core.v1.envVar,
 
   // The store-gateway runs a statefulset.
-  local store_gateway_data_pvc =
+  local newStoreGatewayDataPvc(diskClass) =
     pvc.new() +
     pvc.mixin.spec.resources.withRequests({ storage: $._config.store_gateway_data_disk_size }) +
     pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
-    pvc.mixin.spec.withStorageClassName($._config.store_gateway_data_disk_class) +
+    pvc.mixin.spec.withStorageClassName(diskClass) +
     pvc.mixin.metadata.withName('store-gateway-data'),
 
   store_gateway_args::
@@ -91,7 +91,8 @@
 
   store_gateway_termination_grace_period_seconds:: 120,
 
-  newStoreGatewayStatefulSet(name, container, withAntiAffinity=false, nodeAffinityMatchers=[])::
+  newStoreGatewayStatefulSet(name, container, dataDiskClass, withAntiAffinity=false, nodeAffinityMatchers=[])::
+    local store_gateway_data_pvc = newStoreGatewayDataPvc(dataDiskClass);
     $.newMimirStatefulSet(name, 3, container, store_gateway_data_pvc) +
     $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds($.store_gateway_termination_grace_period_seconds) +
@@ -102,6 +103,7 @@
     self.newStoreGatewayStatefulSet(
       'store-gateway',
       $.store_gateway_container + (if std.length($.store_gateway_env_map) > 0 then container.withEnvMap(std.prune($.store_gateway_env_map)) else {}),
+      $._config.store_gateway_data_disk_class,
       !$._config.store_gateway_allow_multiple_replicas_on_same_node,
       $.store_gateway_node_affinity_matchers,
     ),


### PR DESCRIPTION
#### What this PR does

Add `ingester_zone_(a|b|c)_data_disk_class` and `store_gateway_zone_(a|b|c|a-backup|b-backup)_data_disk_class` config.

This is done in order to faciliate migrating disk class one zone at the time.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
