### PR TITLE
mixin: add an explicit strong-consistency traffic guard

### DIFF
--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -245,7 +245,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               * 100 > 5
             )
             and
-            sum by (%(alert_aggregation_labels)s) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="true"}[%(range)s])) > 0
+            sum by (%(alert_aggregation_labels)s) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"}[%(range)s])) > 0
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             range: $.rateInterval('1m'),

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -238,10 +238,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('StrongConsistencyOffsetMissing'),
           'for': '5m',
           expr: |||
-            sum by (%(alert_aggregation_labels)s) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[%(range)s]))
-            /
-            sum by (%(alert_aggregation_labels)s) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"}[%(range)s]))
-            * 100 > 5
+            (
+              sum by (%(alert_aggregation_labels)s) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[%(range)s]))
+              /
+              sum by (%(alert_aggregation_labels)s) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"}[%(range)s]))
+              * 100 > 5
+            )
+            and
+            sum by (%(alert_aggregation_labels)s) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="true"}[%(range)s])) > 0
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             range: $.rateInterval('1m'),


### PR DESCRIPTION
#### What this PR does

Adds an explicit positive-total-traffic gate to `MimirStrongConsistencyOffsetMissing` in `operations/mimir-mixin/alerts/ingest-storage.libsonnet`.

**Verification correction:** the original claim that this fixes an eventual-consistency false positive was unsupported. The metric counts requests for strong consistency. `with_offset="false"` means a strong request lacks an offset, not that the request uses eventual consistency.

The original expression already returns no alert series when metrics are absent or both rates are zero. The added gate is redundant for the valid counter scenarios checked. No behavior-changing fix was demonstrated, and the previous RED-to-GREEN claim is withdrawn.

#### Verification

Prometheus promtool 3.5.0 evaluated the exact expressions from PR head `236f18b6`, PR-reported base `1a02a517`, and current main `3195332a`. All 21 assertions passed across seven scenarios: absent metrics, zero counters, all strong requests missing offsets, only the missing-offset series present, healthy offsets, 10% missing offsets, and 1% missing offsets. The three revisions produced identical results.

The ingester call path and metric definition were checked against source. Full Go suites and mixin compilation were not run for this review-only correction. No source changes were made during this verification.

#### Which issue(s) this PR fixes or relates to

No linked issue. The originally claimed runtime bug was not reproduced.

#### Checklist

- [ ] Tests updated on the branch.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated.
- [ ] `about-versioning.md` updated with experimental features.
