### PR TITLE
docs: document limited_queries and query rule metadata

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -246,6 +246,7 @@ The following features are currently experimental:
   - Server-side write timeout for responses to active series requests (`-query-frontend.active-series-write-timeout`)
   - Bounding the concurrency of sharded active series requests (`-query-frontend.active-series-max-shard-concurrency`)
   - Blocking HTTP requests on a per-tenant basis (configured with the `blocked_requests` limit)
+  - Rate limiting queries on a per-tenant basis (configured with the `limited_queries` limit)
   - Spinning off (as actual range queries) subqueries from instant queries (`-query-frontend.subquery-spin-off-enabled` and the `subquery_spin_off_enabled` per-tenant limit, as well as `-query-frontend.subquery-spin-off-simple-subqueries` and `-query-frontend.subquery-spin-off-with-excess-downstream-queries`)
   - Support for cluster validation via `-query-frontend.client-cluster-validation.label` or `-common.client-cluster-validation.label`.
     Requests with invalid cluster validation labels are tracked via the `cortex_client_invalid_cluster_validation_label_requests_total` metric.

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -108,13 +108,15 @@ To restrict the blocking to such selectors, use a regex pattern with the curly b
 
 To set up runtime overrides, refer to [runtime configuration](../about-runtime-configuration/).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The order of patterns is preserved, so the first matching pattern will be used.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Rate limit queries
 
-_Rate limiting queries with `limited_queries` is an experimental feature._
+{{< admonition type="note" >}}
+Rate limiting queries with `limited_queries` is an experimental feature.
+{{< /admonition >}}
 
 Use the `limited_queries` limit when a query should only be allowed to run once per configured time period.
 

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -10,10 +10,35 @@ In certain situations, you might want to control what queries are being sent to 
 might be intentionally or unintentionally expensive to run, and they might affect the overall stability or cost of running
 your service.
 
-Each rule must include a `pattern` field; rules without a pattern are a configuration error.
-Rules with `regex: true` must have a valid regular expression pattern; an invalid pattern is also a configuration error.
-To match all queries, use `pattern: ".*"` with `regex: true`.
-Optional filter conditions (`time_range_longer_than`, `step_size_shorter_than`, `unaligned_range_queries`) narrow which matching queries are blocked; all configured conditions must be satisfied to block.
+Mimir provides two per-tenant mechanisms for this, and you can use both at the same time:
+
+- `blocked_queries` rejects every matching query outright.
+- `limited_queries` allows a matching query to run no more often than a configured frequency, and rejects any matching query that arrives sooner.
+
+Blocking is evaluated before rate limiting, so a query that matches both a `blocked_queries` rule and a `limited_queries` rule is reported as blocked.
+
+## Block queries
+
+Each rule has the following attributes:
+
+- `pattern` - required for all rules and is either a complete PromQL query or a regular expression which will be used to match against PromQL queries
+- `regex` - a boolean field and must be set to `true` when the above pattern is to be treated as a regular expression. If the above pattern is not a valid pattern a configuration error will occur
+
+For instance, to match all queries, use `pattern: ".*"` with `regex: true`.
+
+Optional filter conditions can be applied to the matching criteria. These will narrow which queries are blocked and note that all configured conditions must be satisfied to block. See `time_range_longer_than`, `step_size_shorter_than`, `unaligned_range_queries` below.
+
+Optional metadata can be set on a block rule. None of these change which queries are blocked, but each one surfaces at runtime, either in the response returned to the caller, in the `query-frontend` logs, or as a metric:
+
+- `reason` - a string which is returned in the HTTP response to the caller. Use it to tell whoever ran the query why it was denied. The reason also appears in the `query-frontend` logs when a query is blocked.
+- `expires_at` - a date/time to flag when this rule should be re-evaluated for removal. When set, the [overrides-exporter](../../references/architecture/components/overrides-exporter/) emits the `cortex_blocked_query_rule_expires_at` metric, which you can use to monitor for expired rules. Once the rule is expired it is still enforced, and **it is not automatically removed or de-activated**.
+- `id` - a string to give a rule a unique ID. It's logged every time the rule blocks a query, so you can tell which rule matched. When `expires_at` is also set, the `id` is a label on the `cortex_blocked_query_rule_expires_at` metric, where rules that share an `id` are exported as a single series keyed on the earliest `expires_at` among them.
+
+Optional reference fields can be set. These have no functional impact and are for documentation / reference in the configuration file only:
+
+- `created_by` - a string to flag who requested or added this rule
+- `created_at` - a date/time to flag when this rule was added
+- `note` - a string to track why this rule was added. For instance, it could be set to a support ticket reference or an incident ID
 
 You can block queries using [per-tenant overrides](../about-runtime-configuration/):
 
@@ -24,9 +49,10 @@ overrides:
       # exact match
       - pattern: 'sum(rate(node_cpu_seconds_total{env="prod"}[1m]))'
 
-      # regex match
+      # regex match with expiry set
       - pattern: '.*env="prod".*'
         regex: true
+        expires_at: 2026-12-31T00:00:00Z
 
       # match all queries longer than 7 days
       - pattern: ".*"
@@ -49,6 +75,16 @@ overrides:
       # match this query only when the time range is not a multiple of the step
       - pattern: 'sum(rate(node_cpu_seconds_total{env="prod"}[1m]))'
         unaligned_range_queries: true
+
+      # a rule with additional metadata about why and when it was added
+      - pattern: rate(metric[5m])
+        regex: false
+        reason: High cardinality query - add labels to restrict the scope of this query
+        id: fccc06fc73fa9f32fd67f3b37bc82700e8adb3285f77fb5d7df9558a937645e4
+        note: "Incident #ABC123"
+        created_by: dev@grafana.com
+        created_at: 2026-08-26T12:12:18.531385+08:00
+        expires_at: 2026-09-26T12:12:18.531385+08:00
 ```
 
 The blocking is enforced on instant and range queries as well as remote read queries.
@@ -76,13 +112,54 @@ To set up runtime overrides, refer to [runtime configuration](../about-runtime-c
 The order of patterns is preserved, so the first matching pattern will be used.
 {{% /admonition %}}
 
-## Format queries to block
+## Rate limit queries
 
-You can ignore this section if you're not using a regular expression. If you are, you need to ensure that it matches against formatted queries as follows.
+*Rate limiting queries with `limited_queries` is an experimental feature.*
 
-Use Mimirtool's `mimirtool promql format <query>` command to apply the Prometheus formatter to a query that is expected to be blocked by the regular expression pattern, and then check the formatted query will match the regular expression.
+Use the `limited_queries` limit when a query should only be allowed to run once per configured time period.
 
-Mimir parses queries into PromQL expressions before blocking is applied. When a regular expression is not used, the pattern from the blocked queries is also similarly parsed before being compared against the formatted representation of the parsed query. When a regular expression is used, the pattern is used as-is. This process allows for consistent query blocking behavior regardless of formatting differences in the submitted queries.
+Rate limiting requires the `query-frontend` results cache. Enable it with `-query-frontend.cache-results`.
+
+Each rule has the following attributes:
+
+- `query` - required for all rules and must be a complete PromQL query. Note that there is no support for partial expressions or regular expressions
+- `allowed_frequency` - a duration field which defines the minimum time between two runs of this query. A matching query that arrives sooner is rejected. Being rejected doesn't extend the window: the next run is allowed `allowed_frequency` after the last query that was let through, not after the last attempt
+
+As per [block queries](#block-queries), the same optional metadata (`reason`, `expires_at`, `id`) are supported and also the same optional reference fields (`created_by`, `created_at`, `note`).
+
+When `expires_at` is set, the [overrides-exporter](../../references/architecture/components/overrides-exporter/) emits the `cortex_limited_query_rule_expires_at` metric, which you can use to monitor for expired rules.
+
+You can limit queries using [per-tenant overrides](../about-runtime-configuration/):
+
+```yaml
+overrides:
+  "tenant-id":
+    limited_queries:
+      # allow this query to run at most once a minute
+      - query: 'sum(rate(node_cpu_seconds_total{env="prod"}[1m]))'
+        allowed_frequency: 1m
+        reason: "this query is expensive and doesn't need to run more than once a minute"
+```
+
+Rate limiting is enforced on instant and range queries. Unlike blocking, it isn't enforced on remote read requests.
+
+When a matching query arrives less than `allowed_frequency` after the previous matching query was allowed, Mimir rejects it with HTTP status 429 and the [`err-mimir-query-limited`](../../manage/mimir-runbooks/#err-mimir-query-limited) error.
+
+`limited_queries` matches the query text exactly, ignoring only leading and trailing whitespace. The `query` rule must be in the canonicalized format of the query to be limited.
+
+See [Format queries to block or limit](#format-queries-to-block-or-limit) for using `mimirtool` to get a canonical version of a query.
+
+If more than one rule matches a query, Mimir enforces the matching rule with the longest `allowed_frequency`, and reports that rule's `reason` and `id`.
+
+## Format queries to block or limit
+
+**This section is important when using a regular expression block rule or a limited query rule.**
+
+When you observe a `param_query=...` in the `query-frontend` `query stats` log line, the PromQL is what was sent by the operator. Before the blocking and/or limiting rules are applied, this query will be canonicalized. This may result in the query being transformed.
+
+As such, **a regular expression pattern or limited query rule must be constructed to match the canonicalized version of a query**.
+
+Use Mimirtool's `mimirtool promql format <query>` command to apply the Prometheus formatter to a query that is expected to be blocked or limited, and then check the formatted query will match.
 
 Among other transformations the Prometheus formatter may reorder operators, remove empty selector braces, and eliminate newlines, extraneous whitespace, and comments.
 
@@ -125,17 +202,38 @@ rate(
 rate(metric_counter[15m]) / rate(other_counter[15m])
 ```
 
-## View blocked queries
+## Track expiring rules
 
-Blocked queries are logged with `msg="query blocked"` at info level, including the query text, duration, step, rule index, rule `id`, reason, and whether the matched rule's `expires_at` has passed (`expired`). Use these fields to identify which rule matched and why.
+`expires_at` is informational only. Mimir never stops enforcing a rule because it has expired: an expired rule keeps blocking or rate limiting matching queries until you remove it from the tenant's configuration.
+Use it so that rules added for a temporary reason, such as mitigating an incident, aren't forgotten indefinitely.
 
-Blocked queries are also counted in the `cortex_query_frontend_rejected_queries_total` metric per tenant (`user` label) with `reason="blocked"`. Note that the same metric tracks rate-limited queries under `reason="limited"`.
+The [overrides-exporter](../../references/architecture/components/overrides-exporter/) exports the expiry of each rule as:
 
-To see the rate of blocked queries by tenant:
+- `cortex_blocked_query_rule_expires_at{user, id}`
+- `cortex_limited_query_rule_expires_at{user, id}`
+
+The value is the Unix timestamp of the earliest `expires_at` among that tenant's rules that share the same `id`. Rules without an `id` are grouped together under an empty `id`.
+
+The `MimirBlockedQueryRuleExpired` and `MimirLimitedQueryRuleExpired` alerts fire when a tenant has at least one expired rule. Refer to [MimirBlockedQueryRuleExpired](../../manage/mimir-runbooks/#MimirBlockedQueryRuleExpired) and [MimirLimitedQueryRuleExpired](../../manage/mimir-runbooks/#MimirLimitedQueryRuleExpired).
+The **Query blocking and rate limiting** row on the **Mimir / Queries** dashboard shows the number of expired rules per tenant.
+
+## Observe blocked and rate limited queries
+
+Blocked queries are logged at info level with `msg="query blocked"`, including the query text (`query`), the query duration (`query_duration_ms`), the step (`step_ms`), the position of the matching rule in the tenant's `blocked_queries` list (`index`), the rule's `id` and `reason`, and whether the rule's `expires_at` has passed (`expired`).
+
+Rate limited queries are logged at info level with `msg="query limited"`, including the query text (`query`), the rule's `id` and `reason`, the `allowed_frequency` that was enforced, and whether the rule's `expires_at` has passed (`expired`).
+
+Use these fields to identify which rule matched and why.
+
+Both are counted in the `cortex_query_frontend_rejected_queries_total` metric per tenant (`user` label), with `reason="blocked"` for blocked queries and `reason="limited"` for rate limited ones.
+
+To see the rate of rejected queries by tenant:
 
 ```promql
 sum by (user, reason) (rate(cortex_query_frontend_rejected_queries_total[$__interval]))
 ```
+
+For the errors returned to clients, refer to [`err-mimir-query-blocked`](../../manage/mimir-runbooks/#err-mimir-query-blocked) and [`err-mimir-query-limited`](../../manage/mimir-runbooks/#err-mimir-query-limited).
 
 ## Troubleshoot invalid configuration
 

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -220,7 +220,7 @@ The [overrides-exporter](../../references/architecture/components/overrides-expo
 
 The value is the Unix timestamp of the earliest `expires_at` among that tenant's rules that share the same `id`. Rules without an `id` are grouped together under an empty `id`.
 
-The `MimirBlockedQueryRuleExpired` and `MimirLimitedQueryRuleExpired` alerts fire when a tenant has at least one expired rule. Refer to [MimirBlockedQueryRuleExpired](../../manage/mimir-runbooks/#MimirBlockedQueryRuleExpired) and [MimirLimitedQueryRuleExpired](../../manage/mimir-runbooks/#MimirLimitedQueryRuleExpired).
+The `MimirBlockedQueryRuleExpired` and `MimirLimitedQueryRuleExpired` **warnings** fire when a tenant has at least one expired rule. Refer to [MimirBlockedQueryRuleExpired](../../manage/mimir-runbooks/#MimirBlockedQueryRuleExpired) and [MimirLimitedQueryRuleExpired](../../manage/mimir-runbooks/#MimirLimitedQueryRuleExpired).
 The **Query blocking and rate limiting** row on the **Mimir / Queries** dashboard shows the number of expired rules per tenant.
 
 ## Observe blocked and rate limited queries

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -42,7 +42,7 @@ Optional reference fields can be set. These have no functional impact and are fo
 
 - `created_by` - a string to flag who requested or added this rule
 - `created_at` - a date/time to flag when this rule was added
-- `note` - a string to track why this rule was added. For instance, it could be set to a support ticket reference or an incident ID
+- `note` - a string to track why this rule was added. For instance, it could be set to a support ticket reference or an incident ID. This is only relevant for an operator reviewing Mimir configuration files, and this note is not surfaced to callers or emitted in any logs or metrics.
 
 You can block queries using [per-tenant overrides](../about-runtime-configuration/):
 

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -34,6 +34,10 @@ Optional metadata can be set on a block rule. None of these change which queries
 - `expires_at` - a date/time to flag when this rule should be re-evaluated for removal. When set, the [overrides-exporter](../../references/architecture/components/overrides-exporter/) emits the `cortex_blocked_query_rule_expires_at` metric, which you can use to monitor for expired rules. Once the rule is expired it is still enforced, and **it is not automatically removed or de-activated**.
 - `id` - a string to give a rule a unique ID. It's logged every time the rule blocks a query, so you can tell which rule matched. When `expires_at` is also set, the `id` is a label on the `cortex_blocked_query_rule_expires_at` metric, where rules that share an `id` are exported as a single series keyed on the earliest `expires_at` among them.
 
+{{< admonition type="note" >}}
+The `expires_at` should be used by an operator to mark a rule for future re-consideration. The emitted metric and corresponding warnings serve as the reminder mechanism. Often when a block rule is added it is only temporarily needed. It is important that stale block rules do not accumulate or become forgotten. It is encouraged to always set an `expires_at`.
+{{< /admonition >}}
+
 Optional reference fields can be set. These have no functional impact and are for documentation / reference in the configuration file only:
 
 - `created_by` - a string to flag who requested or added this rule

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -114,7 +114,7 @@ The order of patterns is preserved, so the first matching pattern will be used.
 
 ## Rate limit queries
 
-*Rate limiting queries with `limited_queries` is an experimental feature.*
+_Rate limiting queries with `limited_queries` is an experimental feature._
 
 Use the `limited_queries` limit when a query should only be allowed to run once per configured time period.
 

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -15,7 +15,7 @@ Mimir provides two per-tenant mechanisms for this, and you can use both at the s
 - `blocked_queries` rejects every matching query outright.
 - `limited_queries` allows a matching query to run no more often than a configured frequency, and rejects any matching query that arrives sooner.
 
-Blocking is evaluated before rate limiting, so a query that matches both a `blocked_queries` rule and a `limited_queries` rule is reported as blocked.
+Blocking is evaluated before rate limiting, so a query that matches both a `blocked_queries` rule and a `limited_queries` rule is blocked.
 
 ## Block queries
 

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -157,7 +157,7 @@ If more than one rule matches a query, Mimir enforces the matching rule with the
 
 **This section is important when using a regular expression block rule or a limited query rule.**
 
-When you observe a `param_query=...` in the `query-frontend` `query stats` log line, the PromQL is what was sent by the operator. Before the blocking and/or limiting rules are applied, this query will be canonicalized. This may result in the query being transformed.
+When you observe a `param_query=...` in the `query-frontend` `query stats` log line, the PromQL is what was sent by the caller. Before the blocking and/or limiting rules are applied, this query will be canonicalized. This may result in the query being transformed.
 
 As such, **a regular expression pattern or limited query rule must be constructed to match the canonicalized version of a query**.
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1105,7 +1105,7 @@ multiple `blocked_queries` rules, and this alert fires as long as any one of the
 How to **investigate**:
 
 - The `Query blocking and rate limiting` row on the `Mimir / Queries` dashboard shows the count of expired `blocked_queries` rules for the affected tenant, to help confirm scope.
-- Check the tenant's `blocked_queries` runtime config for rules with `expires_at` in the past, and check their `note`, `created_by`, and `created_at` fields for context on why they were added.
+- Check the tenant's `blocked_queries` runtime config for rules with `expires_at` in the past, and check their `note`, `created_by`, and `created_at` fields for context on why they were added. Refer to [Track expiring rules](../../configure/configure-blocked-queries/#track-expiring-rules).
 - If a rule is no longer needed, remove it. If it's still needed, update its `expires_at`.
 
 ### MimirLimitedQueryRuleExpired
@@ -1123,7 +1123,7 @@ multiple `limited_queries` rules, and this alert fires as long as any one of the
 How to **investigate**:
 
 - The `Query blocking and rate limiting` row on the `Mimir / Queries` dashboard shows the count of expired `limited_queries` rules for the affected tenant, to help confirm scope.
-- Check the tenant's `limited_queries` runtime config for rules with `expires_at` in the past, and check their `note`, `created_by`, and `created_at` fields for context on why they were added.
+- Check the tenant's `limited_queries` runtime config for rules with `expires_at` in the past, and check their `note`, `created_by`, and `created_at` fields for context on why they were added. Refer to [Track expiring rules](../../configure/configure-blocked-queries/#track-expiring-rules).
 - If a rule is no longer needed, remove it. If it's still needed, update its `expires_at`.
 
 ### MimirSchedulerQueriesStuck
@@ -3372,7 +3372,7 @@ This error occurs when a query-frontend blocks a read request because the query 
 How it **works**:
 
 - The query-frontend implements a middleware responsible for assessing whether the query is blocked or not.
-- To configure the limit, set the block `blocked_queries` in the `limits`.
+- To configure the limit, set the block `blocked_queries` in the `limits`. Refer to [Block queries](../../configure/configure-blocked-queries/#block-queries).
 
 How to **fix** it:
 
@@ -3385,7 +3385,7 @@ This error occurs when a query-frontend blocks a read request because the query 
 How it **works**:
 
 - The query-frontend implements a middleware responsible for assessing whether the query should be limited and whether it has been run within the last allowed frequency.
-- To configure the limit, set the block `limited_queries` in the `limits`.
+- To configure the limit, set the block `limited_queries` in the `limits`. Refer to [Rate limit queries](../../configure/configure-blocked-queries/#rate-limit-queries).
 
 How to **fix** it:
 


### PR DESCRIPTION
#### What this PR does

This PR updates our documentation on query blocking and query limiting. 

These updates include documentation related to the recent addition of the metadata fields and limited query blocking reason added in #16395 & #16407.

Record limited_queries as experimental in about-versioning.md, and cross-link the runbook alert and error entries to the relevant sections.

No change-log has been recorded since this is documentation only. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
