### PR TITLE
mixin: make compactor resources dashboard single-cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 ### Mixin
 
 * [CHANGE] Mixin: Default `_config.scrape_interval` is now `1m` (was `15s`) so precompiled recording rules and alerts work with common Alloy/ServiceMonitor scrape defaults. Rebuild the mixin if your scrape interval differs. #16178
+* [CHANGE] Dashboards: Make `cluster` and `namespace` single-select on the `Mimir / Compactor resources` dashboard. #16476
 * [FEATURE] Block-builder: add jsonnet for deploying the experimental block-builder and block-builder-scheduler. Enable with `block_builder.enabled: true`. #16175 #16337
 * [FEATURE] Alerts: Add `MimirBlockedQueryRuleExpired` and `MimirLimitedQueryRuleExpired`, firing when a `blocked_queries`/`limited_queries` rule's `expires_at` has passed. #16395
 * [FEATURE] Dashboards: Add a "Query blocking and rate limiting" row to the `Mimir / Queries` dashboard, showing blocked and limited queries by tenant and expired blocked/limited-query rules by tenant. #16395

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -4171,17 +4171,16 @@ data:
                    "type": "datasource"
                 },
                 {
-                   "allValue": ".+",
+                   "allValue": ".*",
                    "current": {
-                      "selected": true,
-                      "text": "All",
-                      "value": "$__all"
+                      "text": "prod",
+                      "value": "prod"
                    },
                    "datasource": "$datasource",
                    "hide": 0,
                    "includeAll": true,
                    "label": "cluster",
-                   "multi": true,
+                   "multi": false,
                    "name": "cluster",
                    "options": [ ],
                    "query": "label_values(cortex_build_info, cluster)",
@@ -4195,17 +4194,16 @@ data:
                    "useTags": false
                 },
                 {
-                   "allValue": ".+",
+                   "allValue": null,
                    "current": {
-                      "selected": true,
-                      "text": "All",
-                      "value": "$__all"
+                      "text": "prod",
+                      "value": "prod"
                    },
                    "datasource": "$datasource",
                    "hide": 0,
                    "includeAll": false,
                    "label": "namespace",
-                   "multi": true,
+                   "multi": false,
                    "name": "namespace",
                    "options": [ ],
                    "query": "label_values(cortex_build_info{cluster=~\"$cluster\"}, namespace)",

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor-resources.json
@@ -609,17 +609,16 @@
                "type": "datasource"
             },
             {
-               "allValue": ".+",
+               "allValue": ".*",
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "text": "prod",
+                  "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
                "includeAll": true,
                "label": "cluster",
-               "multi": true,
+               "multi": false,
                "name": "cluster",
                "options": [ ],
                "query": "label_values(cortex_build_info, cluster)",
@@ -633,17 +632,16 @@
                "useTags": false
             },
             {
-               "allValue": ".+",
+               "allValue": null,
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "text": "prod",
+                  "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
                "includeAll": false,
                "label": "namespace",
-               "multi": true,
+               "multi": false,
                "name": "namespace",
                "options": [ ],
                "query": "label_values(cortex_build_info{cluster=~\"$cluster\"}, namespace)",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -746,17 +746,16 @@
                "type": "datasource"
             },
             {
-               "allValue": ".+",
+               "allValue": ".*",
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "text": "prod",
+                  "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
                "includeAll": true,
                "label": "cluster",
-               "multi": true,
+               "multi": false,
                "name": "cluster",
                "options": [ ],
                "query": "label_values(cortex_build_info, cluster)",
@@ -770,17 +769,16 @@
                "useTags": false
             },
             {
-               "allValue": ".+",
+               "allValue": null,
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "text": "prod",
+                  "value": "prod"
                },
                "datasource": "$datasource",
                "hide": 0,
                "includeAll": false,
                "label": "namespace",
-               "multi": true,
+               "multi": false,
                "name": "namespace",
                "options": [ ],
                "query": "label_values(cortex_build_info{cluster=~\"$cluster\"}, namespace)",

--- a/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
@@ -6,7 +6,7 @@ local filename = 'mimir-compactor-resources.json';
     assert std.md5(filename) == '09a5c49e9cdb2f2b24c6d184574a07fd' : 'UID of the dashboard has changed, please update references to dashboard.';
     local compactor_scheduler_enabled = $._config.compactor_scheduler_enabled;
     ($.dashboard('Compactor resources') + { uid: std.md5(filename) })
-    .addClusterSelectorTemplates()
+    .addClusterSelectorTemplates(false)
     .addRow(
       $.row('Compactor resources')
       .addPanel(


### PR DESCRIPTION
#### What this PR does

The compactor resources dashboard isn't meant to be used for multiple cells, some panels don't make sense (e.g. aggregating by pod). Make `cluster` and `namespace` single-select. This is already the case for all the other resources dashboards.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.