### PR TITLE
[WIP] block-builder: verify block integrity before upload in block-builder

### DIFF
--- a/pkg/blockbuilder/config.go
+++ b/pkg/blockbuilder/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	ApplyMaxGlobalSeriesPerUserBelow int `yaml:"apply_max_global_series_per_user_below" category:"experimental"`
 
 	GenerateSparseIndexHeaders bool `yaml:"generate_sparse_index_headers" category:"experimental"`
+	VerifyBlocksBeforeUpload   bool `yaml:"verify_blocks_before_upload" category:"experimental"`
 
 	// Config parameters defined outside the block-builder config and are injected dynamically.
 	Kafka         ingest.KafkaConfig       `yaml:"-"`
@@ -63,6 +64,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.DataDir, "block-builder.data-dir", "./data-block-builder/", "Directory to temporarily store blocks during building. This directory is wiped out between the restarts.")
 	f.IntVar(&cfg.ApplyMaxGlobalSeriesPerUserBelow, "block-builder.apply-max-global-series-per-user-below", 0, "Apply the global series limit per partition if the global series limit for the user is <= this given value. 0 means limits are disabled. If a user's limit is more than the given value, then the limits are not applied as well.")
 	f.BoolVar(&cfg.GenerateSparseIndexHeaders, "block-builder.generate-sparse-index-headers", false, "Construct and upload sparse index headers to object storage as part of block creation. This makes the sparse headers available to store-gateways when loading uncompacted blocks.")
+	f.BoolVar(&cfg.VerifyBlocksBeforeUpload, "block-builder.verify-blocks-before-upload", false, "Verify the integrity of each block before uploading it to object storage. If verification fails, the block is not uploaded and the job fails.")
 
 	cfg.SchedulerConfig.RegisterFlags(f)
 }

--- a/pkg/blockbuilder/metrics.go
+++ b/pkg/blockbuilder/metrics.go
@@ -49,6 +49,8 @@ type tsdbBuilderMetrics struct {
 	compactAndUploadFailed             *prometheus.CounterVec
 	earlyCompactionsTriggered          *prometheus.CounterVec
 	lastSuccessfulCompactAndUploadTime *prometheus.GaugeVec
+	blockVerificationDuration          *prometheus.HistogramVec
+	blockVerificationFailed            *prometheus.CounterVec
 }
 
 func newTSDBBuilderMetrics(reg prometheus.Registerer) tsdbBuilderMetrics {
@@ -78,6 +80,17 @@ func newTSDBBuilderMetrics(reg prometheus.Registerer) tsdbBuilderMetrics {
 	m.lastSuccessfulCompactAndUploadTime = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Name: "cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds",
 		Help: "Unix timestamp (in seconds) of the last successful tsdb block compacted and uploaded to the object storage on a partition.",
+	}, []string{"partition"})
+
+	m.blockVerificationDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:                        "cortex_blockbuilder_tsdb_block_verification_duration_seconds",
+		Help:                        "Time spent verifying the blocks of one partition before upload.",
+		NativeHistogramBucketFactor: 1.1,
+	}, []string{"partition"})
+
+	m.blockVerificationFailed = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_blockbuilder_tsdb_block_verification_failed_total",
+		Help: "Total number of blocks that failed verification before upload.",
 	}, []string{"partition"})
 
 	return m

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -33,6 +33,7 @@ import (
 	mimir_storage "github.com/grafana/mimir/pkg/storage"
 	"github.com/grafana/mimir/pkg/storage/indexheader"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/util/globalerror"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -50,6 +51,9 @@ type TSDBBuilder struct {
 	logger             log.Logger
 	tsdbBuilderMetrics tsdbBuilderMetrics
 	tsdbMetrics        *mimir_tsdb.TSDBMetrics
+
+	// verifyBlock verifies the integrity of a block before upload. Overridable in tests.
+	verifyBlock func(ctx context.Context, logger log.Logger, blockDir string, minTime, maxTime int64, checkChunks bool) error
 
 	// Number of series in memory across all tenants.
 	seriesCount atomic.Int64
@@ -88,6 +92,7 @@ func NewTSDBBuilder(
 		logger:             logger,
 		tsdbBuilderMetrics: tsdbBuilderMetrics,
 		tsdbMetrics:        tsdbMetrics,
+		verifyBlock:        block.VerifyBlock,
 	}
 }
 
@@ -512,12 +517,12 @@ func (b *TSDBBuilder) CompactAndUpload(ctx context.Context, uploadBlocks blockUp
 	}
 	for tenant, db := range b.tsdbs {
 		eg.Go(func() (err error) {
+			partitionStr := strconv.Itoa(int(tenant.partitionID))
 			defer func(t time.Time) {
 				if errors.Is(err, context.Canceled) {
 					// Don't track any metrics if context was cancelled. Otherwise, it might be misleading.
 					return
 				}
-				partitionStr := strconv.Itoa(int(tenant.partitionID))
 				if err != nil {
 					b.tsdbBuilderMetrics.compactAndUploadFailed.WithLabelValues(partitionStr).Inc()
 					return
@@ -535,6 +540,12 @@ func (b *TSDBBuilder) CompactAndUpload(ctx context.Context, uploadBlocks blockUp
 			var localMetas []tsdb.BlockMeta
 			for _, b := range db.Blocks() {
 				localMetas = append(localMetas, b.Meta())
+			}
+
+			if b.cfg.VerifyBlocksBeforeUpload {
+				if err := b.verifyBlocks(ctx, partitionStr, dbDir, localMetas); err != nil {
+					return err
+				}
 			}
 
 			if b.cfg.GenerateSparseIndexHeaders {
@@ -652,6 +663,25 @@ func (u *userTSDB) compactBlocks(ctx context.Context, blockRange, maxTime int64,
 		return err
 	}
 
+	return nil
+}
+
+// verifyBlocks verifies the integrity of each block in the metas list in the directory, before it is uploaded.
+// On failure, the block's ULID and error are logged and the failure metric is incremented.
+func (b *TSDBBuilder) verifyBlocks(ctx context.Context, partition, dbDir string, metas []tsdb.BlockMeta) error {
+	start := time.Now()
+	defer func() {
+		b.tsdbBuilderMetrics.blockVerificationDuration.WithLabelValues(partition).Observe(time.Since(start).Seconds())
+	}()
+
+	for _, m := range metas {
+		blockDir := filepath.Join(dbDir, m.ULID.String())
+		if err := b.verifyBlock(ctx, b.logger, blockDir, m.MinTime, m.MaxTime, false); err != nil {
+			b.tsdbBuilderMetrics.blockVerificationFailed.WithLabelValues(partition).Inc()
+			level.Error(b.logger).Log("msg", "block verification failed", "block", m.ULID.String(), "err", err)
+			return fmt.Errorf("verify block %s: %w", m.ULID.String(), err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -485,6 +485,78 @@ func TestTSDBBuilder_CompactAndUpload_fail(t *testing.T) {
 	require.ErrorIs(t, err, errUploadFailed)
 }
 
+func TestTSDBBuilder_CompactAndUpload_verificationFail(t *testing.T) {
+	partitionID := int32(0)
+	userID := "user1"
+
+	config, overrides := blockBuilderConfig(t, "kafka:9092", nil)
+	config.VerifyBlocksBeforeUpload = true
+	logger := log.NewNopLogger()
+	registry := prometheus.NewPedanticRegistry()
+	tsdbBuilderMetrics := newTSDBBuilderMetrics(registry)
+	tsdbMetrics := mimir_tsdb.NewTSDBMetrics(prometheus.NewPedanticRegistry(), logger)
+	builder := NewTSDBBuilder(partitionID, config, overrides, logger, tsdbBuilderMetrics, tsdbMetrics)
+	t.Cleanup(func() {
+		require.NoError(t, builder.Close())
+	})
+
+	errVerificationFailed := fmt.Errorf("verification failed")
+	builder.verifyBlock = func(_ context.Context, _ log.Logger, _ string, _, _ int64, _ bool) error {
+		return errVerificationFailed
+	}
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+	req := createWriteRequest(userID, floatSample(1000, 1), nil)
+	require.NoError(t, builder.PushToStorageAndReleaseRequest(ctx, &req))
+
+	uploaderCalled := false
+	_, err := builder.CompactAndUpload(ctx, func(_ context.Context, _, _ string, _ []tsdb.BlockMeta) error {
+		uploaderCalled = true
+		return nil
+	})
+	require.ErrorIs(t, err, errVerificationFailed)
+	require.False(t, uploaderCalled, "the uploader must not be called when block verification fails")
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+		# HELP cortex_blockbuilder_tsdb_block_verification_failed_total Total number of blocks that failed verification before upload.
+		# TYPE cortex_blockbuilder_tsdb_block_verification_failed_total counter
+		cortex_blockbuilder_tsdb_block_verification_failed_total{partition="0"} 1
+	`), "cortex_blockbuilder_tsdb_block_verification_failed_total"))
+	require.Equal(t, 1, testutil.CollectAndCount(tsdbBuilderMetrics.blockVerificationDuration), "verification duration should still be observed on failure")
+}
+
+func TestTSDBBuilder_CompactAndUpload_verificationDisabled(t *testing.T) {
+	partitionID := int32(0)
+	userID := "user1"
+
+	config, overrides := blockBuilderConfig(t, "kafka:9092", nil)
+	config.VerifyBlocksBeforeUpload = false
+	logger := log.NewNopLogger()
+	registry := prometheus.NewPedanticRegistry()
+	tsdbBuilderMetrics := newTSDBBuilderMetrics(registry)
+	tsdbMetrics := mimir_tsdb.NewTSDBMetrics(prometheus.NewPedanticRegistry(), logger)
+	builder := NewTSDBBuilder(partitionID, config, overrides, logger, tsdbBuilderMetrics, tsdbMetrics)
+	t.Cleanup(func() {
+		require.NoError(t, builder.Close())
+	})
+
+	builder.verifyBlock = func(_ context.Context, _ log.Logger, _ string, _, _ int64, _ bool) error {
+		t.Fatal("verifyBlock must not be called when verification is disabled")
+		return nil
+	}
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+	req := createWriteRequest(userID, floatSample(1000, 1), nil)
+	require.NoError(t, builder.PushToStorageAndReleaseRequest(ctx, &req))
+
+	shipperDir := t.TempDir()
+	_, err := builder.CompactAndUpload(ctx, mockUploaderFunc(t, shipperDir))
+	require.NoError(t, err)
+
+	require.Equal(t, 0, testutil.CollectAndCount(tsdbBuilderMetrics.blockVerificationFailed))
+	require.Equal(t, 0, testutil.CollectAndCount(tsdbBuilderMetrics.blockVerificationDuration))
+}
+
 func validateSparseIndexHeadersInDir(t *testing.T, ctx context.Context, dbDir string, cfg Config) []ulid.ULID {
 	ll := log.NewNopLogger()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Block-builder currently uploads blocks to object storage without verifying their structural integrity, so a corrupt block can reach the compactor undetected.

This PR reuses the compactor's existing `block.VerifyBlock` check and runs it in block-builder right after compaction and before upload. If verification fails, the block is not uploaded and the job fails (so it gets retried), instead of silently shipping a bad block.

This is currently sat behind an experimental flag (`-block-builder.verify-blocks-before-upload`), off by default, until its performance cost is measured. Currently monitoring the change with a dedicated `cortex_blockbuilder_tsdb_block_verification_duration_seconds` metric that isolates that cost from existing upload/compaction metrics.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3772

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
