### PR TITLE
MQE: Experimental Grouped Fill operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [ENHANCEMENT] Query-frontend: Improve the stability of cardinality estimates and therefore sharding factors for queries when running splitting and caching inside MQE is enabled, or range vector splitting is enabled. #16274 #16301 #16305 #16311
   * When running splitting and caching inside MQE is enabled, the `cortex_query_frontend_cardinality_estimation_difference` metric will no longer be emitted.
 * [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
-* [ENHANCEMENT] MQE: Add experimental support for `fill`, `fill_left`, and `fill_right` modifiers for filling missing samples in one-to-one binary operations. #16071
+* [ENHANCEMENT] MQE: Add experimental support for `fill`, `fill_left`, and `fill_right` modifiers for filling missing samples in one-to-one, one-to-many and many-to-one binary operations. #16071 #16494
 * [ENHANCEMENT] Ruler: Split oversized remote distributor writes to keep resulting calls within the configured gRPC maximum send size, and expose the number of generated requests in `cortex_ruler_remote_distributor_requests_per_write_request`. #16160
 * [ENHANCEMENT] Alerts: Don't fire `MimirMemberlistZoneAwareRoutingAutoFailover` while the node is still joining the cluster. #16315
 * [ENHANCEMENT] Store-gateway: added a `route` label to the `cortex_bucket_store_series_request_stage_duration_seconds` metric to match the `route` label of `cortex_request_duration_seconds`. #16374

--- a/pkg/querier/dispatcher.go
+++ b/pkg/querier/dispatcher.go
@@ -136,11 +136,13 @@ func (d *Dispatcher) evaluateQuery(ctx context.Context, body []byte, resp *query
 	}
 
 	nodeIndices := make([]int64, 0, len(req.Nodes))
+	nodeTimeRanges := make([]types.QueryTimeRange, 0, len(req.Nodes))
 	for _, node := range req.Nodes {
 		nodeIndices = append(nodeIndices, node.NodeIndex)
+		nodeTimeRanges = append(nodeTimeRanges, node.TimeRange.Decode())
 	}
 
-	nodes, err := req.Plan.DecodeNodes(nodeIndices...)
+	nodes, err := req.Plan.DecodeNodesWithTimeRanges(nodeIndices, nodeTimeRanges)
 	if err != nil {
 		resp.WriteError(ctx, apierror.TypeBadData, fmt.Errorf("could not decode plan: %w", err))
 		return
@@ -152,7 +154,7 @@ func (d *Dispatcher) evaluateQuery(ctx context.Context, body []byte, resp *query
 	for idx, node := range nodes {
 		nodeRequests = append(nodeRequests, streamingpromql.NodeEvaluationRequest{
 			Node:      node,
-			TimeRange: req.Nodes[idx].TimeRange.Decode(),
+			TimeRange: nodeTimeRanges[idx],
 		})
 
 		nodeToIndexMap[node] = req.Nodes[idx].NodeIndex

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -78,13 +78,7 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 	// The goal of this is not to list every conceivable expression that is unsupported, but to cover all the
 	// different cases and make sure we produce a reasonable error message when these cases are encountered.
 	unsupportedExpressions := map[string]string{
-		// Grouped (group_left/group_right) fills are not supported yet.
-		"left_vector + on(instance) group_left fill_right(0) right_vector": "'fill' modifier with many-to-one/one-to-many matching (group_left/group_right)",
-		"left_vector + on(instance) group_left fill(0) right_vector":       "'fill' modifier with many-to-one/one-to-many matching (group_left/group_right)",
-		"left_vector + on(instance) group_right fill_left(0) right_vector": "'fill' modifier with many-to-one/one-to-many matching (group_left/group_right)",
-
-		// Fills with __name__ in the 'on' clause are not supported yet: two match groups that
-		// differ only by __name__ produce the same filled output series.
+		// Filled output labels drop __name__, which can merge distinct match groups into one output series.
 		"left_vector + on(__name__, instance) fill_left(0) right_vector":  "'fill' modifier with __name__ in the 'on' clause",
 		"left_vector + on(__name__, instance) fill_right(0) right_vector": "'fill' modifier with __name__ in the 'on' clause",
 		"left_vector + on(__name__, instance) fill(0) right_vector":       "'fill' modifier with __name__ in the 'on' clause",
@@ -99,6 +93,8 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 		"left_vector == bool on(__name__, instance) fill_right(0) right_vector": "'fill' modifier with __name__ in the 'on' clause",
 		// The grammar also accepts fill_left and fill_right together.
 		"left_vector + on(__name__, instance) fill_left(0) fill_right(0) right_vector": "'fill' modifier with __name__ in the 'on' clause",
+		"left_vector + on(__name__, instance) group_left fill(0) right_vector":         "'fill' modifier with __name__ in the 'on' clause",
+		"left_vector + on(__name__, instance) group_right fill(0) right_vector":        "'fill' modifier with __name__ in the 'on' clause",
 
 		"start_timestamp(vector(0))": "'start_timestamp' function",
 	}

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -311,77 +311,93 @@ func newVectorVectorBinaryOperationEvaluator(
 
 }
 
-// missingLeftMode selects what computeResult does at a timestep where only the right side has a
-// sample. When e.fillLeft is set, computeResult synthesises a left operand from the fill value.
-// When e.fillLeft is nil, computeResult drops the timestep regardless of this mode.
-type missingLeftMode int
+// missingSideMode selects how computeResult handles a missing-side timestep.
+type missingSideMode int
 
 const (
-	// missingLeftInResult adds a kept fill-left point to result, next to every other kept point. It
-	// is the default mode. Every caller that does not split a match group needs it.
-	missingLeftInResult missingLeftMode = iota
+	// missingInResult adds each kept fill point to the main result.
+	missingInResult missingSideMode = iota
 
-	// missingLeftSeparate adds a kept fill-left point to fillLeftResult instead of result. This lets
-	// the caller give the fill-left points labels that differ from the labels of the other points.
-	//
-	// Upstream Prometheus builds the missing left operand from the right series' match labels only
-	// and drops __name__. A kept fill-left timestep for a name-retaining operator therefore has no
-	// metric name. Only the one-to-one operator asks for this mode. It asks only for a matched
-	// group, and only when the operator retains __name__ and fillLeft is set. See
-	// OneToOneVectorVectorBinaryOperation.computeOutputSeries.
-	//
-	// Example expression: `a > ignoring(foo) fill_left(0) b`
-	// A comparison operator without `bool` retains __name__, and `ignoring(...)` (not `on(...)`)
-	// matching is used, so a fill-left timestep on a matched group produces two output series: one
-	// with __name__ (from the right series' match labels) and one without.
+	// missingLeftSeparate adds kept missing-left points to the separate result.
 	missingLeftSeparate
 
-	// missingLeftSkip evaluates no fill-left timestep at all. computeResult then produces neither a
-	// point nor an annotation for such a timestep.
-	missingLeftSkip
+	// missingSkip evaluates no fill timestep and produces no annotation.
+	missingSkip
 )
 
-// fillLeftOptions controls the fill-left branch of computeResult.
-//
-// The zero value (mode == missingLeftInResult, leftSidePresence == nil) keeps every fill-left point
-// in result. A nil leftSidePresence means "evaluate every fill-left timestep"; an empty non-nil
-// slice means "no timestep has a left sample", which is a different value. Every caller that does
-// not split a match group uses the zero value.
-type fillLeftOptions struct {
-	// mode selects what computeResult does at a timestep where only the right side has a sample.
-	mode missingLeftMode
+// missingSideOptions controls one missing-side branch.
+// Its zero value evaluates every eligible timestep and adds kept points to the main result.
+type missingSideOptions struct {
+	mode missingSideMode
 
-	// leftSidePresence holds one entry per step of the query time range. Each entry is the index of
-	// the left series with a sample at that step. The entry is -1 when no left series has a sample at
-	// that step. computeResult skips every fill-left timestep whose entry is not -1.
-	//
-	// A nil leftSidePresence means that computeResult evaluates every fill-left timestep. Only the
-	// missingLeftSeparate mode uses this field.
-	//
-	// The one-to-one operator passes the presence of the whole match group here. That keeps the
-	// evaluator from raising an annotation for a step where the operator emits no point.
-	leftSidePresence []int
+	// groupPresence records one series index per present step and uses -1 for absent steps.
+	// A nil slice evaluates every eligible timestep.
+	groupPresence []int
 }
 
-// evaluatesStepAt reports whether computeResult evaluates the fill-left timestep at timestamp t.
-func (o fillLeftOptions) evaluatesStepAt(t int64, timeRange *types.QueryTimeRange) bool {
+// validate checks the mode and presence length for one side.
+func (o missingSideOptions) validate(side string, stepCount int) error {
 	switch o.mode {
-	case missingLeftSkip:
-		return false
+	case missingInResult, missingSkip:
 	case missingLeftSeparate:
-		return o.leftSidePresence == nil || o.leftSidePresence[timeRange.PointIndex(t)] == -1
+		if side == "right" {
+			return fmt.Errorf("mode %d cannot produce separate missing-right output", o.mode)
+		}
 	default:
-		return true
+		return fmt.Errorf("unknown missing-%s mode %d", side, o.mode)
+	}
+
+	if o.groupPresence != nil && len(o.groupPresence) != stepCount {
+		return fmt.Errorf("missing-%s presence has length %d, expected %d", side, len(o.groupPresence), stepCount)
+	}
+
+	return nil
+}
+
+// evaluatesStepAt reports whether computeResult evaluates the fill timestep at timestamp t.
+func (o missingSideOptions) evaluatesStepAt(t int64, timeRange *types.QueryTimeRange) (bool, error) {
+	switch o.mode {
+	case missingSkip:
+		return false, nil
+	default:
+		if o.groupPresence == nil {
+			return true, nil
+		}
+
+		stepIndex := timeRange.PointIndex(t)
+		if stepIndex < 0 || stepIndex >= int64(len(o.groupPresence)) {
+			indexErr := fmt.Errorf("step index %d is outside presence length %d", stepIndex, len(o.groupPresence))
+			return false, fmt.Errorf("look up group presence at timestamp %d: %w", t, indexErr)
+		}
+
+		return o.groupPresence[stepIndex] == -1, nil
 	}
 }
 
-// computeResult evaluates the binary operation over the two operands and returns the result.
-//
-// fillLeft controls the fill-left branch. That branch handles a timestep where only the right side
-// has a sample. The evaluator must also have a fill value for the left operand. The zero value of
-// fillLeft adds every kept point to result and leaves fillLeftResult as the zero value. See
-// fillLeftOptions for the other modes.
-func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantVectorSeriesData, right types.InstantVectorSeriesData, takeOwnershipOfLeft bool, takeOwnershipOfRight bool, fillLeft fillLeftOptions) (result types.InstantVectorSeriesData, fillLeftResult types.InstantVectorSeriesData, err error) {
+// computeResultOptions controls timesteps with one missing operand.
+// Its zero value evaluates every eligible fill timestep.
+type computeResultOptions struct {
+	missingLeft  missingSideOptions
+	missingRight missingSideOptions
+}
+
+// validate checks both missing-side options before evaluation.
+func (o computeResultOptions) validate(stepCount int) error {
+	if err := o.missingLeft.validate("left", stepCount); err != nil {
+		return fmt.Errorf("validate missing-left options: %w", err)
+	}
+	if err := o.missingRight.validate("right", stepCount); err != nil {
+		return fmt.Errorf("validate missing-right options: %w", err)
+	}
+	return nil
+}
+
+// computeResult evaluates the binary operation over both operands.
+func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantVectorSeriesData, right types.InstantVectorSeriesData, takeOwnershipOfLeft bool, takeOwnershipOfRight bool, options computeResultOptions) (result types.InstantVectorSeriesData, fillLeftResult types.InstantVectorSeriesData, err error) {
+	if err := options.validate(e.timeRange.StepCount); err != nil {
+		return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, fmt.Errorf("validate compute result options: %w", err)
+	}
+
 	var fPoints []promql.FPoint
 	var hPoints []promql.HPoint
 
@@ -631,8 +647,14 @@ func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantV
 		case lOk && (!rOk || lT < rT):
 			// Only the left side has a sample; fill the right operand if a fill value is set.
 			if e.fillRight != nil {
-				if err := appendNextSample(lT, lF, *e.fillRight, lH, nil, false); err != nil {
-					return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, err
+				evaluate, err := options.missingRight.evaluatesStepAt(lT, &e.timeRange)
+				if err != nil {
+					return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, fmt.Errorf("evaluate missing-right timestep: %w", err)
+				}
+				if evaluate {
+					if err := appendNextSample(lT, lF, *e.fillRight, lH, nil, false); err != nil {
+						return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, err
+					}
 				}
 			}
 		default:
@@ -643,11 +665,16 @@ func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantV
 			// group at once, so it only evaluates a fill-left timestep for the one output series that
 			// owns the group's fill-left points. Earlier output series in the group never see that
 			// timestep at all, so they raise no annotation for it either.
-			if e.fillLeft != nil && fillLeft.evaluatesStepAt(rT, &e.timeRange) {
-				// In the missingLeftSeparate mode, appendNextSample adds this kept point to the fill-left
-				// output stream so the caller can give it name-dropped labels.
-				if err := appendNextSample(rT, *e.fillLeft, rF, nil, rH, fillLeft.mode == missingLeftSeparate); err != nil {
-					return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, err
+			if e.fillLeft != nil {
+				evaluate, err := options.missingLeft.evaluatesStepAt(rT, &e.timeRange)
+				if err != nil {
+					return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, fmt.Errorf("evaluate missing-left timestep: %w", err)
+				}
+				if evaluate {
+					// missingLeftSeparate sends this point to the separate output.
+					if err := appendNextSample(rT, *e.fillLeft, rF, nil, rH, options.missingLeft.mode == missingLeftSeparate); err != nil {
+						return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, err
+					}
 				}
 			}
 		}

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -311,27 +311,38 @@ func newVectorVectorBinaryOperationEvaluator(
 
 }
 
-// missingSideMode selects how computeResult handles a missing-side timestep.
+// missingSideMode selects how computeResult handles a timestep containing only the opposite operand.
+// A configured fill value must exist, or computeResult drops the timestep regardless of this mode.
 type missingSideMode int
 
 const (
 	// missingInResult adds each kept fill point to the main result.
+	// Callers use this default unless missing-left points require distinct labels.
 	missingInResult missingSideMode = iota
 
-	// missingLeftSeparate adds kept missing-left points to the separate result.
+	// missingLeftSeparate adds kept missing-left points to fillLeftResult instead of result.
+	// This lets the caller apply labels that differ from the other result points.
+	// Prometheus builds a missing left operand from the right series' matching labels and removes __name__.
+	// A name-retaining operator can therefore produce differently labelled points within one match group.
+	// Only one-to-one matching uses this mode for groups needing separate name-dropped output.
+	// For example, `a > ignoring(foo) fill_left(0) b` keeps names for matches but drops names for filled points.
 	missingLeftSeparate
 
-	// missingSkip evaluates no fill timestep and produces no annotation.
+	// missingSkip suppresses all fill evaluation for that side.
+	// It produces neither a point nor an annotation.
 	missingSkip
 )
 
-// missingSideOptions controls one missing-side branch.
-// Its zero value evaluates every eligible timestep and adds kept points to the main result.
+// missingSideOptions controls one missing-side branch of computeResult.
+// Its zero value evaluates every eligible fill timestep and adds kept points to the main result.
 type missingSideOptions struct {
 	mode missingSideMode
 
-	// groupPresence records one series index per present step and uses -1 for absent steps.
-	// A nil slice evaluates every eligible timestep.
+	// groupPresence contains one entry for each query step.
+	// Each entry identifies a present series, while -1 indicates no series.
+	// computeResult skips fill timesteps where any group series is present.
+	// A nil groupPresence evaluates every eligible fill timestep.
+	// Matching operators pass whole-group presence to avoid annotations for suppressed points.
 	groupPresence []int
 }
 
@@ -374,8 +385,9 @@ func (o missingSideOptions) evaluatesStepAt(t int64, timeRange *types.QueryTimeR
 	}
 }
 
-// computeResultOptions controls timesteps with one missing operand.
-// Its zero value evaluates every eligible fill timestep.
+// computeResultOptions controls both missing-side branches.
+// missingLeft handles right-only timesteps, while missingRight handles left-only timesteps.
+// Its zero value evaluates every eligible fill timestep and adds kept points to the main result.
 type computeResultOptions struct {
 	missingLeft  missingSideOptions
 	missingRight missingSideOptions
@@ -393,6 +405,9 @@ func (o computeResultOptions) validate(stepCount int) error {
 }
 
 // computeResult evaluates the binary operation over both operands.
+// options.missingLeft controls right-only timesteps that require fillLeft.
+// options.missingRight controls left-only timesteps that require fillRight.
+// fillLeftResult contains points only when missingLeftSeparate is selected.
 func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantVectorSeriesData, right types.InstantVectorSeriesData, takeOwnershipOfLeft bool, takeOwnershipOfRight bool, options computeResultOptions) (result types.InstantVectorSeriesData, fillLeftResult types.InstantVectorSeriesData, err error) {
 	if err := options.validate(e.timeRange.StepCount); err != nil {
 		return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, fmt.Errorf("validate compute result options: %w", err)
@@ -671,7 +686,7 @@ func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantV
 					return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, fmt.Errorf("evaluate missing-left timestep: %w", err)
 				}
 				if evaluate {
-					// missingLeftSeparate sends this point to the separate output.
+					// missingLeftSeparate sends this point to the name-dropped output stream.
 					if err := appendNextSample(rT, *e.fillLeft, rF, nil, rH, options.missingLeft.mode == missingLeftSeparate); err != nil {
 						return types.InstantVectorSeriesData{}, types.InstantVectorSeriesData{}, err
 					}

--- a/pkg/streamingpromql/operators/binops/binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation_test.go
@@ -4,16 +4,21 @@ package binops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
 func TestBuildMatchers(t *testing.T) {
@@ -298,4 +303,371 @@ func TestTrimOperatorsRespectMutability(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestVectorVectorBinaryOperationEvaluator_MissingSideOptions(t *testing.T) {
+	timeRange := types.NewRangeQueryTimeRange(time.Unix(0, 0), time.Unix(60, 0), time.Minute)
+	firstStep := timeRange.IndexTime(0)
+	secondStep := timeRange.IndexTime(1)
+
+	floatPoint := func(timestamp int64) promql.FPoint {
+		return promql.FPoint{T: timestamp, F: 3}
+	}
+	histogramPoint := func(timestamp int64) promql.HPoint {
+		return promql.HPoint{
+			T: timestamp,
+			H: &histogram.FloatHistogram{Count: 2, Sum: 6},
+		}
+	}
+
+	testCases := map[string]struct {
+		op                  parser.ItemType
+		left                types.InstantVectorSeriesData
+		right               types.InstantVectorSeriesData
+		options             computeResultOptions
+		expectedFloatTimes  []int64
+		expectedHistTimes   []int64
+		expectedAnnotations int
+		expectSeparate      bool
+	}{
+		"missing left evaluates floats with nil presence": {
+			op:                 parser.MUL,
+			right:              types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep)}},
+			expectedFloatTimes: []int64{firstStep},
+		},
+		"missing left evaluates only absent steps": {
+			op:                 parser.MUL,
+			right:              types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep), floatPoint(secondStep)}},
+			options:            computeResultOptions{missingLeft: missingSideOptions{groupPresence: []int{4, -1}}},
+			expectedFloatTimes: []int64{secondStep},
+		},
+		"missing left suppresses a present step": {
+			op:      parser.MUL,
+			right:   types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep)}},
+			options: computeResultOptions{missingLeft: missingSideOptions{groupPresence: []int{4, -1}}},
+		},
+		"missing left skip mode suppresses the step": {
+			op:      parser.MUL,
+			right:   types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep)}},
+			options: computeResultOptions{missingLeft: missingSideOptions{mode: missingSkip}},
+		},
+		"missing left evaluates a histogram": {
+			op:                parser.MUL,
+			right:             types.InstantVectorSeriesData{Histograms: []promql.HPoint{histogramPoint(firstStep)}},
+			expectedHistTimes: []int64{firstStep},
+		},
+		"missing left emits an invalid type annotation": {
+			op:                  parser.ADD,
+			right:               types.InstantVectorSeriesData{Histograms: []promql.HPoint{histogramPoint(firstStep)}},
+			options:             computeResultOptions{missingLeft: missingSideOptions{groupPresence: []int{-1, -1}}},
+			expectedAnnotations: 1,
+		},
+		"missing left suppresses an invalid type annotation": {
+			op:      parser.ADD,
+			right:   types.InstantVectorSeriesData{Histograms: []promql.HPoint{histogramPoint(firstStep)}},
+			options: computeResultOptions{missingLeft: missingSideOptions{groupPresence: []int{4, -1}}},
+		},
+		"missing left keeps separate output mode": {
+			op:                 parser.MUL,
+			right:              types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep)}},
+			options:            computeResultOptions{missingLeft: missingSideOptions{mode: missingLeftSeparate}},
+			expectedFloatTimes: []int64{firstStep},
+			expectSeparate:     true,
+		},
+		"missing right evaluates floats with nil presence": {
+			op:                 parser.MUL,
+			left:               types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep)}},
+			expectedFloatTimes: []int64{firstStep},
+		},
+		"missing right evaluates only absent steps": {
+			op:                 parser.MUL,
+			left:               types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep), floatPoint(secondStep)}},
+			options:            computeResultOptions{missingRight: missingSideOptions{groupPresence: []int{8, -1}}},
+			expectedFloatTimes: []int64{secondStep},
+		},
+		"missing right suppresses a present step": {
+			op:      parser.MUL,
+			left:    types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep)}},
+			options: computeResultOptions{missingRight: missingSideOptions{groupPresence: []int{8, -1}}},
+		},
+		"missing right skip mode suppresses the step": {
+			op:      parser.MUL,
+			left:    types.InstantVectorSeriesData{Floats: []promql.FPoint{floatPoint(firstStep)}},
+			options: computeResultOptions{missingRight: missingSideOptions{mode: missingSkip}},
+		},
+		"missing right evaluates a histogram": {
+			op:                parser.MUL,
+			left:              types.InstantVectorSeriesData{Histograms: []promql.HPoint{histogramPoint(firstStep)}},
+			expectedHistTimes: []int64{firstStep},
+		},
+		"missing right emits an invalid type annotation": {
+			op:                  parser.ADD,
+			left:                types.InstantVectorSeriesData{Histograms: []promql.HPoint{histogramPoint(firstStep)}},
+			options:             computeResultOptions{missingRight: missingSideOptions{groupPresence: []int{-1, -1}}},
+			expectedAnnotations: 1,
+		},
+		"missing right suppresses an invalid type annotation": {
+			op:      parser.ADD,
+			left:    types.InstantVectorSeriesData{Histograms: []promql.HPoint{histogramPoint(firstStep)}},
+			options: computeResultOptions{missingRight: missingSideOptions{groupPresence: []int{8, -1}}},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			leftBefore := cloneBinaryOperationTestData(testCase.left)
+			rightBefore := cloneBinaryOperationTestData(testCase.right)
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			fillValue := 2.0
+			var fillLeft, fillRight *float64
+			if len(testCase.right.Floats)+len(testCase.right.Histograms) > 0 {
+				fillLeft = &fillValue
+			}
+			if len(testCase.left.Floats)+len(testCase.left.Histograms) > 0 {
+				fillRight = &fillValue
+			}
+
+			evaluator, err := newVectorVectorBinaryOperationEvaluator(testCase.op, false, memoryConsumptionTracker, posrange.PositionRange{}, timeRange, fillLeft, fillRight)
+			require.NoError(t, err)
+
+			result, separateResult, err := evaluator.computeResult(testCase.left, testCase.right, false, false, testCase.options)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				types.PutInstantVectorSeriesData(result, memoryConsumptionTracker)
+				types.PutInstantVectorSeriesData(separateResult, memoryConsumptionTracker)
+				require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+			})
+
+			actualResult := result
+			if testCase.expectSeparate {
+				require.Empty(t, result.Floats)
+				require.Empty(t, result.Histograms)
+				actualResult = separateResult
+			} else {
+				require.Empty(t, separateResult.Floats)
+				require.Empty(t, separateResult.Histograms)
+			}
+
+			require.Equal(t, testCase.expectedFloatTimes, binaryOperationFloatTimes(actualResult.Floats))
+			require.Equal(t, testCase.expectedHistTimes, binaryOperationHistogramTimes(actualResult.Histograms))
+			if len(actualResult.Histograms) > 0 {
+				inputHistogram := testCase.left.Histograms
+				if len(inputHistogram) == 0 {
+					inputHistogram = testCase.right.Histograms
+				}
+				require.Len(t, inputHistogram, 1)
+				require.NotSame(t, inputHistogram[0].H, actualResult.Histograms[0].H)
+			}
+			require.Len(t, evaluator.annotations, testCase.expectedAnnotations)
+			require.Equal(t, leftBefore, testCase.left)
+			require.Equal(t, rightBefore, testCase.right)
+		})
+	}
+}
+
+func TestVectorVectorBinaryOperationEvaluator_InvalidMissingSideOptions(t *testing.T) {
+	timeRange := types.NewRangeQueryTimeRange(time.Unix(0, 0), time.Unix(60, 0), time.Minute)
+	fillValue := 2.0
+
+	testCases := map[string]struct {
+		left          types.InstantVectorSeriesData
+		right         types.InstantVectorSeriesData
+		options       computeResultOptions
+		expectedError string
+		expectWrapped bool
+	}{
+		"unknown missing-left mode": {
+			options:       computeResultOptions{missingLeft: missingSideOptions{mode: missingSideMode(99)}},
+			expectedError: "unknown missing-left mode 99",
+		},
+		"unknown missing-right mode": {
+			options:       computeResultOptions{missingRight: missingSideOptions{mode: missingSideMode(99)}},
+			expectedError: "unknown missing-right mode 99",
+		},
+		"separate missing-right output": {
+			options:       computeResultOptions{missingRight: missingSideOptions{mode: missingLeftSeparate}},
+			expectedError: "cannot produce separate missing-right output",
+		},
+		"short missing-left presence": {
+			options:       computeResultOptions{missingLeft: missingSideOptions{groupPresence: []int{-1}}},
+			expectedError: "missing-left presence has length 1, expected 2",
+		},
+		"short missing-right presence": {
+			options:       computeResultOptions{missingRight: missingSideOptions{groupPresence: []int{-1}}},
+			expectedError: "missing-right presence has length 1, expected 2",
+		},
+		"empty missing-left presence": {
+			options:       computeResultOptions{missingLeft: missingSideOptions{groupPresence: []int{}}},
+			expectedError: "missing-left presence has length 0, expected 2",
+		},
+		"empty missing-right presence": {
+			options:       computeResultOptions{missingRight: missingSideOptions{groupPresence: []int{}}},
+			expectedError: "missing-right presence has length 0, expected 2",
+		},
+		"missing-left timestamp after query range": {
+			right: types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: timeRange.IndexTime(2), F: 3}}},
+			options: computeResultOptions{
+				missingLeft: missingSideOptions{groupPresence: []int{-1, -1}},
+			},
+			expectedError: "look up group presence at timestamp 120000: step index 2 is outside presence length 2",
+			expectWrapped: true,
+		},
+		"missing-right timestamp before query range": {
+			left: types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: -time.Minute.Milliseconds(), F: 3}}},
+			options: computeResultOptions{
+				missingRight: missingSideOptions{groupPresence: []int{-1, -1}},
+			},
+			expectedError: "look up group presence at timestamp -60000: step index -1 is outside presence length 2",
+			expectWrapped: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			evaluator, err := newVectorVectorBinaryOperationEvaluator(parser.MUL, false, memoryConsumptionTracker, posrange.PositionRange{}, timeRange, &fillValue, &fillValue)
+			require.NoError(t, err)
+
+			result, separateResult, err := evaluator.computeResult(testCase.left, testCase.right, false, false, testCase.options)
+			require.ErrorContains(t, err, testCase.expectedError)
+			if testCase.expectWrapped {
+				require.Error(t, errors.Unwrap(err))
+			}
+			require.Empty(t, result.Floats)
+			require.Empty(t, result.Histograms)
+			require.Empty(t, separateResult.Floats)
+			require.Empty(t, separateResult.Histograms)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+		})
+	}
+}
+
+func TestVectorVectorBinaryOperationEvaluator_PooledHistogramOwnership(t *testing.T) {
+	timeRange := types.NewRangeQueryTimeRange(time.Unix(0, 0), time.Unix(60, 0), time.Minute)
+	fillValue := 2.0
+
+	testCases := map[string]struct {
+		sourceSide      string
+		options         computeResultOptions
+		expectOutput    bool
+		expectSeparate  bool
+		expectSourceNil bool
+	}{
+		"left ownership moves the histogram": {
+			sourceSide:      "left",
+			expectOutput:    true,
+			expectSourceNil: true,
+		},
+		"right ownership moves the histogram": {
+			sourceSide:      "right",
+			expectOutput:    true,
+			expectSourceNil: true,
+		},
+		"suppression returns the owned source": {
+			sourceSide: "left",
+			options: computeResultOptions{
+				missingRight: missingSideOptions{groupPresence: []int{7, -1}},
+			},
+		},
+		"separate output moves the right histogram": {
+			sourceSide:      "right",
+			options:         computeResultOptions{missingLeft: missingSideOptions{mode: missingLeftSeparate}},
+			expectOutput:    true,
+			expectSeparate:  true,
+			expectSourceNil: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			sourcePoints, err := types.HPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			sourcePoints = sourcePoints[:1]
+			originalHistogram := &histogram.FloatHistogram{Count: 2, Sum: 6}
+			sourcePoints[0] = promql.HPoint{T: timeRange.IndexTime(0), H: originalHistogram}
+
+			var left, right types.InstantVectorSeriesData
+			var fillLeft, fillRight *float64
+			var takeOwnershipOfLeft, takeOwnershipOfRight bool
+			switch testCase.sourceSide {
+			case "left":
+				left.Histograms = sourcePoints
+				fillRight = &fillValue
+				takeOwnershipOfLeft = true
+			case "right":
+				right.Histograms = sourcePoints
+				fillLeft = &fillValue
+				takeOwnershipOfRight = true
+			default:
+				require.FailNow(t, "unknown source side")
+			}
+
+			evaluator, err := newVectorVectorBinaryOperationEvaluator(parser.MUL, false, memoryConsumptionTracker, posrange.PositionRange{}, timeRange, fillLeft, fillRight)
+			require.NoError(t, err)
+			result, separateResult, err := evaluator.computeResult(left, right, takeOwnershipOfLeft, takeOwnershipOfRight, testCase.options)
+			require.NoError(t, err)
+
+			if !testCase.expectOutput {
+				require.Empty(t, result.Histograms)
+				require.Empty(t, separateResult.Histograms)
+				require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+				return
+			}
+
+			output := result
+			otherOutput := separateResult
+			if testCase.expectSeparate {
+				output = separateResult
+				otherOutput = result
+			}
+			require.Empty(t, otherOutput.Histograms)
+			require.Len(t, output.Histograms, 1)
+			require.Same(t, originalHistogram, output.Histograms[0].H)
+			if testCase.expectSourceNil {
+				require.Nil(t, sourcePoints[0].H)
+			}
+
+			types.PutInstantVectorSeriesData(result, memoryConsumptionTracker)
+			types.PutInstantVectorSeriesData(separateResult, memoryConsumptionTracker)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+		})
+	}
+}
+
+func cloneBinaryOperationTestData(data types.InstantVectorSeriesData) types.InstantVectorSeriesData {
+	result := types.InstantVectorSeriesData{Floats: append([]promql.FPoint(nil), data.Floats...)}
+	if data.Histograms == nil {
+		return result
+	}
+
+	result.Histograms = make([]promql.HPoint, len(data.Histograms))
+	for i, point := range data.Histograms {
+		result.Histograms[i] = promql.HPoint{T: point.T, H: point.H.Copy()}
+	}
+	return result
+}
+
+func binaryOperationFloatTimes(points []promql.FPoint) []int64 {
+	if len(points) == 0 {
+		return nil
+	}
+
+	timestamps := make([]int64, len(points))
+	for i, point := range points {
+		timestamps[i] = point.T
+	}
+	return timestamps
+}
+
+func binaryOperationHistogramTimes(points []promql.HPoint) []int64 {
+	if len(points) == 0 {
+		return nil
+	}
+
+	timestamps := make([]int64, len(points))
+	for i, point := range points {
+		timestamps[i] = point.T
+	}
+	return timestamps
 }

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -56,6 +56,10 @@ type GroupedVectorVectorBinaryOperation struct {
 	leftFinishedReading     bool
 	rightFinishedReading    bool
 	manyPresenceGroups      []*oneSideMatchGroup
+	oneSideValidationGroups []*oneSideMatchGroup
+	oneSideValidationSeen   []int
+	oneSideValidationSource []int
+	oneSideValidationRound  int
 
 	// We need to retain these so that NextSeries() can return an error message with the series labels when
 	// multiple points match on a single side.
@@ -296,6 +300,36 @@ type oneSideMatchGroup struct {
 	manySideFillCarrierCount  int
 }
 
+func (g *oneSideMatchGroup) ensureMatchGroup() {
+	if g.matchGroup != nil {
+		return
+	}
+
+	g.matchGroup = &matchGroup{
+		oneSides:     g.ordered,
+		oneSideCount: len(g.ordered),
+	}
+	for _, side := range g.ordered {
+		side.matchGroup = g.matchGroup
+	}
+}
+
+func (g *oneSideMatchGroup) latestOneSideSeriesIndex() int {
+	latest := -1
+	for _, side := range g.ordered {
+		latest = max(latest, side.latestSeriesIndex())
+	}
+	return latest
+}
+
+func (g *oneSideMatchGroup) requiresValidation() bool {
+	seriesCount := 0
+	for _, side := range g.ordered {
+		seriesCount += len(side.seriesIndices)
+	}
+	return seriesCount > 1
+}
+
 func (g *oneSideMatchGroup) releaseManyPresence(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	if g.manyPresence != nil {
 		types.IntSlicePool.Put(&g.manyPresence, memoryConsumptionTracker)
@@ -391,9 +425,9 @@ func NewGroupedVectorVectorBinaryOperation(
 // contain points, but that would mean we'd need to hold the entire result in memory at once, which we want to
 // avoid.)
 func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {
-	if canProduceAnySeries, err := g.loadSeriesMetadata(ctx, matchers); err != nil {
+	if shouldContinue, err := g.loadSeriesMetadata(ctx, matchers); err != nil {
 		return nil, err
-	} else if !canProduceAnySeries {
+	} else if !shouldContinue {
 		if err := g.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
@@ -406,20 +440,6 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context,
 		return nil, err
 	}
 
-	if len(allMetadata) == 0 {
-		types.SeriesMetadataSlicePool.Put(&allMetadata, g.MemoryConsumptionTracker)
-		types.BoolSlicePool.Put(&oneSideSeriesUsed, g.MemoryConsumptionTracker)
-		types.BoolSlicePool.Put(&manySideSeriesUsed, g.MemoryConsumptionTracker)
-
-		if err := g.FinishedReading(ctx); err != nil {
-			return nil, err
-		}
-
-		return nil, nil
-	}
-
-	g.sortSeries(allMetadata, allSeries)
-	g.remainingSeries = allSeries
 	g.lastOneSideSeriesIndex = lastOneSideSeriesUsedIndex
 	g.lastManySideSeriesIndex = lastManySideSeriesUsedIndex
 
@@ -440,12 +460,23 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context,
 		g.manySideBuffer = operators.NewInstantVectorOperatorBuffer(g.manySide, manySideSeriesUsed, lastManySideSeriesUsedIndex, g.MemoryConsumptionTracker)
 	}
 
+	if len(allMetadata) == 0 {
+		types.SeriesMetadataSlicePool.Put(&allMetadata, g.MemoryConsumptionTracker)
+
+		if err := g.FinishedReading(ctx); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	g.sortSeries(allMetadata, allSeries)
+	g.remainingSeries = allSeries
+
 	return allMetadata, nil
 }
 
-// loadSeriesMetadata loads child metadata and reports whether labels can drive output.
-// A nonempty side can drive output when the empty normalized side has a fill value.
-// Two empty sides cannot drive output.
+// loadSeriesMetadata loads child metadata and reports whether output or fill validation remains.
 func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Context, matchers types.Matchers) (bool, error) {
 	// We retain the series labels for later so we can use them to generate error messages.
 	// We'll return them to the pool in Close().
@@ -497,7 +528,7 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 	if oneSideEmpty && manySideEmpty {
 		return false, nil
 	}
-	if manySideEmpty && g.fillValues.LHS == nil {
+	if manySideEmpty && g.fillValues.LHS == nil && g.fillValues.RHS == nil {
 		return false, nil
 	}
 	if oneSideEmpty {
@@ -561,6 +592,11 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 
 		side.seriesIndices = append(side.seriesIndices, idx)
 	}
+	for _, oneSideGroup := range oneSideGroups {
+		if len(oneSideGroup.ordered) > 1 {
+			oneSideGroup.ensureMatchGroup()
+		}
+	}
 
 	// Now iterate through all series on the "many" side and determine all the possible output series, as
 	// well as which series from the "many" side we'll actually need.
@@ -592,14 +628,8 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 		} else {
 			oneSideGroup.relevant = true
 			oneSideGroup.latestManySideSeriesIndex = idx
-			if oneSideGroup.matchGroup == nil && (g.fillValues.RHS != nil || len(oneSideGroup.ordered) > 1) {
-				oneSideGroup.matchGroup = &matchGroup{
-					oneSides:     oneSideGroup.ordered,
-					oneSideCount: len(oneSideGroup.ordered),
-				}
-				for _, side := range oneSideGroup.ordered {
-					side.matchGroup = oneSideGroup.matchGroup
-				}
+			if g.fillValues.RHS != nil {
+				oneSideGroup.ensureMatchGroup()
 			}
 		}
 
@@ -733,6 +763,21 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 		}
 	}
 
+	var oneSideValidationGroups []*oneSideMatchGroup
+	if g.fillValues.LHS == nil && g.fillValues.RHS != nil {
+		for _, oneSideGroup := range oneSideGroups {
+			if oneSideGroup.relevant || !oneSideGroup.requiresValidation() {
+				continue
+			}
+
+			oneSideGroup.relevant = true
+			oneSideValidationGroups = append(oneSideValidationGroups, oneSideGroup)
+		}
+		sort.Slice(oneSideValidationGroups, func(i, j int) bool {
+			return oneSideValidationGroups[i].latestOneSideSeriesIndex() < oneSideValidationGroups[j].latestOneSideSeriesIndex()
+		})
+	}
+
 	// Next, go through all the "one" side groups again, and determine which of the "one" side series we'll actually need.
 	oneSideSeriesUsed, err := types.BoolSlicePool.Get(len(g.oneSideMetadata), g.MemoryConsumptionTracker)
 	if err != nil {
@@ -769,6 +814,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 		outputMetadata = append(outputMetadata, types.SeriesMetadata{Labels: o.labels})
 		outputSeries = append(outputSeries, o.outputSeries)
 	}
+	g.oneSideValidationGroups = oneSideValidationGroups
 
 	return outputMetadata, outputSeries, oneSideSeriesUsed, lastOneSideSeriesUsedIndex, manySideSeriesUsed, lastManySideSeriesUsedIndex, nil
 }
@@ -1016,6 +1062,22 @@ func outputOneSideSeriesIndex(series *groupedBinaryOperationOutputSeries) int {
 	return series.oneSide.latestSeriesIndex()
 }
 
+func outputLatestOneSideSeriesIndexForRead(series *groupedBinaryOperationOutputSeries) int {
+	latest := -1
+	if series.oneSide != nil {
+		latest = series.oneSide.latestSeriesIndex()
+	}
+	for _, carrier := range series.manySideFillCarriers {
+		latest = max(latest, carrier.oneSide.latestSeriesIndex())
+	}
+	if series.fillCarrier != nil && series.fillCarrier.matchGroup != nil {
+		for _, side := range series.fillCarrier.matchGroup.oneSides {
+			latest = max(latest, side.latestSeriesIndex())
+		}
+	}
+	return latest
+}
+
 func (s favourManySideSorter) Swap(i, j int) {
 	s.metadata[i], s.metadata[j] = s.metadata[j], s.metadata[i]
 	s.series[i], s.series[j] = s.series[j], s.series[i]
@@ -1042,6 +1104,13 @@ func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (re
 			g.releaseManyPresence()
 		}
 	}()
+	validationSeriesIndex := outputLatestOneSideSeriesIndexForRead(thisSeries)
+	if len(g.remainingSeries) == 1 {
+		validationSeriesIndex = int(^uint(0) >> 1)
+	}
+	if err := g.validateOneSideGroupsThrough(ctx, validationSeriesIndex); err != nil {
+		return types.InstantVectorSeriesData{}, err
+	}
 
 	if thisSeries.oneSide != nil {
 		if err := g.ensureOneSidePopulated(ctx, thisSeries.oneSide); err != nil {
@@ -1383,6 +1452,142 @@ func (g *GroupedVectorVectorBinaryOperation) ensureOneSideGroupPopulated(ctx con
 			return err
 		}
 	}
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) validateOneSideGroupsThrough(ctx context.Context, maxSeriesIndex int) error {
+	for len(g.oneSideValidationGroups) > 0 {
+		group := g.oneSideValidationGroups[0]
+		if group.latestOneSideSeriesIndex() > maxSeriesIndex {
+			return nil
+		}
+
+		if err := g.startOneSideValidationRound(ctx); err != nil {
+			g.oneSideValidationGroups = nil
+			g.releaseOneSideValidationState()
+			return fmt.Errorf("prepare unmatched one-side group validation: %w", err)
+		}
+		g.oneSideValidationGroups = g.oneSideValidationGroups[1:]
+		if err := g.validateOneSideGroup(ctx, group); err != nil {
+			g.oneSideValidationGroups = nil
+			g.releaseOneSideValidationState()
+			return fmt.Errorf("validate unmatched one-side group for fill: %w", err)
+		}
+	}
+
+	g.releaseOneSideValidationState()
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) startOneSideValidationRound(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("start one-side validation: %w", err)
+	}
+
+	if g.oneSideValidationSeen == nil {
+		var err error
+		g.oneSideValidationSeen, err = types.IntSlicePool.Get(g.timeRange.StepCount, g.MemoryConsumptionTracker)
+		if err != nil {
+			return err
+		}
+		g.oneSideValidationSeen = g.oneSideValidationSeen[:g.timeRange.StepCount]
+
+		g.oneSideValidationSource, err = types.IntSlicePool.Get(g.timeRange.StepCount, g.MemoryConsumptionTracker)
+		if err != nil {
+			types.IntSlicePool.Put(&g.oneSideValidationSeen, g.MemoryConsumptionTracker)
+			return err
+		}
+		g.oneSideValidationSource = g.oneSideValidationSource[:g.timeRange.StepCount]
+
+		for idx := range g.oneSideValidationSeen {
+			if idx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("initialize one-side validation state: %w", err)
+				}
+			}
+			g.oneSideValidationSeen[idx] = 0
+		}
+	}
+
+	if g.oneSideValidationRound == int(^uint(0)>>1) {
+		clear(g.oneSideValidationSeen)
+		g.oneSideValidationRound = 0
+	}
+	g.oneSideValidationRound++
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) releaseOneSideValidationState() {
+	types.IntSlicePool.Put(&g.oneSideValidationSeen, g.MemoryConsumptionTracker)
+	types.IntSlicePool.Put(&g.oneSideValidationSource, g.MemoryConsumptionTracker)
+	g.oneSideValidationRound = 0
+}
+
+func (g *GroupedVectorVectorBinaryOperation) validateOneSideGroup(ctx context.Context, group *oneSideMatchGroup) error {
+
+	for _, side := range group.ordered {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("validate one-side group: %w", err)
+		}
+
+		latestSeriesIndex := side.latestSeriesIndex()
+		data, err := g.oneSideBuffer.GetSeries(ctx, side.seriesIndices)
+		if err != nil {
+			return fmt.Errorf("read one-side group for validation: %w", err)
+		}
+		if latestSeriesIndex == g.lastOneSideSeriesIndex {
+			g.markOneSideFinishedReading()
+		}
+
+		err = g.validateOneSideData(ctx, side.seriesIndices, data)
+		putSeriesData(data, g.MemoryConsumptionTracker)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) validateOneSideData(ctx context.Context, seriesIndices []int, data []types.InstantVectorSeriesData) error {
+	for dataIdx, seriesData := range data {
+		seriesIndex := seriesIndices[dataIdx]
+		for pointIdx, point := range seriesData.Floats {
+			if pointIdx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("validate one-side float data: %w", err)
+				}
+			}
+			if err := g.recordOneSideValidationPresence(seriesIndex, point.T); err != nil {
+				return err
+			}
+		}
+		for pointIdx, point := range seriesData.Histograms {
+			if pointIdx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("validate one-side histogram data: %w", err)
+				}
+			}
+			if err := g.recordOneSideValidationPresence(seriesIndex, point.T); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) recordOneSideValidationPresence(seriesIndex int, timestamp int64) error {
+	timestampIndex, err := g.presenceTimestampIndex(timestamp, len(g.oneSideValidationSeen))
+	if err != nil {
+		return fmt.Errorf("record one-side validation presence at timestamp %d: %w", timestamp, err)
+	}
+	if g.oneSideValidationSeen[timestampIndex] == g.oneSideValidationRound {
+		return formatConflictError(g.oneSideValidationSource[timestampIndex], seriesIndex, "duplicate series", timestamp, g.oneSideMetadata, g.oneSideHandedness(), g.VectorMatching, g.Op, g.ReturnBool)
+	}
+
+	g.oneSideValidationSeen[timestampIndex] = g.oneSideValidationRound
+	g.oneSideValidationSource[timestampIndex] = seriesIndex
 	return nil
 }
 
@@ -1743,6 +1948,13 @@ func (g *GroupedVectorVectorBinaryOperation) AfterPrepare(ctx context.Context) e
 }
 
 func (g *GroupedVectorVectorBinaryOperation) FinishedReading(ctx context.Context) error {
+	var validationErr error
+	if g.oneSideBuffer != nil {
+		validationErr = g.validateOneSideGroupsThrough(ctx, int(^uint(0)>>1))
+	}
+	g.oneSideValidationGroups = nil
+	g.releaseOneSideValidationState()
+
 	types.SeriesMetadataSlicePool.Put(&g.oneSideMetadata, g.MemoryConsumptionTracker)
 	types.SeriesMetadataSlicePool.Put(&g.manySideMetadata, g.MemoryConsumptionTracker)
 
@@ -1763,11 +1975,9 @@ func (g *GroupedVectorVectorBinaryOperation) FinishedReading(ctx context.Context
 	g.remainingSeries = nil
 	g.releaseManyPresence()
 
-	if err := g.finishLeft(ctx); err != nil {
-		return err
-	}
-
-	return g.finishRight(ctx)
+	leftErr := g.finishLeft(ctx)
+	rightErr := g.finishRight(ctx)
+	return errors.Join(validationErr, leftErr, rightErr)
 }
 
 func (g *GroupedVectorVectorBinaryOperation) finishOneSide(ctx context.Context) error {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -645,9 +645,9 @@ func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (ty
 	switch g.VectorMatching.Card {
 	case parser.CardOneToMany:
 		// The grouped operator never splits fill-left points, so the second return value is always empty.
-		result, _, err = g.evaluator.computeResult(thisSeries.oneSide.mergedData, thisSeries.manySide.mergedData, isLastOutputSeriesForOneSide, isLastOutputSeriesForManySide, fillLeftOptions{})
+		result, _, err = g.evaluator.computeResult(thisSeries.oneSide.mergedData, thisSeries.manySide.mergedData, isLastOutputSeriesForOneSide, isLastOutputSeriesForManySide, computeResultOptions{})
 	case parser.CardManyToOne:
-		result, _, err = g.evaluator.computeResult(thisSeries.manySide.mergedData, thisSeries.oneSide.mergedData, isLastOutputSeriesForManySide, isLastOutputSeriesForOneSide, fillLeftOptions{})
+		result, _, err = g.evaluator.computeResult(thisSeries.manySide.mergedData, thisSeries.oneSide.mergedData, isLastOutputSeriesForManySide, isLastOutputSeriesForOneSide, computeResultOptions{})
 	default:
 		panic(fmt.Sprintf("unsupported cardinality '%v'", g.VectorMatching.Card))
 	}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -55,6 +55,7 @@ type GroupedVectorVectorBinaryOperation struct {
 	lastManySideSeriesIndex int
 	leftFinishedReading     bool
 	rightFinishedReading    bool
+	manyPresenceGroups      []*oneSideMatchGroup
 
 	// We need to retain these so that NextSeries() can return an error message with the series labels when
 	// multiple points match on a single side.
@@ -71,20 +72,30 @@ type groupedBinaryOperationOutputSeries struct {
 	oneSide              *oneSide
 	fillCarrier          *oneSide
 	manySideFillCarriers []syntheticManySideCarrier
+	fillCarriersFinished bool
+	referencesFinished   bool
 }
 
 func (g *groupedBinaryOperationOutputSeries) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	g.finishFillCarrier(memoryConsumptionTracker)
+	g.finishManySideFillCarriers(memoryConsumptionTracker)
+	g.finishReferences()
 	if g.manySide != nil {
 		g.manySide.FinishedReading(memoryConsumptionTracker)
 	}
 	if g.oneSide != nil {
 		g.oneSide.FinishedReading(memoryConsumptionTracker)
 	}
+	seen := make(map[*oneSide]struct{}, len(g.manySideFillCarriers)+1)
+	if g.oneSide != nil {
+		seen[g.oneSide] = struct{}{}
+	}
 	for _, carrier := range g.manySideFillCarriers {
-		if carrier.oneSide != g.oneSide {
-			carrier.oneSide.FinishedReading(memoryConsumptionTracker)
+		if _, exists := seen[carrier.oneSide]; exists {
+			continue
 		}
+		seen[carrier.oneSide] = struct{}{}
+		carrier.oneSide.FinishedReading(memoryConsumptionTracker)
 	}
 }
 
@@ -97,6 +108,61 @@ func (g *groupedBinaryOperationOutputSeries) finishFillCarrier(memoryConsumption
 		g.fillCarrier.matchGroup.fillCarrierFinished(memoryConsumptionTracker)
 	}
 	g.fillCarrier = nil
+}
+
+func (g *groupedBinaryOperationOutputSeries) finishManySideFillCarriers(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	if g.fillCarriersFinished {
+		return
+	}
+
+	for _, carrier := range g.manySideFillCarriers {
+		carrier.matchGroup.manySideFillCarrierFinished(memoryConsumptionTracker)
+	}
+	g.fillCarriersFinished = true
+}
+
+func (g *groupedBinaryOperationOutputSeries) finishReferences() (map[*oneSide]bool, bool) {
+	if g.referencesFinished {
+		return nil, false
+	}
+
+	oneSides := make(map[*oneSide]bool, len(g.manySideFillCarriers)+1)
+	if g.oneSide != nil {
+		oneSides[g.oneSide] = false
+	}
+	for _, carrier := range g.manySideFillCarriers {
+		oneSides[carrier.oneSide] = false
+	}
+	for side := range oneSides {
+		side.outputSeriesCount--
+		oneSides[side] = side.outputSeriesCount == 0
+	}
+
+	lastManySideUse := false
+	if g.manySide != nil {
+		g.manySide.outputSeriesCount--
+		lastManySideUse = g.manySide.outputSeriesCount == 0
+	}
+	g.referencesFinished = true
+	return oneSides, lastManySideUse
+}
+
+func (g *groupedBinaryOperationOutputSeries) releaseZeroReferenceData(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	seen := make(map[*oneSide]struct{}, len(g.manySideFillCarriers)+1)
+	if g.oneSide != nil {
+		seen[g.oneSide] = struct{}{}
+	}
+	for _, carrier := range g.manySideFillCarriers {
+		seen[carrier.oneSide] = struct{}{}
+	}
+	for side := range seen {
+		if side.outputSeriesCount == 0 {
+			side.FinishedReading(memoryConsumptionTracker)
+		}
+	}
+	if g.manySide != nil && g.manySide.outputSeriesCount == 0 {
+		g.manySide.FinishedReading(memoryConsumptionTracker)
+	}
 }
 
 type groupedBinaryOperationOutputSeriesWithLabels struct {
@@ -150,6 +216,7 @@ type manySide struct {
 
 	outputSeriesCount int
 	matchGroup        *oneSideMatchGroup
+	presenceRecorded  bool
 }
 
 // latestSeriesIndex returns the index of the last series from this side.
@@ -224,6 +291,26 @@ type oneSideMatchGroup struct {
 	matchGroup                *matchGroup
 	relevant                  bool
 	latestManySideSeriesIndex int
+	manySides                 []*manySide
+	manyPresence              []int
+	manySideFillCarrierCount  int
+}
+
+func (g *oneSideMatchGroup) releaseManyPresence(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	if g.manyPresence != nil {
+		types.IntSlicePool.Put(&g.manyPresence, memoryConsumptionTracker)
+	}
+}
+
+func (g *oneSideMatchGroup) manySideFillCarrierFinished(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	if g.manySideFillCarrierCount == 0 {
+		return
+	}
+
+	g.manySideFillCarrierCount--
+	if g.manySideFillCarrierCount == 0 {
+		g.releaseManyPresence(memoryConsumptionTracker)
+	}
 }
 
 // updatePresence records the presence of a sample from the series with index seriesIdx at the timestamp with index timestampIdx.
@@ -531,6 +618,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 			seriesIndices: []int{idx},
 			matchGroup:    oneSideGroup,
 		}
+		oneSideGroup.manySides = append(oneSideGroup.manySides, thisManySide)
 
 		manySideMap[string(manySideGroupKey)] = thisManySide
 
@@ -610,6 +698,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	if g.fillValues.LHS != nil {
 		for _, oneSideGroup := range oneSideGroups {
 			oneSideGroup.relevant = true
+			g.manyPresenceGroups = append(g.manyPresenceGroups, oneSideGroup)
 			for variantIndex, oneSide := range oneSideGroup.ordered {
 				oneSideLabels := g.oneSideMetadata[oneSide.seriesIndices[0]].Labels
 				syntheticManySideLabels := g.syntheticManySideLabels(oneSideLabels)
@@ -620,6 +709,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 					matchGroup:   oneSideGroup,
 					variantIndex: variantIndex,
 				}
+				oneSideGroup.manySideFillCarrierCount++
 
 				if existing, exists := outputSeriesMap[key]; exists {
 					if !outputSeriesReferencesOneSide(existing.outputSeries, oneSide) {
@@ -931,17 +1021,35 @@ func (s favourManySideSorter) Swap(i, j int) {
 	s.series[i], s.series[j] = s.series[j], s.series[i]
 }
 
-func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+type groupedEvaluationComponent struct {
+	manySide *manySide
+	oneSide  *oneSide
+	options  computeResultOptions
+}
+
+func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (result types.InstantVectorSeriesData, err error) {
 	if len(g.remainingSeries) == 0 {
 		return types.InstantVectorSeriesData{}, types.EOS
 	}
 
 	thisSeries := g.remainingSeries[0]
-	g.remainingSeries = g.remainingSeries[1:]
-	defer thisSeries.finishFillCarrier(g.MemoryConsumptionTracker)
+	defer func() {
+		thisSeries.finishFillCarrier(g.MemoryConsumptionTracker)
+		thisSeries.finishManySideFillCarriers(g.MemoryConsumptionTracker)
+		if err != nil {
+			thisSeries.finishReferences()
+			thisSeries.releaseZeroReferenceData(g.MemoryConsumptionTracker)
+			g.releaseManyPresence()
+		}
+	}()
 
 	if thisSeries.oneSide != nil {
 		if err := g.ensureOneSidePopulated(ctx, thisSeries.oneSide); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+	}
+	for _, carrier := range thisSeries.manySideFillCarriers {
+		if err := g.ensureOneSidePopulated(ctx, carrier.oneSide); err != nil {
 			return types.InstantVectorSeriesData{}, err
 		}
 	}
@@ -954,49 +1062,82 @@ func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (ty
 	if err := g.ensureManySidePopulated(ctx, thisSeries.manySide); err != nil {
 		return types.InstantVectorSeriesData{}, err
 	}
-
-	isLastOutputSeriesForOneSide := false
-	oneSideData := types.InstantVectorSeriesData{}
-	if thisSeries.oneSide != nil {
-		thisSeries.oneSide.outputSeriesCount--
-		isLastOutputSeriesForOneSide = thisSeries.oneSide.outputSeriesCount == 0
-		oneSideData = thisSeries.oneSide.mergedData
+	for _, carrier := range thisSeries.manySideFillCarriers {
+		if err := g.ensureManySideGroupPopulated(ctx, carrier.matchGroup); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
 	}
 
-	thisSeries.manySide.outputSeriesCount--
-	isLastOutputSeriesForManySide := thisSeries.manySide.outputSeriesCount == 0
+	components := g.evaluationComponents(thisSeries)
+	oneSideUses := make(map[*oneSide]int, len(components))
+	for _, component := range components {
+		if component.oneSide != nil {
+			oneSideUses[component.oneSide]++
+		}
+	}
+	lastOneSideUse, lastManySideUse := thisSeries.finishReferences()
 
-	var result types.InstantVectorSeriesData
-	var err error
-	options := g.computeResultOptions(thisSeries)
+	componentResults := make([]types.InstantVectorSeriesData, 0, len(components))
+	for _, component := range components {
+		if err := ctx.Err(); err != nil {
+			putSeriesData(componentResults, g.MemoryConsumptionTracker)
+			return types.InstantVectorSeriesData{}, fmt.Errorf("evaluate grouped output: %w", err)
+		}
 
-	switch g.VectorMatching.Card {
-	case parser.CardOneToMany:
-		// The grouped operator never splits fill-left points, so the second return value is always empty.
-		result, _, err = g.evaluator.computeResult(oneSideData, thisSeries.manySide.mergedData, isLastOutputSeriesForOneSide, isLastOutputSeriesForManySide, options)
-	case parser.CardManyToOne:
-		result, _, err = g.evaluator.computeResult(thisSeries.manySide.mergedData, oneSideData, isLastOutputSeriesForManySide, isLastOutputSeriesForOneSide, options)
-	default:
-		panic(fmt.Sprintf("unsupported cardinality %d", int(g.VectorMatching.Card)))
+		takeOneSide := false
+		if component.oneSide != nil {
+			oneSideUses[component.oneSide]--
+			takeOneSide = lastOneSideUse[component.oneSide] && oneSideUses[component.oneSide] == 0
+		}
+		takeManySide := component.manySide != nil && lastManySideUse
+
+		componentResult, computeErr := g.evaluateComponent(component, takeManySide, takeOneSide)
+		if takeOneSide {
+			if computeErr != nil {
+				component.oneSide.FinishedReading(g.MemoryConsumptionTracker)
+			}
+			component.oneSide.mergedData = types.InstantVectorSeriesData{}
+		}
+		if takeManySide {
+			if computeErr != nil {
+				component.manySide.FinishedReading(g.MemoryConsumptionTracker)
+			}
+			component.manySide.mergedData = types.InstantVectorSeriesData{}
+		}
+		if computeErr != nil {
+			putSeriesData(componentResults, g.MemoryConsumptionTracker)
+			return types.InstantVectorSeriesData{}, fmt.Errorf("evaluate grouped output component: %w", computeErr)
+		}
+		componentResults = append(componentResults, componentResult)
 	}
 
-	// If this is the last output series for that side, then we've passed ownership of mergedData to the evaluator, so clear it now to avoid returning it to the pool later.
-	if isLastOutputSeriesForOneSide && thisSeries.oneSide != nil {
-		thisSeries.oneSide.mergedData = types.InstantVectorSeriesData{}
-	}
-
-	if isLastOutputSeriesForManySide {
-		thisSeries.manySide.mergedData = types.InstantVectorSeriesData{}
-	}
-
+	result, err = g.mergeComponentResults(ctx, componentResults)
 	if err != nil {
 		return types.InstantVectorSeriesData{}, err
 	}
-
+	g.remainingSeries = g.remainingSeries[1:]
 	return result, nil
 }
 
-func (g *GroupedVectorVectorBinaryOperation) computeResultOptions(series *groupedBinaryOperationOutputSeries) computeResultOptions {
+func (g *GroupedVectorVectorBinaryOperation) evaluationComponents(series *groupedBinaryOperationOutputSeries) []groupedEvaluationComponent {
+	components := make([]groupedEvaluationComponent, 0, 1+len(series.manySideFillCarriers))
+	if series.manySide != nil {
+		components = append(components, groupedEvaluationComponent{
+			manySide: series.manySide,
+			oneSide:  series.oneSide,
+			options:  g.realComponentOptions(series),
+		})
+	}
+	for _, carrier := range series.manySideFillCarriers {
+		components = append(components, groupedEvaluationComponent{
+			oneSide: carrier.oneSide,
+			options: g.manySideCarrierOptions(carrier.matchGroup.manyPresence),
+		})
+	}
+	return components
+}
+
+func (g *GroupedVectorVectorBinaryOperation) realComponentOptions(series *groupedBinaryOperationOutputSeries) computeResultOptions {
 	oneMissing := missingSideOptions{mode: missingSkip}
 	if series.fillCarrier != nil {
 		oneMissing = missingSideOptions{}
@@ -1006,9 +1147,231 @@ func (g *GroupedVectorVectorBinaryOperation) computeResultOptions(series *groupe
 	}
 
 	if g.VectorMatching.Card == parser.CardOneToMany {
-		return computeResultOptions{missingLeft: oneMissing}
+		return computeResultOptions{
+			missingLeft:  oneMissing,
+			missingRight: missingSideOptions{mode: missingSkip},
+		}
 	}
-	return computeResultOptions{missingRight: oneMissing}
+	return computeResultOptions{
+		missingLeft:  missingSideOptions{mode: missingSkip},
+		missingRight: oneMissing,
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) manySideCarrierOptions(presence []int) computeResultOptions {
+	manyMissing := missingSideOptions{groupPresence: presence}
+	if g.VectorMatching.Card == parser.CardOneToMany {
+		return computeResultOptions{
+			missingLeft:  missingSideOptions{mode: missingSkip},
+			missingRight: manyMissing,
+		}
+	}
+	return computeResultOptions{
+		missingLeft:  manyMissing,
+		missingRight: missingSideOptions{mode: missingSkip},
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) evaluateComponent(component groupedEvaluationComponent, takeManySide, takeOneSide bool) (types.InstantVectorSeriesData, error) {
+	manyData := types.InstantVectorSeriesData{}
+	if component.manySide != nil {
+		manyData = component.manySide.mergedData
+	}
+	oneData := types.InstantVectorSeriesData{}
+	if component.oneSide != nil {
+		oneData = component.oneSide.mergedData
+	}
+
+	switch g.VectorMatching.Card {
+	case parser.CardOneToMany:
+		result, _, err := g.evaluator.computeResult(oneData, manyData, takeOneSide, takeManySide, component.options)
+		return result, err
+	case parser.CardManyToOne:
+		result, _, err := g.evaluator.computeResult(manyData, oneData, takeManySide, takeOneSide, component.options)
+		return result, err
+	default:
+		return types.InstantVectorSeriesData{}, fmt.Errorf("unsupported cardinality %d", int(g.VectorMatching.Card))
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) mergeComponentResults(ctx context.Context, results []types.InstantVectorSeriesData) (types.InstantVectorSeriesData, error) {
+	if err := ctx.Err(); err != nil {
+		putSeriesData(results, g.MemoryConsumptionTracker)
+		return types.InstantVectorSeriesData{}, fmt.Errorf("merge grouped output components: %w", err)
+	}
+	if len(results) == 1 {
+		return results[0], nil
+	}
+
+	floatCount, histogramCount := 0, 0
+	for resultIndex, result := range results {
+		if resultIndex&1023 == 0 {
+			if err := ctx.Err(); err != nil {
+				putSeriesData(results, g.MemoryConsumptionTracker)
+				return types.InstantVectorSeriesData{}, fmt.Errorf("merge grouped output components: %w", err)
+			}
+		}
+		floatCount += len(result.Floats)
+		histogramCount += len(result.Histograms)
+	}
+	merged := types.InstantVectorSeriesData{}
+	var err error
+	if floatCount > 0 {
+		merged.Floats, err = types.FPointSlicePool.Get(floatCount, g.MemoryConsumptionTracker)
+		if err != nil {
+			putSeriesData(results, g.MemoryConsumptionTracker)
+			return types.InstantVectorSeriesData{}, fmt.Errorf("allocate merged output floats: %w", err)
+		}
+	}
+	if histogramCount > 0 {
+		merged.Histograms, err = types.HPointSlicePool.Get(histogramCount, g.MemoryConsumptionTracker)
+		if err != nil {
+			types.FPointSlicePool.Put(&merged.Floats, g.MemoryConsumptionTracker)
+			putSeriesData(results, g.MemoryConsumptionTracker)
+			return types.InstantVectorSeriesData{}, fmt.Errorf("allocate merged output histograms: %w", err)
+		}
+	}
+
+	heap := make(groupedResultCursorHeap, 0, len(results))
+	for resultIndex := range results {
+		if resultIndex&1023 == 0 {
+			if err := ctx.Err(); err != nil {
+				releasePartialMergedResult(merged, g.MemoryConsumptionTracker)
+				putSeriesData(results, g.MemoryConsumptionTracker)
+				return types.InstantVectorSeriesData{}, fmt.Errorf("merge grouped output components: %w", err)
+			}
+		}
+		cursor := groupedResultCursor{resultIndex: resultIndex}
+		if cursor.advance(results) {
+			heap.push(cursor)
+		}
+	}
+
+	var previousTimestamp int64
+	havePreviousTimestamp := false
+	for pointCount := 0; len(heap) > 0; pointCount++ {
+		if pointCount&1023 == 0 {
+			if err := ctx.Err(); err != nil {
+				releasePartialMergedResult(merged, g.MemoryConsumptionTracker)
+				putSeriesData(results, g.MemoryConsumptionTracker)
+				return types.InstantVectorSeriesData{}, fmt.Errorf("merge grouped output components: %w", err)
+			}
+		}
+
+		cursor := heap.pop()
+		if havePreviousTimestamp && cursor.timestamp == previousTimestamp {
+			releasePartialMergedResult(merged, g.MemoryConsumptionTracker)
+			putSeriesData(results, g.MemoryConsumptionTracker)
+			overlapErr := fmt.Errorf("unexpected overlapping result point at timestamp %d", cursor.timestamp)
+			return types.InstantVectorSeriesData{}, fmt.Errorf("merge grouped output components: %w", overlapErr)
+		}
+		previousTimestamp = cursor.timestamp
+		havePreviousTimestamp = true
+
+		result := results[cursor.resultIndex]
+		if cursor.histogram {
+			merged.Histograms = append(merged.Histograms, result.Histograms[cursor.pointIndex])
+		} else {
+			merged.Floats = append(merged.Floats, result.Floats[cursor.pointIndex])
+		}
+		if cursor.advance(results) {
+			heap.push(cursor)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		releasePartialMergedResult(merged, g.MemoryConsumptionTracker)
+		putSeriesData(results, g.MemoryConsumptionTracker)
+		return types.InstantVectorSeriesData{}, fmt.Errorf("merge grouped output components: %w", err)
+	}
+
+	putTransferredSeriesData(results, g.MemoryConsumptionTracker)
+	return merged, nil
+}
+
+type groupedResultCursor struct {
+	resultIndex    int
+	floatIndex     int
+	histogramIndex int
+	pointIndex     int
+	timestamp      int64
+	histogram      bool
+}
+
+func (c *groupedResultCursor) advance(results []types.InstantVectorSeriesData) bool {
+	result := results[c.resultIndex]
+	hasFloat := c.floatIndex < len(result.Floats)
+	hasHistogram := c.histogramIndex < len(result.Histograms)
+	if !hasFloat && !hasHistogram {
+		return false
+	}
+	if !hasHistogram || hasFloat && result.Floats[c.floatIndex].T <= result.Histograms[c.histogramIndex].T {
+		c.pointIndex = c.floatIndex
+		c.timestamp = result.Floats[c.floatIndex].T
+		c.histogram = false
+		c.floatIndex++
+		return true
+	}
+	c.pointIndex = c.histogramIndex
+	c.timestamp = result.Histograms[c.histogramIndex].T
+	c.histogram = true
+	c.histogramIndex++
+	return true
+}
+
+type groupedResultCursorHeap []groupedResultCursor
+
+func (h *groupedResultCursorHeap) push(cursor groupedResultCursor) {
+	*h = append(*h, cursor)
+	for child := len(*h) - 1; child > 0; {
+		parent := (child - 1) / 2
+		if (*h)[parent].timestamp <= (*h)[child].timestamp {
+			break
+		}
+		(*h)[parent], (*h)[child] = (*h)[child], (*h)[parent]
+		child = parent
+	}
+}
+
+func (h *groupedResultCursorHeap) pop() groupedResultCursor {
+	result := (*h)[0]
+	last := len(*h) - 1
+	(*h)[0] = (*h)[last]
+	*h = (*h)[:last]
+	for parent := 0; ; {
+		left := 2*parent + 1
+		if left >= len(*h) {
+			break
+		}
+		smallest := left
+		right := left + 1
+		if right < len(*h) && (*h)[right].timestamp < (*h)[left].timestamp {
+			smallest = right
+		}
+		if (*h)[parent].timestamp <= (*h)[smallest].timestamp {
+			break
+		}
+		(*h)[parent], (*h)[smallest] = (*h)[smallest], (*h)[parent]
+		parent = smallest
+	}
+	return result
+}
+
+func releasePartialMergedResult(data types.InstantVectorSeriesData, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	clear(data.Histograms)
+	types.PutInstantVectorSeriesData(data, memoryConsumptionTracker)
+}
+
+func putTransferredSeriesData(data []types.InstantVectorSeriesData, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	for idx := range data {
+		clear(data[idx].Histograms)
+		types.PutInstantVectorSeriesData(data[idx], memoryConsumptionTracker)
+	}
+}
+
+func putSeriesData(data []types.InstantVectorSeriesData, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	for idx := range data {
+		types.PutInstantVectorSeriesData(data[idx], memoryConsumptionTracker)
+	}
 }
 
 func (g *GroupedVectorVectorBinaryOperation) ensureOneSideGroupPopulated(ctx context.Context, group *matchGroup) error {
@@ -1033,19 +1396,23 @@ func (g *GroupedVectorVectorBinaryOperation) ensureOneSidePopulated(ctx context.
 	latestSeriesIndex := side.latestSeriesIndex()
 	data, err := g.oneSideBuffer.GetSeries(ctx, side.seriesIndices)
 	if err != nil {
-		return err
+		return fmt.Errorf("read one-side series: %w", err)
 	}
 	if latestSeriesIndex == g.lastOneSideSeriesIndex {
 		g.markOneSideFinishedReading()
 	}
 
-	if err := g.updateOneSidePresence(side, data); err != nil {
+	if err := g.updateOneSidePresence(ctx, side, data); err != nil {
+		putSeriesData(data, g.MemoryConsumptionTracker)
+		if side.matchGroup != nil {
+			side.matchGroup.releasePresence(g.MemoryConsumptionTracker)
+		}
 		return err
 	}
 
 	side.mergedData, err = g.mergeOneSide(data, side.seriesIndices)
 	if err != nil {
-		return err
+		return fmt.Errorf("merge one-side series: %w", err)
 	}
 
 	// Clear seriesIndices to indicate that we've populated it.
@@ -1054,7 +1421,7 @@ func (g *GroupedVectorVectorBinaryOperation) ensureOneSidePopulated(ctx context.
 	return nil
 }
 
-func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(side *oneSide, data []types.InstantVectorSeriesData) error {
+func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(ctx context.Context, side *oneSide, data []types.InstantVectorSeriesData) error {
 	matchGroup := side.matchGroup
 	if matchGroup == nil {
 		// If there is only one set of additional labels for this set of grouping labels, then there's nothing to do.
@@ -1063,6 +1430,9 @@ func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(side *oneSide
 
 	// If there are multiple sets of additional labels for the same set of grouping labels, check that there is only one series at each
 	// time step for each set of grouping labels.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update one-side presence: %w", err)
+	}
 
 	if matchGroup.presence == nil {
 		var err error
@@ -1075,6 +1445,11 @@ func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(side *oneSide
 		matchGroup.presence = matchGroup.presence[:g.timeRange.StepCount]
 
 		for idx := range matchGroup.presence {
+			if idx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("initialize one-side presence: %w", err)
+				}
+			}
 			matchGroup.presence[idx] = -1
 		}
 	}
@@ -1082,13 +1457,23 @@ func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(side *oneSide
 	for dataIdx, seriesData := range data {
 		seriesIdx := side.seriesIndices[dataIdx]
 
-		for _, p := range seriesData.Floats {
+		for pointIdx, p := range seriesData.Floats {
+			if pointIdx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("update one-side float presence: %w", err)
+				}
+			}
 			if err := g.recordOneSidePresence(matchGroup, seriesIdx, p.T); err != nil {
 				return err
 			}
 		}
 
-		for _, p := range seriesData.Histograms {
+		for pointIdx, p := range seriesData.Histograms {
+			if pointIdx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("update one-side histogram presence: %w", err)
+				}
+			}
 			if err := g.recordOneSidePresence(matchGroup, seriesIdx, p.T); err != nil {
 				return err
 			}
@@ -1148,7 +1533,22 @@ func (g *GroupedVectorVectorBinaryOperation) mergeOneSide(data []types.InstantVe
 	return merged, nil
 }
 
+func (g *GroupedVectorVectorBinaryOperation) ensureManySideGroupPopulated(ctx context.Context, group *oneSideMatchGroup) error {
+	for _, side := range group.manySides {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("populate grouped many-side presence: %w", err)
+		}
+		if err := g.ensureManySidePopulated(ctx, side); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (g *GroupedVectorVectorBinaryOperation) ensureManySidePopulated(ctx context.Context, side *manySide) error {
+	if side == nil {
+		return nil
+	}
 	if side.seriesIndices == nil {
 		// Already populated.
 		return nil
@@ -1158,21 +1558,97 @@ func (g *GroupedVectorVectorBinaryOperation) ensureManySidePopulated(ctx context
 	latestSeriesIndex := side.latestSeriesIndex()
 	data, err := g.manySideBuffer.GetSeries(ctx, side.seriesIndices)
 	if err != nil {
-		return err
+		return fmt.Errorf("read many-side series: %w", err)
 	}
 	if latestSeriesIndex == g.lastManySideSeriesIndex {
 		g.markManySideFinishedReading()
 	}
 
+	if err := g.updateManySidePresence(ctx, side, data); err != nil {
+		putSeriesData(data, g.MemoryConsumptionTracker)
+		return err
+	}
+
 	side.mergedData, err = g.mergeManySide(data, side.seriesIndices)
 	if err != nil {
-		return err
+		if errors.Is(err, errMultipleMatchesOnManySide) {
+			return err
+		}
+		return fmt.Errorf("merge many-side series: %w", err)
 	}
 
 	// Clear seriesIndices to indicate that we've populated it.
 	side.seriesIndices = nil
 
 	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) updateManySidePresence(ctx context.Context, side *manySide, data []types.InstantVectorSeriesData) error {
+	group := side.matchGroup
+	if side.presenceRecorded || group == nil || group.manySideFillCarrierCount == 0 {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update many-side presence: %w", err)
+	}
+	if group.manyPresence == nil {
+		presence, err := types.IntSlicePool.Get(g.timeRange.StepCount, g.MemoryConsumptionTracker)
+		if err != nil {
+			return fmt.Errorf("allocate many-side presence: %w", err)
+		}
+		group.manyPresence = presence[:g.timeRange.StepCount]
+		for idx := range group.manyPresence {
+			if idx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("initialize many-side presence: %w", err)
+				}
+			}
+			group.manyPresence[idx] = -1
+		}
+	}
+
+	for dataIdx, seriesData := range data {
+		seriesIndex := side.seriesIndices[dataIdx]
+		for pointIdx, point := range seriesData.Floats {
+			if pointIdx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("update many-side float presence: %w", err)
+				}
+			}
+			if err := g.recordManySidePresence(group, seriesIndex, point.T); err != nil {
+				return err
+			}
+		}
+		for pointIdx, point := range seriesData.Histograms {
+			if pointIdx&1023 == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("update many-side histogram presence: %w", err)
+				}
+			}
+			if err := g.recordManySidePresence(group, seriesIndex, point.T); err != nil {
+				return err
+			}
+		}
+	}
+	side.presenceRecorded = true
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) recordManySidePresence(group *oneSideMatchGroup, seriesIndex int, timestamp int64) error {
+	timestampIndex, err := g.presenceTimestampIndex(timestamp, len(group.manyPresence))
+	if err != nil {
+		return fmt.Errorf("record many-side presence at timestamp %d: %w", timestamp, err)
+	}
+	if group.manyPresence[timestampIndex] == -1 {
+		group.manyPresence[timestampIndex] = seriesIndex
+	}
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) releaseManyPresence() {
+	for _, group := range g.manyPresenceGroups {
+		group.releaseManyPresence(g.MemoryConsumptionTracker)
+	}
 }
 
 func (g *GroupedVectorVectorBinaryOperation) mergeManySide(data []types.InstantVectorSeriesData, sourceSeriesIndices []int) (types.InstantVectorSeriesData, error) {
@@ -1285,6 +1761,7 @@ func (g *GroupedVectorVectorBinaryOperation) FinishedReading(ctx context.Context
 	}
 
 	g.remainingSeries = nil
+	g.releaseManyPresence()
 
 	if err := g.finishLeft(ctx); err != nil {
 		return err

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -67,16 +67,24 @@ type GroupedVectorVectorBinaryOperation struct {
 var _ types.InstantVectorOperator = &GroupedVectorVectorBinaryOperation{}
 
 type groupedBinaryOperationOutputSeries struct {
-	manySide    *manySide
-	oneSide     *oneSide
-	fillCarrier *oneSide
+	manySide             *manySide
+	oneSide              *oneSide
+	fillCarrier          *oneSide
+	manySideFillCarriers []syntheticManySideCarrier
 }
 
 func (g *groupedBinaryOperationOutputSeries) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	g.finishFillCarrier(memoryConsumptionTracker)
-	g.manySide.FinishedReading(memoryConsumptionTracker)
+	if g.manySide != nil {
+		g.manySide.FinishedReading(memoryConsumptionTracker)
+	}
 	if g.oneSide != nil {
 		g.oneSide.FinishedReading(memoryConsumptionTracker)
+	}
+	for _, carrier := range g.manySideFillCarriers {
+		if carrier.oneSide != g.oneSide {
+			carrier.oneSide.FinishedReading(memoryConsumptionTracker)
+		}
 	}
 }
 
@@ -94,6 +102,12 @@ func (g *groupedBinaryOperationOutputSeries) finishFillCarrier(memoryConsumption
 type groupedBinaryOperationOutputSeriesWithLabels struct {
 	labels       labels.Labels
 	outputSeries *groupedBinaryOperationOutputSeries
+}
+
+type syntheticManySideCarrier struct {
+	oneSide      *oneSide
+	matchGroup   *oneSideMatchGroup
+	variantIndex int
 }
 
 type normalizedGroupedSides struct {
@@ -135,6 +149,7 @@ type manySide struct {
 	mergedData    types.InstantVectorSeriesData
 
 	outputSeriesCount int
+	matchGroup        *oneSideMatchGroup
 }
 
 // latestSeriesIndex returns the index of the last series from this side.
@@ -204,10 +219,11 @@ func (g *matchGroup) fillCarrierFinished(memoryConsumptionTracker *limiter.Memor
 }
 
 type oneSideMatchGroup struct {
-	sides      map[string]*oneSide
-	ordered    []*oneSide
-	matchGroup *matchGroup
-	relevant   bool
+	sides                     map[string]*oneSide
+	ordered                   []*oneSide
+	matchGroup                *matchGroup
+	relevant                  bool
+	latestManySideSeriesIndex int
 }
 
 // updatePresence records the presence of a sample from the series with index seriesIdx at the timestamp with index timestampIdx.
@@ -328,7 +344,14 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context,
 	} else {
 		g.oneSideBuffer = operators.NewInstantVectorOperatorBuffer(g.oneSide, oneSideSeriesUsed, lastOneSideSeriesUsedIndex, g.MemoryConsumptionTracker)
 	}
-	g.manySideBuffer = operators.NewInstantVectorOperatorBuffer(g.manySide, manySideSeriesUsed, lastManySideSeriesUsedIndex, g.MemoryConsumptionTracker)
+	if lastManySideSeriesUsedIndex == -1 {
+		types.BoolSlicePool.Put(&manySideSeriesUsed, g.MemoryConsumptionTracker)
+		if err := g.finishManySide(ctx); err != nil {
+			return nil, err
+		}
+	} else {
+		g.manySideBuffer = operators.NewInstantVectorOperatorBuffer(g.manySide, manySideSeriesUsed, lastManySideSeriesUsedIndex, g.MemoryConsumptionTracker)
+	}
 
 	return allMetadata, nil
 }
@@ -428,14 +451,16 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	// [env=prod][region=us]: {...}
 	additionalLabelsKeyFunc := g.additionalLabelsKeyFunc()
 	oneSideMap := map[string]*oneSideMatchGroup{}
+	oneSideGroups := make([]*oneSideMatchGroup, 0, len(g.oneSideMetadata))
 
 	for idx, s := range g.oneSideMetadata {
 		groupKey := groupKeyFunc(s.Labels)
 		oneSideGroup, exists := oneSideMap[string(groupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
 
 		if !exists {
-			oneSideGroup = &oneSideMatchGroup{sides: map[string]*oneSide{}}
+			oneSideGroup = &oneSideMatchGroup{sides: map[string]*oneSide{}, latestManySideSeriesIndex: -1}
 			oneSideMap[string(groupKey)] = oneSideGroup
+			oneSideGroups = append(oneSideGroups, oneSideGroup)
 		}
 
 		additionalLabelsKey := additionalLabelsKeyFunc(s.Labels)
@@ -479,6 +504,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 			oneSideGroup = &oneSideMatchGroup{}
 		} else {
 			oneSideGroup.relevant = true
+			oneSideGroup.latestManySideSeriesIndex = idx
 			if oneSideGroup.matchGroup == nil && (g.fillValues.RHS != nil || len(oneSideGroup.ordered) > 1) {
 				oneSideGroup.matchGroup = &matchGroup{
 					oneSides:     oneSideGroup.ordered,
@@ -503,6 +529,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 
 		thisManySide = &manySide{
 			seriesIndices: []int{idx},
+			matchGroup:    oneSideGroup,
 		}
 
 		manySideMap[string(manySideGroupKey)] = thisManySide
@@ -580,6 +607,42 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 		}
 	}
 
+	if g.fillValues.LHS != nil {
+		for _, oneSideGroup := range oneSideGroups {
+			oneSideGroup.relevant = true
+			for variantIndex, oneSide := range oneSideGroup.ordered {
+				oneSideLabels := g.oneSideMetadata[oneSide.seriesIndices[0]].Labels
+				syntheticManySideLabels := g.syntheticManySideLabels(oneSideLabels)
+				l := outputSeriesLabelsFunc(oneSideLabels, syntheticManySideLabels)
+				key := string(l.Bytes(buf))
+				carrier := syntheticManySideCarrier{
+					oneSide:      oneSide,
+					matchGroup:   oneSideGroup,
+					variantIndex: variantIndex,
+				}
+
+				if existing, exists := outputSeriesMap[key]; exists {
+					if !outputSeriesReferencesOneSide(existing.outputSeries, oneSide) {
+						oneSide.outputSeriesCount++
+					}
+					existing.outputSeries.manySideFillCarriers = append(existing.outputSeries.manySideFillCarriers, carrier)
+					continue
+				}
+
+				oneSide.outputSeriesCount++
+				if err := g.MemoryConsumptionTracker.IncreaseMemoryConsumptionForLabels(l); err != nil {
+					return nil, nil, nil, -1, nil, -1, err
+				}
+				outputSeriesMap[key] = groupedBinaryOperationOutputSeriesWithLabels{
+					labels: l,
+					outputSeries: &groupedBinaryOperationOutputSeries{
+						manySideFillCarriers: []syntheticManySideCarrier{carrier},
+					},
+				}
+			}
+		}
+	}
+
 	// Next, go through all the "one" side groups again, and determine which of the "one" side series we'll actually need.
 	oneSideSeriesUsed, err := types.BoolSlicePool.Get(len(g.oneSideMetadata), g.MemoryConsumptionTracker)
 	if err != nil {
@@ -651,6 +714,24 @@ func (g *GroupedVectorVectorBinaryOperation) syntheticOneSideLabelsFunc() func(m
 	return func(manySideLabels labels.Labels) labels.Labels {
 		return manySideLabels.MatchLabels(g.VectorMatching.On, g.VectorMatching.MatchingLabels...)
 	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) syntheticManySideLabels(oneSideLabels labels.Labels) labels.Labels {
+	return oneSideLabels.MatchLabels(g.VectorMatching.On, g.VectorMatching.MatchingLabels...).DropReserved(func(name string) bool {
+		return name == model.MetricNameLabel
+	})
+}
+
+func outputSeriesReferencesOneSide(series *groupedBinaryOperationOutputSeries, side *oneSide) bool {
+	if series.oneSide == side {
+		return true
+	}
+	for _, carrier := range series.manySideFillCarriers {
+		if carrier.oneSide == side {
+			return true
+		}
+	}
+	return false
 }
 
 // manySideGroupKeyFunc returns a function that extracts a key representing the set of labels from the "many" side that will contribute
@@ -769,13 +850,73 @@ func (s favourManySideSorter) Len() int {
 }
 
 func (s favourManySideSorter) Less(i, j int) bool {
-	iMany := s.series[i].manySide.latestSeriesIndex()
-	jMany := s.series[j].manySide.latestSeriesIndex()
+	iMany := outputLatestManySideSeriesIndex(s.series[i])
+	jMany := outputLatestManySideSeriesIndex(s.series[j])
 	if iMany != jMany {
 		return iMany < jMany
 	}
+	if outputManySideCarrierFollows(s.series[i], s.series[j]) {
+		return false
+	}
+	if outputManySideCarrierFollows(s.series[j], s.series[i]) {
+		return true
+	}
 
-	return outputOneSideSeriesIndex(s.series[i]) < outputOneSideSeriesIndex(s.series[j])
+	iCarrierSeries, iCarrierVariant := outputManySideCarrierOrder(s.series[i])
+	jCarrierSeries, jCarrierVariant := outputManySideCarrierOrder(s.series[j])
+	if iCarrierSeries != jCarrierSeries {
+		return iCarrierSeries < jCarrierSeries
+	}
+	if iCarrierVariant != jCarrierVariant {
+		return iCarrierVariant < jCarrierVariant
+	}
+
+	iOne := outputOneSideSeriesIndex(s.series[i])
+	jOne := outputOneSideSeriesIndex(s.series[j])
+	if iOne != jOne {
+		return iOne < jOne
+	}
+
+	return labels.Compare(s.metadata[i].Labels, s.metadata[j].Labels) < 0
+}
+
+func outputLatestManySideSeriesIndex(series *groupedBinaryOperationOutputSeries) int {
+	latest := -1
+	if series.manySide != nil {
+		latest = series.manySide.latestSeriesIndex()
+	}
+	for _, carrier := range series.manySideFillCarriers {
+		latest = max(latest, carrier.matchGroup.latestManySideSeriesIndex)
+	}
+	return latest
+}
+
+func outputManySideCarrierFollows(carrier, real *groupedBinaryOperationOutputSeries) bool {
+	if len(carrier.manySideFillCarriers) == 0 || real.manySide == nil || len(real.manySideFillCarriers) > 0 {
+		return false
+	}
+	for _, candidate := range carrier.manySideFillCarriers {
+		if candidate.matchGroup == real.manySide.matchGroup {
+			return true
+		}
+	}
+	return false
+}
+
+func outputManySideCarrierOrder(series *groupedBinaryOperationOutputSeries) (int, int) {
+	if len(series.manySideFillCarriers) == 0 {
+		return -1, -1
+	}
+	seriesIndex := int(^uint(0) >> 1)
+	variantIndex := int(^uint(0) >> 1)
+	for _, carrier := range series.manySideFillCarriers {
+		candidateSeriesIndex := carrier.oneSide.latestSeriesIndex()
+		if candidateSeriesIndex < seriesIndex || candidateSeriesIndex == seriesIndex && carrier.variantIndex < variantIndex {
+			seriesIndex = candidateSeriesIndex
+			variantIndex = carrier.variantIndex
+		}
+	}
+	return seriesIndex, variantIndex
 }
 
 func outputOneSideSeriesIndex(series *groupedBinaryOperationOutputSeries) int {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -43,12 +43,15 @@ type GroupedVectorVectorBinaryOperation struct {
 	hints              *Hints
 	logger             log.Logger
 
-	evaluator       *vectorVectorBinaryOperationEvaluator
-	remainingSeries []*groupedBinaryOperationOutputSeries
-	oneSide         types.InstantVectorOperator // Either Left or Right
-	manySide        types.InstantVectorOperator
-	oneSideBuffer   *operators.InstantVectorOperatorBuffer
-	manySideBuffer  *operators.InstantVectorOperatorBuffer
+	evaluator            *vectorVectorBinaryOperationEvaluator
+	remainingSeries      []*groupedBinaryOperationOutputSeries
+	oneSide              types.InstantVectorOperator // Either Left or Right
+	manySide             types.InstantVectorOperator
+	fillValues           parser.VectorMatchFillValues
+	oneSideBuffer        *operators.InstantVectorOperatorBuffer
+	manySideBuffer       *operators.InstantVectorOperatorBuffer
+	leftFinishedReading  bool
+	rightFinishedReading bool
 
 	// We need to retain these so that NextSeries() can return an error message with the series labels when
 	// multiple points match on a single side.
@@ -73,6 +76,38 @@ func (g *groupedBinaryOperationOutputSeries) FinishedReading(memoryConsumptionTr
 type groupedBinaryOperationOutputSeriesWithLabels struct {
 	labels       labels.Labels
 	outputSeries *groupedBinaryOperationOutputSeries
+}
+
+type normalizedGroupedSides struct {
+	many       types.InstantVectorOperator
+	one        types.InstantVectorOperator
+	fillValues parser.VectorMatchFillValues // LHS fills many, and RHS fills one.
+}
+
+func normalizeGroupedSides(left, right types.InstantVectorOperator, vectorMatching parser.VectorMatching) (normalizedGroupedSides, error) {
+	switch vectorMatching.Card {
+	case parser.CardManyToOne:
+		return normalizedGroupedSides{many: left, one: right, fillValues: vectorMatching.FillValues}, nil
+	case parser.CardOneToMany:
+		return normalizedGroupedSides{
+			many:       right,
+			one:        left,
+			fillValues: vectorMatching.FillValues,
+		}, nil
+	default:
+		return normalizedGroupedSides{}, fmt.Errorf("unsupported cardinality %d", int(vectorMatching.Card))
+	}
+}
+
+func (s normalizedGroupedSides) evaluatorFillValues(card parser.VectorMatchCardinality) (*float64, *float64, error) {
+	switch card {
+	case parser.CardManyToOne:
+		return s.fillValues.LHS, s.fillValues.RHS, nil
+	case parser.CardOneToMany:
+		return s.fillValues.RHS, s.fillValues.LHS, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported cardinality %d", int(card))
+	}
 }
 
 type manySide struct {
@@ -156,7 +191,16 @@ func NewGroupedVectorVectorBinaryOperation(
 	hints *Hints,
 	logger log.Logger,
 ) (*GroupedVectorVectorBinaryOperation, error) {
-	e, err := newVectorVectorBinaryOperationEvaluator(op, returnBool, memoryConsumptionTracker, expressionPosition, timeRange, nil, nil)
+	sides, err := normalizeGroupedSides(left, right, vectorMatching)
+	if err != nil {
+		return nil, err
+	}
+
+	fillLeft, fillRight, err := sides.evaluatorFillValues(vectorMatching.Card)
+	if err != nil {
+		return nil, err
+	}
+	e, err := newVectorVectorBinaryOperationEvaluator(op, returnBool, memoryConsumptionTracker, expressionPosition, timeRange, fillLeft, fillRight)
 	if err != nil {
 		return nil, err
 	}
@@ -174,15 +218,9 @@ func NewGroupedVectorVectorBinaryOperation(
 		timeRange:          timeRange,
 		hints:              hints,
 		logger:             logger,
-	}
-
-	switch g.VectorMatching.Card {
-	case parser.CardOneToMany:
-		g.oneSide, g.manySide = g.Left, g.Right
-	case parser.CardManyToOne:
-		g.manySide, g.oneSide = g.Left, g.Right
-	default:
-		return nil, fmt.Errorf("unsupported cardinality '%v'", g.VectorMatching.Card)
+		manySide:           sides.many,
+		oneSide:            sides.one,
+		fillValues:         sides.fillValues,
 	}
 
 	slices.Sort(g.VectorMatching.Include)
@@ -242,9 +280,9 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context,
 	return allMetadata, nil
 }
 
-// loadSeriesMetadata loads series metadata from both sides of this operation.
-// It returns false if one side returned no series and that means there is no way for this operation to return any series.
-// (eg. if doing A + B and either A or B have no series, then there is no way for this operation to produce any series)
+// loadSeriesMetadata loads child metadata and reports whether labels can drive output.
+// A nonempty side can drive output when the empty normalized side has a fill value.
+// Two empty sides cannot drive output.
 func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Context, matchers types.Matchers) (bool, error) {
 	// We retain the series labels for later so we can use them to generate error messages.
 	// We'll return them to the pool in Close().
@@ -269,8 +307,8 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 		return false, err
 	}
 
-	if len(g.oneSideMetadata) == 0 {
-		// The current grouped evaluator cannot produce output when the one side is empty.
+	oneSideEmpty := len(g.oneSideMetadata) == 0
+	if oneSideEmpty && g.fillValues.RHS == nil {
 		return false, nil
 	}
 
@@ -292,9 +330,22 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 		return false, err
 	}
 
-	if len(g.manySideMetadata) == 0 {
-		// No series on right-hand side, we'll never have any output series.
+	manySideEmpty := len(g.manySideMetadata) == 0
+	if oneSideEmpty && manySideEmpty {
 		return false, nil
+	}
+	if manySideEmpty && g.fillValues.LHS == nil {
+		return false, nil
+	}
+	if oneSideEmpty {
+		if err := g.finishOneSide(ctx); err != nil {
+			return false, err
+		}
+	}
+	if manySideEmpty {
+		if err := g.finishManySide(ctx); err != nil {
+			return false, err
+		}
 	}
 
 	return true, nil
@@ -649,7 +700,7 @@ func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (ty
 	case parser.CardManyToOne:
 		result, _, err = g.evaluator.computeResult(thisSeries.manySide.mergedData, thisSeries.oneSide.mergedData, isLastOutputSeriesForManySide, isLastOutputSeriesForOneSide, computeResultOptions{})
 	default:
-		panic(fmt.Sprintf("unsupported cardinality '%v'", g.VectorMatching.Card))
+		panic(fmt.Sprintf("unsupported cardinality %d", int(g.VectorMatching.Card)))
 	}
 
 	// If this is the last output series for that side, then we've passed ownership of mergedData to the evaluator, so clear it now to avoid returning it to the pool later.
@@ -850,7 +901,7 @@ func (g *GroupedVectorVectorBinaryOperation) oneSideHandedness() string {
 	case parser.CardManyToOne:
 		return "right"
 	default:
-		panic(fmt.Sprintf("unsupported cardinality '%v'", g.VectorMatching.Card))
+		panic(fmt.Sprintf("unsupported cardinality %d", int(g.VectorMatching.Card)))
 	}
 }
 
@@ -894,12 +945,55 @@ func (g *GroupedVectorVectorBinaryOperation) FinishedReading(ctx context.Context
 
 	g.remainingSeries = nil
 
-	// We don't need to call FinishedReading on g.oneSide or g.manySide, as these are either g.Left or g.Right and so will have FinishedReading called below.
-	if err := g.Left.FinishedReading(ctx); err != nil {
+	if err := g.finishLeft(ctx); err != nil {
 		return err
 	}
 
-	return g.Right.FinishedReading(ctx)
+	return g.finishRight(ctx)
+}
+
+func (g *GroupedVectorVectorBinaryOperation) finishOneSide(ctx context.Context) error {
+	switch g.VectorMatching.Card {
+	case parser.CardOneToMany:
+		return g.finishLeft(ctx)
+	case parser.CardManyToOne:
+		return g.finishRight(ctx)
+	default:
+		return fmt.Errorf("unsupported cardinality %d", int(g.VectorMatching.Card))
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) finishManySide(ctx context.Context) error {
+	switch g.VectorMatching.Card {
+	case parser.CardOneToMany:
+		return g.finishRight(ctx)
+	case parser.CardManyToOne:
+		return g.finishLeft(ctx)
+	default:
+		return fmt.Errorf("unsupported cardinality %d", int(g.VectorMatching.Card))
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) finishLeft(ctx context.Context) error {
+	if g.leftFinishedReading {
+		return nil
+	}
+	if err := g.Left.FinishedReading(ctx); err != nil {
+		return fmt.Errorf("finish left child: %w", err)
+	}
+	g.leftFinishedReading = true
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) finishRight(ctx context.Context) error {
+	if g.rightFinishedReading {
+		return nil
+	}
+	if err := g.Right.FinishedReading(ctx); err != nil {
+		return fmt.Errorf("finish right child: %w", err)
+	}
+	g.rightFinishedReading = true
+	return nil
 }
 
 func (g *GroupedVectorVectorBinaryOperation) Finalize(ctx context.Context) (*types.OperatorEvaluationStats, annotations.Annotations, error) {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -256,7 +256,12 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 	// with "on(...)" that's MatchingLabels (so "on()" forwards none), and Include labels are never
 	// forwarded (they come from the many side). Other matchers go to the many side instead;
 	// forwarding them to the one side would incorrectly filter it to empty (see separateIncludeLabelMatchers).
-	oneSideMatchers, includeMatchers := separateIncludeLabelMatchers(matchers, g.VectorMatching.Include, g.VectorMatching.On, g.VectorMatching.MatchingLabels)
+	// Grouped fill disables all matchers because unmatched series can produce output.
+	fillActive := g.VectorMatching.FillValues.LHS != nil || g.VectorMatching.FillValues.RHS != nil
+	var oneSideMatchers, includeMatchers types.Matchers
+	if !fillActive {
+		oneSideMatchers, includeMatchers = separateIncludeLabelMatchers(matchers, g.VectorMatching.Include, g.VectorMatching.On, g.VectorMatching.MatchingLabels)
+	}
 
 	var err error
 	g.oneSideMetadata, err = g.oneSide.SeriesMetadata(ctx, oneSideMatchers)
@@ -265,8 +270,7 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 	}
 
 	if len(g.oneSideMetadata) == 0 {
-		// No series on the "one" side. With fill, the "many" side could still produce output,
-		// but grouped fill is not yet implemented — the planner rejects it before reaching here.
+		// The current grouped evaluator cannot produce output when the one side is empty.
 		return false, nil
 	}
 
@@ -275,8 +279,11 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 	// metadata and merge them with any outer matchers for included labels (which belong to the
 	// many side). Otherwise fall back to the same outer matchers used for the "one" side, plus those
 	// that apply to the included labels (derived from the "many" side).
-	manySideMatchers := matchers
-	if g.hints != nil {
+	var manySideMatchers types.Matchers
+	if !fillActive {
+		manySideMatchers = matchers
+	}
+	if !fillActive && g.hints != nil {
 		manySideMatchers = append(BuildMatchers(ctx, g.logger, g.oneSideMetadata, g.hints), includeMatchers...)
 	}
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -7,6 +7,7 @@ package binops
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"slices"
@@ -43,15 +44,17 @@ type GroupedVectorVectorBinaryOperation struct {
 	hints              *Hints
 	logger             log.Logger
 
-	evaluator            *vectorVectorBinaryOperationEvaluator
-	remainingSeries      []*groupedBinaryOperationOutputSeries
-	oneSide              types.InstantVectorOperator // Either Left or Right
-	manySide             types.InstantVectorOperator
-	fillValues           parser.VectorMatchFillValues
-	oneSideBuffer        *operators.InstantVectorOperatorBuffer
-	manySideBuffer       *operators.InstantVectorOperatorBuffer
-	leftFinishedReading  bool
-	rightFinishedReading bool
+	evaluator               *vectorVectorBinaryOperationEvaluator
+	remainingSeries         []*groupedBinaryOperationOutputSeries
+	oneSide                 types.InstantVectorOperator // Either Left or Right
+	manySide                types.InstantVectorOperator
+	fillValues              parser.VectorMatchFillValues
+	oneSideBuffer           *operators.InstantVectorOperatorBuffer
+	manySideBuffer          *operators.InstantVectorOperatorBuffer
+	lastOneSideSeriesIndex  int
+	lastManySideSeriesIndex int
+	leftFinishedReading     bool
+	rightFinishedReading    bool
 
 	// We need to retain these so that NextSeries() can return an error message with the series labels when
 	// multiple points match on a single side.
@@ -64,13 +67,28 @@ type GroupedVectorVectorBinaryOperation struct {
 var _ types.InstantVectorOperator = &GroupedVectorVectorBinaryOperation{}
 
 type groupedBinaryOperationOutputSeries struct {
-	manySide *manySide
-	oneSide  *oneSide
+	manySide    *manySide
+	oneSide     *oneSide
+	fillCarrier *oneSide
 }
 
 func (g *groupedBinaryOperationOutputSeries) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	g.finishFillCarrier(memoryConsumptionTracker)
 	g.manySide.FinishedReading(memoryConsumptionTracker)
-	g.oneSide.FinishedReading(memoryConsumptionTracker)
+	if g.oneSide != nil {
+		g.oneSide.FinishedReading(memoryConsumptionTracker)
+	}
+}
+
+func (g *groupedBinaryOperationOutputSeries) finishFillCarrier(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	if g.fillCarrier == nil {
+		return
+	}
+
+	if g.fillCarrier.matchGroup != nil {
+		g.fillCarrier.matchGroup.fillCarrierFinished(memoryConsumptionTracker)
+	}
+	g.fillCarrier = nil
 }
 
 type groupedBinaryOperationOutputSeriesWithLabels struct {
@@ -139,13 +157,17 @@ type oneSide struct {
 
 	outputSeriesCount int // The number of output series that refer to this side.
 
-	matchGroup *matchGroup // nil if this is the only "one" side in this group.
+	matchGroup *matchGroup // matchGroup tracks presence for fills and groups with multiple one-side variants.
 }
 
 // latestSeriesIndex returns the index of the last series from this side.
 //
 // It assumes that seriesIndices is sorted in ascending order.
 func (s *oneSide) latestSeriesIndex() int {
+	if len(s.seriesIndices) == 0 {
+		return -1
+	}
+
 	return s.seriesIndices[len(s.seriesIndices)-1]
 }
 
@@ -153,8 +175,8 @@ func (s *oneSide) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsum
 	types.PutInstantVectorSeriesData(s.mergedData, memoryConsumptionTracker)
 	s.mergedData = types.InstantVectorSeriesData{}
 
-	if s.matchGroup != nil {
-		types.IntSlicePool.Put(&s.matchGroup.presence, memoryConsumptionTracker)
+	if s.matchGroup != nil && s.matchGroup.fillCarrierCount == 0 {
+		s.matchGroup.releasePresence(memoryConsumptionTracker)
 	}
 }
 
@@ -163,7 +185,29 @@ type matchGroup struct {
 	// Each value is the index of the source series of the sample, or -1 if no sample has been seen for this time step yet.
 	presence []int
 
-	oneSideCount int
+	oneSides         []*oneSide
+	oneSideCount     int
+	fillCarrierCount int
+}
+
+func (g *matchGroup) releasePresence(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	if g.presence != nil {
+		types.IntSlicePool.Put(&g.presence, memoryConsumptionTracker)
+	}
+}
+
+func (g *matchGroup) fillCarrierFinished(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	g.fillCarrierCount--
+	if g.fillCarrierCount == 0 {
+		g.releasePresence(memoryConsumptionTracker)
+	}
+}
+
+type oneSideMatchGroup struct {
+	sides      map[string]*oneSide
+	ordered    []*oneSide
+	matchGroup *matchGroup
+	relevant   bool
 }
 
 // updatePresence records the presence of a sample from the series with index seriesIdx at the timestamp with index timestampIdx.
@@ -273,8 +317,17 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context,
 
 	g.sortSeries(allMetadata, allSeries)
 	g.remainingSeries = allSeries
+	g.lastOneSideSeriesIndex = lastOneSideSeriesUsedIndex
+	g.lastManySideSeriesIndex = lastManySideSeriesUsedIndex
 
-	g.oneSideBuffer = operators.NewInstantVectorOperatorBuffer(g.oneSide, oneSideSeriesUsed, lastOneSideSeriesUsedIndex, g.MemoryConsumptionTracker)
+	if lastOneSideSeriesUsedIndex == -1 {
+		types.BoolSlicePool.Put(&oneSideSeriesUsed, g.MemoryConsumptionTracker)
+		if err := g.finishOneSide(ctx); err != nil {
+			return nil, err
+		}
+	} else {
+		g.oneSideBuffer = operators.NewInstantVectorOperatorBuffer(g.oneSide, oneSideSeriesUsed, lastOneSideSeriesUsedIndex, g.MemoryConsumptionTracker)
+	}
 	g.manySideBuffer = operators.NewInstantVectorOperatorBuffer(g.manySide, manySideSeriesUsed, lastManySideSeriesUsedIndex, g.MemoryConsumptionTracker)
 
 	return allMetadata, nil
@@ -374,23 +427,24 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	// [env=prod][region=eu]: {...}
 	// [env=prod][region=us]: {...}
 	additionalLabelsKeyFunc := g.additionalLabelsKeyFunc()
-	oneSideMap := map[string]map[string]*oneSide{}
+	oneSideMap := map[string]*oneSideMatchGroup{}
 
 	for idx, s := range g.oneSideMetadata {
 		groupKey := groupKeyFunc(s.Labels)
 		oneSideGroup, exists := oneSideMap[string(groupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
 
 		if !exists {
-			oneSideGroup = map[string]*oneSide{}
+			oneSideGroup = &oneSideMatchGroup{sides: map[string]*oneSide{}}
 			oneSideMap[string(groupKey)] = oneSideGroup
 		}
 
 		additionalLabelsKey := additionalLabelsKeyFunc(s.Labels)
-		side, exists := oneSideGroup[string(additionalLabelsKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+		side, exists := oneSideGroup.sides[string(additionalLabelsKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
 
 		if !exists {
 			side = &oneSide{}
-			oneSideGroup[string(additionalLabelsKey)] = side
+			oneSideGroup.sides[string(additionalLabelsKey)] = side
+			oneSideGroup.ordered = append(oneSideGroup.ordered, side)
 		}
 
 		side.seriesIndices = append(side.seriesIndices, idx)
@@ -402,6 +456,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	manySideMap := map[string]*manySide{}                                        // Series from the "many" side, grouped by which output series they'll contribute to.
 	manySideGroupKeyFunc := g.manySideGroupKeyFunc()
 	outputSeriesLabelsFunc := g.outputSeriesLabelsFunc()
+	syntheticOneSideLabelsFunc := g.syntheticOneSideLabelsFunc()
 	buf := make([]byte, 0, types.LabelBytesBufferSize)
 
 	manySideSeriesUsed, err := types.BoolSlicePool.Get(len(g.manySideMetadata), g.MemoryConsumptionTracker)
@@ -417,8 +472,22 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 		oneSideGroup, exists := oneSideMap[string(groupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
 
 		if !exists {
-			// There are no series on the "one" side that match this series, so we'll produce no output series for this series.
-			continue
+			if g.fillValues.RHS == nil {
+				continue
+			}
+
+			oneSideGroup = &oneSideMatchGroup{}
+		} else {
+			oneSideGroup.relevant = true
+			if oneSideGroup.matchGroup == nil && (g.fillValues.RHS != nil || len(oneSideGroup.ordered) > 1) {
+				oneSideGroup.matchGroup = &matchGroup{
+					oneSides:     oneSideGroup.ordered,
+					oneSideCount: len(oneSideGroup.ordered),
+				}
+				for _, side := range oneSideGroup.ordered {
+					side.matchGroup = oneSideGroup.matchGroup
+				}
+			}
 		}
 
 		manySideSeriesUsed[idx] = true
@@ -438,30 +507,73 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 
 		manySideMap[string(manySideGroupKey)] = thisManySide
 
-		for _, oneSide := range oneSideGroup {
+		for _, oneSide := range oneSideGroup.ordered {
 			// Most of the time, the output series won't already exist (unless we have input series with different metric names),
 			// so just create the series labels directly rather than trying to avoid their creation until we know for sure we'll
 			// need them.
-			l := outputSeriesLabelsFunc(g.oneSideMetadata[oneSide.seriesIndices[0]].Labels, s.Labels)
-			_, exists := outputSeriesMap[string(l.Bytes(buf))]
+			oneSideLabels := g.oneSideMetadata[oneSide.seriesIndices[0]].Labels
+			l := outputSeriesLabelsFunc(oneSideLabels, s.Labels)
+			key := string(l.Bytes(buf))
+			existing, exists := outputSeriesMap[key]
 
-			if !exists {
-				oneSide.outputSeriesCount++
+			if exists {
+				if existing.outputSeries.manySide != thisManySide {
+					return nil, nil, nil, -1, nil, -1, fmt.Errorf("real one-side output labels %s collide across many-side groups", l.String())
+				}
+				if existing.outputSeries.oneSide != oneSide {
+					return nil, nil, nil, -1, nil, -1, fmt.Errorf("real one-side output labels %s collide across one-side variants", l.String())
+				}
+				continue
+			}
+
+			oneSide.outputSeriesCount++
+			thisManySide.outputSeriesCount++
+
+			// Account for the memory consumption from the labels now. This helps protect against
+			// queries that return many series from this operator.
+			// All series in outputSeriesMap will be returned, so this doesn't lead to over-counting
+			// of memory consumption.
+			if err := g.MemoryConsumptionTracker.IncreaseMemoryConsumptionForLabels(l); err != nil {
+				return nil, nil, nil, -1, nil, -1, err
+			}
+
+			outputSeriesMap[key] = groupedBinaryOperationOutputSeriesWithLabels{
+				labels: l,
+				outputSeries: &groupedBinaryOperationOutputSeries{
+					manySide: thisManySide,
+					oneSide:  oneSide,
+				},
+			}
+		}
+
+		if g.fillValues.RHS != nil {
+			syntheticOneSideLabels := syntheticOneSideLabelsFunc(s.Labels)
+			l := outputSeriesLabelsFunc(syntheticOneSideLabels, s.Labels)
+			key := string(l.Bytes(buf))
+			carrier := &oneSide{matchGroup: oneSideGroup.matchGroup}
+			if existing, exists := outputSeriesMap[key]; exists {
+				if existing.outputSeries.manySide != thisManySide {
+					return nil, nil, nil, -1, nil, -1, fmt.Errorf("synthetic one-side output labels %s collide across many-side groups", l.String())
+				}
+				if existing.outputSeries.fillCarrier == nil {
+					existing.outputSeries.fillCarrier = carrier
+					if oneSideGroup.matchGroup != nil {
+						oneSideGroup.matchGroup.fillCarrierCount++
+					}
+				}
+			} else {
 				thisManySide.outputSeriesCount++
-
-				// Account for the memory consumption from the labels now. This helps protect against
-				// queries that return many series from this operator.
-				// All series in outputSeriesMap will be returned, so this doesn't lead to over-counting
-				// of memory consumption.
+				if oneSideGroup.matchGroup != nil {
+					oneSideGroup.matchGroup.fillCarrierCount++
+				}
 				if err := g.MemoryConsumptionTracker.IncreaseMemoryConsumptionForLabels(l); err != nil {
 					return nil, nil, nil, -1, nil, -1, err
 				}
-
-				outputSeriesMap[string(l.Bytes(buf))] = groupedBinaryOperationOutputSeriesWithLabels{
+				outputSeriesMap[key] = groupedBinaryOperationOutputSeriesWithLabels{
 					labels: l,
 					outputSeries: &groupedBinaryOperationOutputSeries{
-						manySide: thisManySide,
-						oneSide:  oneSide,
+						manySide:    thisManySide,
+						fillCarrier: carrier,
 					},
 				}
 			}
@@ -478,20 +590,10 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	lastOneSideSeriesUsedIndex := -1
 
 	for _, oneSideGroup := range oneSideMap {
-		var thisMatchGroup *matchGroup
-
-		for _, oneSide := range oneSideGroup {
-			if oneSide.outputSeriesCount == 0 {
-				// If any part of a group has no output series, then no parts of that group will have output series.
-				break
-			} else if thisMatchGroup == nil && len(oneSideGroup) > 1 {
-				// We only need a matchGroup to detect conflicts between series on the "one" side that have the same grouping labels.
-				// So if there is only one "one" side, we don't need to bother with this and can skip creating the matchGroup.
-				thisMatchGroup = &matchGroup{oneSideCount: len(oneSideGroup)}
-			}
-
-			oneSide.matchGroup = thisMatchGroup
-
+		if !oneSideGroup.relevant {
+			continue
+		}
+		for _, oneSide := range oneSideGroup.ordered {
 			for _, idx := range oneSide.seriesIndices {
 				oneSideSeriesUsed[idx] = true
 			}
@@ -530,8 +632,24 @@ func (g *GroupedVectorVectorBinaryOperation) additionalLabelsKeyFunc() func(oneS
 	buf := make([]byte, 0, types.LabelBytesBufferSize)
 
 	return func(oneSideLabels labels.Labels) []byte {
-		buf = oneSideLabels.BytesWithLabels(buf, g.VectorMatching.Include...)
+		buf = buf[:0]
+		for _, name := range g.VectorMatching.Include {
+			value := oneSideLabels.Get(name)
+			if value == "" {
+				continue
+			}
+			buf = binary.AppendUvarint(buf, uint64(len(name)))
+			buf = append(buf, name...)
+			buf = binary.AppendUvarint(buf, uint64(len(value)))
+			buf = append(buf, value...)
+		}
 		return buf
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) syntheticOneSideLabelsFunc() func(manySideLabels labels.Labels) labels.Labels {
+	return func(manySideLabels labels.Labels) labels.Labels {
+		return manySideLabels.MatchLabels(g.VectorMatching.On, g.VectorMatching.MatchingLabels...)
 	}
 }
 
@@ -554,25 +672,13 @@ func (g *GroupedVectorVectorBinaryOperation) manySideGroupKeyFunc() func(manySid
 		}
 	}
 
-	labelsToRemove := make([]string, 0, len(g.VectorMatching.Include)+1)
-	for _, l := range g.VectorMatching.Include {
-		// Remove the include labels from the key of the many side when the grouping is `on(label)`.
-		// When it's `ignore(label)` we need to keep the include labels that aren't part of the matching
-		// set otherwise the series is non-unique. __name__ is never part of the key when used as an
-		// include label.
-		if l == model.MetricNameLabel || g.VectorMatching.On || slices.Contains(g.VectorMatching.MatchingLabels, l) {
-			labelsToRemove = append(labelsToRemove, l)
-		}
-	}
-
-	if g.shouldRemoveMetricNameFromManySide() {
-		labelsToRemove = append(labelsToRemove, model.MetricNameLabel)
-	}
-
-	slices.Sort(labelsToRemove)
+	outputSeriesLabelsFunc := g.outputSeriesLabelsFunc()
+	syntheticOneSideLabelsFunc := g.syntheticOneSideLabelsFunc()
 
 	return func(manySideLabels labels.Labels) []byte {
-		buf = manySideLabels.BytesWithoutLabels(buf, labelsToRemove...)
+		syntheticOneSideLabels := syntheticOneSideLabelsFunc(manySideLabels)
+		outputSeriesLabels := outputSeriesLabelsFunc(syntheticOneSideLabels, manySideLabels)
+		buf = outputSeriesLabels.Bytes(buf)
 		return buf
 	}
 }
@@ -582,8 +688,9 @@ func (g *GroupedVectorVectorBinaryOperation) outputSeriesLabelsFunc() func(oneSi
 	if len(g.VectorMatching.Include) == 0 {
 		if g.shouldRemoveMetricNameFromManySide() {
 			return func(_ labels.Labels, manySideLabels labels.Labels) labels.Labels {
-				//nolint:staticcheck // SA1019: DropMetricName is deprecated.
-				return manySideLabels.DropMetricName()
+				return manySideLabels.DropReserved(func(name string) bool {
+					return name == model.MetricNameLabel
+				})
 			}
 		}
 
@@ -600,7 +707,11 @@ func (g *GroupedVectorVectorBinaryOperation) outputSeriesLabelsFunc() func(oneSi
 			lb.Del(model.MetricNameLabel)
 
 			for _, l := range g.VectorMatching.Include {
-				lb.Set(l, oneSideLabels.Get(l))
+				if value := oneSideLabels.Get(l); value != "" {
+					lb.Set(l, value)
+				} else {
+					lb.Del(l)
+				}
 			}
 
 			return lb.Labels()
@@ -611,7 +722,11 @@ func (g *GroupedVectorVectorBinaryOperation) outputSeriesLabelsFunc() func(oneSi
 		lb.Reset(manySideLabels)
 
 		for _, l := range g.VectorMatching.Include {
-			lb.Set(l, oneSideLabels.Get(l))
+			if value := oneSideLabels.Get(l); value != "" {
+				lb.Set(l, value)
+			} else {
+				lb.Del(l)
+			}
 		}
 
 		return lb.Labels()
@@ -660,7 +775,14 @@ func (s favourManySideSorter) Less(i, j int) bool {
 		return iMany < jMany
 	}
 
-	return s.series[i].oneSide.latestSeriesIndex() < s.series[j].oneSide.latestSeriesIndex()
+	return outputOneSideSeriesIndex(s.series[i]) < outputOneSideSeriesIndex(s.series[j])
+}
+
+func outputOneSideSeriesIndex(series *groupedBinaryOperationOutputSeries) int {
+	if series.oneSide == nil {
+		return int(^uint(0) >> 1)
+	}
+	return series.oneSide.latestSeriesIndex()
 }
 
 func (s favourManySideSorter) Swap(i, j int) {
@@ -675,36 +797,50 @@ func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (ty
 
 	thisSeries := g.remainingSeries[0]
 	g.remainingSeries = g.remainingSeries[1:]
+	defer thisSeries.finishFillCarrier(g.MemoryConsumptionTracker)
 
-	if err := g.ensureOneSidePopulated(ctx, thisSeries.oneSide); err != nil {
-		return types.InstantVectorSeriesData{}, err
+	if thisSeries.oneSide != nil {
+		if err := g.ensureOneSidePopulated(ctx, thisSeries.oneSide); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+	}
+	if thisSeries.fillCarrier != nil && thisSeries.fillCarrier.matchGroup != nil {
+		if err := g.ensureOneSideGroupPopulated(ctx, thisSeries.fillCarrier.matchGroup); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
 	}
 
 	if err := g.ensureManySidePopulated(ctx, thisSeries.manySide); err != nil {
 		return types.InstantVectorSeriesData{}, err
 	}
 
-	thisSeries.oneSide.outputSeriesCount--
-	isLastOutputSeriesForOneSide := thisSeries.oneSide.outputSeriesCount == 0
+	isLastOutputSeriesForOneSide := false
+	oneSideData := types.InstantVectorSeriesData{}
+	if thisSeries.oneSide != nil {
+		thisSeries.oneSide.outputSeriesCount--
+		isLastOutputSeriesForOneSide = thisSeries.oneSide.outputSeriesCount == 0
+		oneSideData = thisSeries.oneSide.mergedData
+	}
 
 	thisSeries.manySide.outputSeriesCount--
 	isLastOutputSeriesForManySide := thisSeries.manySide.outputSeriesCount == 0
 
 	var result types.InstantVectorSeriesData
 	var err error
+	options := g.computeResultOptions(thisSeries)
 
 	switch g.VectorMatching.Card {
 	case parser.CardOneToMany:
 		// The grouped operator never splits fill-left points, so the second return value is always empty.
-		result, _, err = g.evaluator.computeResult(thisSeries.oneSide.mergedData, thisSeries.manySide.mergedData, isLastOutputSeriesForOneSide, isLastOutputSeriesForManySide, computeResultOptions{})
+		result, _, err = g.evaluator.computeResult(oneSideData, thisSeries.manySide.mergedData, isLastOutputSeriesForOneSide, isLastOutputSeriesForManySide, options)
 	case parser.CardManyToOne:
-		result, _, err = g.evaluator.computeResult(thisSeries.manySide.mergedData, thisSeries.oneSide.mergedData, isLastOutputSeriesForManySide, isLastOutputSeriesForOneSide, computeResultOptions{})
+		result, _, err = g.evaluator.computeResult(thisSeries.manySide.mergedData, oneSideData, isLastOutputSeriesForManySide, isLastOutputSeriesForOneSide, options)
 	default:
 		panic(fmt.Sprintf("unsupported cardinality %d", int(g.VectorMatching.Card)))
 	}
 
 	// If this is the last output series for that side, then we've passed ownership of mergedData to the evaluator, so clear it now to avoid returning it to the pool later.
-	if isLastOutputSeriesForOneSide {
+	if isLastOutputSeriesForOneSide && thisSeries.oneSide != nil {
 		thisSeries.oneSide.mergedData = types.InstantVectorSeriesData{}
 	}
 
@@ -719,6 +855,33 @@ func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (ty
 	return result, nil
 }
 
+func (g *GroupedVectorVectorBinaryOperation) computeResultOptions(series *groupedBinaryOperationOutputSeries) computeResultOptions {
+	oneMissing := missingSideOptions{mode: missingSkip}
+	if series.fillCarrier != nil {
+		oneMissing = missingSideOptions{}
+		if series.fillCarrier.matchGroup != nil {
+			oneMissing.groupPresence = series.fillCarrier.matchGroup.presence
+		}
+	}
+
+	if g.VectorMatching.Card == parser.CardOneToMany {
+		return computeResultOptions{missingLeft: oneMissing}
+	}
+	return computeResultOptions{missingRight: oneMissing}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) ensureOneSideGroupPopulated(ctx context.Context, group *matchGroup) error {
+	for _, side := range group.oneSides {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("populate grouped one-side presence: %w", err)
+		}
+		if err := g.ensureOneSidePopulated(ctx, side); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (g *GroupedVectorVectorBinaryOperation) ensureOneSidePopulated(ctx context.Context, side *oneSide) error {
 	if side.seriesIndices == nil {
 		// Already populated.
@@ -726,9 +889,13 @@ func (g *GroupedVectorVectorBinaryOperation) ensureOneSidePopulated(ctx context.
 	}
 
 	// First time we've used this "one" side, populate it.
+	latestSeriesIndex := side.latestSeriesIndex()
 	data, err := g.oneSideBuffer.GetSeries(ctx, side.seriesIndices)
 	if err != nil {
 		return err
+	}
+	if latestSeriesIndex == g.lastOneSideSeriesIndex {
+		g.markOneSideFinishedReading()
 	}
 
 	if err := g.updateOneSidePresence(side, data); err != nil {
@@ -775,25 +942,54 @@ func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(side *oneSide
 		seriesIdx := side.seriesIndices[dataIdx]
 
 		for _, p := range seriesData.Floats {
-			if otherSeriesIdx := matchGroup.updatePresence(g.timeRange.PointIndex(p.T), seriesIdx); otherSeriesIdx != -1 {
-				return formatConflictError(otherSeriesIdx, seriesIdx, "duplicate series", p.T, g.oneSideMetadata, g.oneSideHandedness(), g.VectorMatching, g.Op, g.ReturnBool)
+			if err := g.recordOneSidePresence(matchGroup, seriesIdx, p.T); err != nil {
+				return err
 			}
 		}
 
 		for _, p := range seriesData.Histograms {
-			if otherSeriesIdx := matchGroup.updatePresence(g.timeRange.PointIndex(p.T), seriesIdx); otherSeriesIdx != -1 {
-				return formatConflictError(otherSeriesIdx, seriesIdx, "duplicate series", p.T, g.oneSideMetadata, g.oneSideHandedness(), g.VectorMatching, g.Op, g.ReturnBool)
+			if err := g.recordOneSidePresence(matchGroup, seriesIdx, p.T); err != nil {
+				return err
 			}
 		}
 	}
 
 	matchGroup.oneSideCount--
 
-	if matchGroup.oneSideCount == 0 {
-		types.IntSlicePool.Put(&matchGroup.presence, g.MemoryConsumptionTracker)
+	if matchGroup.oneSideCount == 0 && matchGroup.fillCarrierCount == 0 {
+		matchGroup.releasePresence(g.MemoryConsumptionTracker)
 	}
 
 	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) recordOneSidePresence(group *matchGroup, seriesIndex int, timestamp int64) error {
+	timestampIndex, err := g.presenceTimestampIndex(timestamp, len(group.presence))
+	if err != nil {
+		return fmt.Errorf("record one-side presence at timestamp %d: %w", timestamp, err)
+	}
+	if otherSeriesIndex := group.updatePresence(timestampIndex, seriesIndex); otherSeriesIndex != -1 {
+		return formatConflictError(otherSeriesIndex, seriesIndex, "duplicate series", timestamp, g.oneSideMetadata, g.oneSideHandedness(), g.VectorMatching, g.Op, g.ReturnBool)
+	}
+	return nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) presenceTimestampIndex(timestamp int64, presenceLength int) (int64, error) {
+	if timestamp < g.timeRange.StartT || timestamp > g.timeRange.EndT {
+		return -1, fmt.Errorf("timestamp %d is outside query range [%d, %d]", timestamp, g.timeRange.StartT, g.timeRange.EndT)
+	}
+	if g.timeRange.IntervalMilliseconds <= 0 {
+		return -1, fmt.Errorf("query interval %d is not positive", g.timeRange.IntervalMilliseconds)
+	}
+	delta := timestamp - g.timeRange.StartT
+	if delta%g.timeRange.IntervalMilliseconds != 0 {
+		return -1, fmt.Errorf("timestamp %d is not aligned to query interval %d", timestamp, g.timeRange.IntervalMilliseconds)
+	}
+	index := delta / g.timeRange.IntervalMilliseconds
+	if index < 0 || index >= int64(presenceLength) {
+		return -1, fmt.Errorf("timestamp %d maps to presence index %d outside length %d", timestamp, index, presenceLength)
+	}
+	return index, nil
 }
 
 func (g *GroupedVectorVectorBinaryOperation) mergeOneSide(data []types.InstantVectorSeriesData, sourceSeriesIndices []int) (types.InstantVectorSeriesData, error) {
@@ -818,9 +1014,13 @@ func (g *GroupedVectorVectorBinaryOperation) ensureManySidePopulated(ctx context
 	}
 
 	// First time we've used this "many" side, populate it.
+	latestSeriesIndex := side.latestSeriesIndex()
 	data, err := g.manySideBuffer.GetSeries(ctx, side.seriesIndices)
 	if err != nil {
 		return err
+	}
+	if latestSeriesIndex == g.lastManySideSeriesIndex {
+		g.markManySideFinishedReading()
 	}
 
 	side.mergedData, err = g.mergeManySide(data, side.seriesIndices)
@@ -971,6 +1171,22 @@ func (g *GroupedVectorVectorBinaryOperation) finishManySide(ctx context.Context)
 		return g.finishLeft(ctx)
 	default:
 		return fmt.Errorf("unsupported cardinality %d", int(g.VectorMatching.Card))
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) markOneSideFinishedReading() {
+	if g.VectorMatching.Card == parser.CardOneToMany {
+		g.leftFinishedReading = true
+	} else {
+		g.rightFinishedReading = true
+	}
+}
+
+func (g *GroupedVectorVectorBinaryOperation) markManySideFinishedReading() {
+	if g.VectorMatching.Card == parser.CardOneToMany {
+		g.rightFinishedReading = true
+	} else {
+		g.leftFinishedReading = true
 	}
 }
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -4,13 +4,16 @@ package binops
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
@@ -1271,7 +1274,11 @@ func TestGroupedVectorVectorBinaryOperation_EmptySideMetadataWithFill(t *testing
 				if canProduceAnySeries && (emptyCase.many || emptyCase.one) {
 					metadata, _, oneUsed, _, manyUsed, _, err := o.computeOutputSeries()
 					require.NoError(t, err)
-					require.Empty(t, metadata)
+					expectedMetadataCount := 0
+					if emptyCase.one && !emptyCase.many && fillCase.fillsOne {
+						expectedMetadataCount = 1
+					}
+					require.Len(t, metadata, expectedMetadataCount)
 					types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
 					types.BoolSlicePool.Put(&oneUsed, memoryConsumptionTracker)
 					types.BoolSlicePool.Put(&manyUsed, memoryConsumptionTracker)
@@ -1282,6 +1289,858 @@ func TestGroupedVectorVectorBinaryOperation_EmptySideMetadataWithFill(t *testing
 				require.Equal(t, 1, one.finishedReadingCalls)
 			})
 		}
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_FillsSyntheticOneSide(t *testing.T) {
+	fillThree := 3.0
+	fillTwo := 2.0
+	fillInfinity := math.Inf(1)
+	fillNaN := math.NaN()
+	ts := int64(0)
+	secondTS := time.Minute.Milliseconds()
+	thirdTS := 2 * time.Minute.Milliseconds()
+
+	type expectedSeries struct {
+		labels    labels.Labels
+		floats    []promql.FPoint
+		histogram *histogram.FloatHistogram
+	}
+	testCases := map[string]struct {
+		card       parser.VectorMatchCardinality
+		op         parser.ItemType
+		returnBool bool
+		fill       parser.VectorMatchFillValues
+		include    []string
+		ignoring   []string
+		onLabels   []string
+
+		manySeries []labels.Labels
+		manyData   []types.InstantVectorSeriesData
+		oneSeries  []labels.Labels
+		oneData    []types.InstantVectorSeriesData
+		timeRange  types.QueryTimeRange
+
+		expected                       []expectedSeries
+		expectOneFinishedAfterMetadata bool
+		carrierFirst                   bool
+		expectCarrierCollision         bool
+	}{
+		"many-to-one arithmetic preserves all unmatched many series": {
+			card: parser.CardManyToOne,
+			op:   parser.SUB,
+			fill: parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "1"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "b", "series", "2"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: ts, F: 20}}},
+			},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "series", "1"), floats: []promql.FPoint{{T: ts, F: 7}}},
+				{labels: labels.FromStrings("group", "b", "series", "2"), floats: []promql.FPoint{{T: ts, F: 17}}},
+			},
+		},
+		"one-to-many arithmetic maps the synthetic operand to the left": {
+			card: parser.CardOneToMany,
+			op:   parser.SUB,
+			fill: parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "1"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "b", "series", "2"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: ts, F: 20}}},
+			},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "series", "1"), floats: []promql.FPoint{{T: ts, F: -7}}},
+				{labels: labels.FromStrings("group", "b", "series", "2"), floats: []promql.FPoint{{T: ts, F: -17}}},
+			},
+		},
+		"many-to-one uses real include labels and deletes synthetic values": {
+			card:    parser.CardManyToOne,
+			op:      parser.ADD,
+			fill:    parser.VectorMatchFillValues{RHS: &fillThree},
+			include: []string{"owner"},
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "b", "owner", "stale"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: ts, F: 20}}},
+			},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+			},
+			oneData: []types.InstantVectorSeriesData{{}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "owner", "team-a")},
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 13}}},
+				{labels: labels.FromStrings("group", "b"), floats: []promql.FPoint{{T: ts, F: 23}}},
+			},
+		},
+		"one-to-many uses real include labels and deletes synthetic values": {
+			card:    parser.CardOneToMany,
+			op:      parser.ADD,
+			fill:    parser.VectorMatchFillValues{RHS: &fillThree},
+			include: []string{"owner"},
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "b", "owner", "stale"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: ts, F: 20}}},
+			},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+			},
+			oneData: []types.InstantVectorSeriesData{{}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "owner", "team-a")},
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 13}}},
+				{labels: labels.FromStrings("group", "b"), floats: []promql.FPoint{{T: ts, F: 23}}},
+			},
+		},
+		"many-to-one emits one carrier across intermittent include variants": {
+			card:         parser.CardManyToOne,
+			op:           parser.ADD,
+			fill:         parser.VectorMatchFillValues{RHS: &fillThree},
+			include:      []string{"owner"},
+			timeRange:    types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(thirdTS), time.Minute),
+			carrierFirst: true,
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale"),
+			},
+			manyData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{
+				{T: ts, F: 10},
+				{T: secondTS, F: 20},
+				{T: thirdTS, F: 30},
+			}}},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-b"),
+			},
+			oneData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 1}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 2}}},
+			},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: ts, F: 11}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-b"), floats: []promql.FPoint{{T: secondTS, F: 22}}},
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: thirdTS, F: 33}}},
+			},
+		},
+		"one-to-many merges a carrier collision across intermittent include variants": {
+			card:      parser.CardOneToMany,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{RHS: &fillThree},
+			include:   []string{"owner"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(thirdTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale"),
+			},
+			manyData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{
+				{T: ts, F: 10},
+				{T: secondTS, F: 20},
+				{T: thirdTS, F: 30},
+			}}},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a"),
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+			},
+			oneData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 1}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 2}}},
+			},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 11}, {T: thirdTS, F: 33}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: secondTS, F: 22}}},
+			},
+		},
+		"many-to-one canonicalizes absent and empty include values": {
+			card:                   parser.CardManyToOne,
+			op:                     parser.ADD,
+			fill:                   parser.VectorMatchFillValues{RHS: &fillThree},
+			include:                []string{"owner"},
+			timeRange:              types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(thirdTS), time.Minute),
+			manySeries:             []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			expectCarrierCollision: true,
+			manyData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{
+				{T: ts, F: 10},
+				{T: secondTS, F: 20},
+				{T: thirdTS, F: 30},
+			}}},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a"),
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", ""),
+			},
+			oneData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 1}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 2}}},
+			},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 11}, {T: secondTS, F: 22}, {T: thirdTS, F: 33}}},
+			},
+		},
+		"one-to-many canonicalizes absent and empty include values": {
+			card:                   parser.CardOneToMany,
+			op:                     parser.ADD,
+			fill:                   parser.VectorMatchFillValues{RHS: &fillThree},
+			include:                []string{"owner"},
+			timeRange:              types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(thirdTS), time.Minute),
+			manySeries:             []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			expectCarrierCollision: true,
+			manyData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{
+				{T: ts, F: 10},
+				{T: secondTS, F: 20},
+				{T: thirdTS, F: 30},
+			}}},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a"),
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", ""),
+			},
+			oneData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 1}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 2}}},
+			},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 11}, {T: secondTS, F: 22}, {T: thirdTS, F: 33}}},
+			},
+		},
+		"many-to-one on retains an included matching label on fill": {
+			card:       parser.CardManyToOne,
+			op:         parser.ADD,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			include:    []string{"owner"},
+			onLabels:   []string{"group", "owner"},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "team-a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: ts, F: 13}}}},
+		},
+		"one-to-many on retains an included matching label on fill": {
+			card:       parser.CardOneToMany,
+			op:         parser.ADD,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			include:    []string{"owner"},
+			onLabels:   []string{"group", "owner"},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "team-a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: ts, F: 13}}}},
+		},
+		"many-to-one ignoring retains an included matching label on fill": {
+			card:       parser.CardManyToOne,
+			op:         parser.ADD,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			include:    []string{"zone"},
+			ignoring:   []string{"instance"},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "many", "zone", "us")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a", "instance", "many", "zone", "us"), floats: []promql.FPoint{{T: ts, F: 13}}}},
+		},
+		"one-to-many ignoring retains an included matching label on fill": {
+			card:       parser.CardOneToMany,
+			op:         parser.ADD,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			include:    []string{"zone"},
+			ignoring:   []string{"instance"},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "many", "zone", "us")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a", "instance", "many", "zone", "us"), floats: []promql.FPoint{{T: ts, F: 13}}}},
+		},
+		"many-to-one ignoring removes an ignored include and merges many series": {
+			card:      parser.CardManyToOne,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{RHS: &fillThree},
+			include:   []string{"owner"},
+			ignoring:  []string{"owner"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(secondTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "team-a"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "team-b"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 20}}},
+			},
+			expected: []expectedSeries{{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 13}, {T: secondTS, F: 23}}}},
+		},
+		"one-to-many ignoring removes an ignored include and merges many series": {
+			card:      parser.CardOneToMany,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{RHS: &fillThree},
+			include:   []string{"owner"},
+			ignoring:  []string{"owner"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(secondTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "team-a"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "team-b"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 20}}},
+			},
+			expected: []expectedSeries{{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 13}, {T: secondTS, F: 23}}}},
+		},
+		"many-to-one ignoring merges absent and empty included many labels": {
+			card:      parser.CardManyToOne,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{RHS: &fillThree},
+			include:   []string{"owner"},
+			ignoring:  []string{"instance"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(secondTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "x"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "x", "owner", ""),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 20}}},
+			},
+			expected: []expectedSeries{{labels: labels.FromStrings("group", "a", "instance", "x"), floats: []promql.FPoint{{T: ts, F: 13}, {T: secondTS, F: 23}}}},
+		},
+		"one-to-many ignoring merges absent and empty included many labels": {
+			card:      parser.CardOneToMany,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{RHS: &fillThree},
+			include:   []string{"owner"},
+			ignoring:  []string{"instance"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(secondTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "x"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "x", "owner", ""),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 20}}},
+			},
+			expected: []expectedSeries{{labels: labels.FromStrings("group", "a", "instance", "x"), floats: []promql.FPoint{{T: ts, F: 13}, {T: secondTS, F: 23}}}},
+		},
+		"many-to-one finishes a wholly unused disjoint one side": {
+			card:                           parser.CardManyToOne,
+			op:                             parser.ADD,
+			fill:                           parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries:                     []labels.Labels{labels.FromStrings("group", "many")},
+			manyData:                       []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			oneSeries:                      []labels.Labels{labels.FromStrings("group", "one")},
+			oneData:                        []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 20}}}},
+			expected:                       []expectedSeries{{labels: labels.FromStrings("group", "many"), floats: []promql.FPoint{{T: ts, F: 13}}}},
+			expectOneFinishedAfterMetadata: true,
+		},
+		"one-to-many finishes a wholly unused disjoint one side": {
+			card:                           parser.CardOneToMany,
+			op:                             parser.ADD,
+			fill:                           parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries:                     []labels.Labels{labels.FromStrings("group", "many")},
+			manyData:                       []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			oneSeries:                      []labels.Labels{labels.FromStrings("group", "one")},
+			oneData:                        []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 20}}}},
+			expected:                       []expectedSeries{{labels: labels.FromStrings("group", "many"), floats: []promql.FPoint{{T: ts, F: 13}}}},
+			expectOneFinishedAfterMetadata: true,
+		},
+		"many-to-one comparison retains the many metric name": {
+			card:       parser.CardManyToOne,
+			op:         parser.GTR,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings(model.MetricNameLabel, "many", "group", "a"), floats: []promql.FPoint{{T: ts, F: 10}}},
+			},
+		},
+		"one-to-many comparison retains the many metric name": {
+			card:       parser.CardOneToMany,
+			op:         parser.LSS,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings(model.MetricNameLabel, "many", "group", "a"), floats: []promql.FPoint{{T: ts, F: 3}}},
+			},
+		},
+		"many-to-one bool comparison drops the metric name": {
+			card:       parser.CardManyToOne,
+			op:         parser.GTR,
+			returnBool: true,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 1}}},
+			},
+		},
+		"one-to-many bool comparison drops the metric name": {
+			card:       parser.CardOneToMany,
+			op:         parser.LSS,
+			returnBool: true,
+			fill:       parser.VectorMatchFillValues{RHS: &fillThree},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 1}}},
+			},
+		},
+		"many-to-one multiplies a histogram by the synthetic scalar": {
+			card:       parser.CardManyToOne,
+			op:         parser.MUL,
+			fill:       parser.VectorMatchFillValues{RHS: &fillTwo},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			manyData: []types.InstantVectorSeriesData{{Histograms: []promql.HPoint{
+				{T: ts, H: &histogram.FloatHistogram{Count: 3, Sum: 6}},
+			}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a"), histogram: &histogram.FloatHistogram{Count: 6, Sum: 12}},
+			},
+		},
+		"one-to-many multiplies the synthetic scalar by a histogram": {
+			card:       parser.CardOneToMany,
+			op:         parser.MUL,
+			fill:       parser.VectorMatchFillValues{RHS: &fillTwo},
+			manySeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "many", "group", "a")},
+			manyData: []types.InstantVectorSeriesData{{Histograms: []promql.HPoint{
+				{T: ts, H: &histogram.FloatHistogram{Count: 3, Sum: 6}},
+			}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a"), histogram: &histogram.FloatHistogram{Count: 6, Sum: 12}},
+			},
+		},
+		"many-to-one applies an infinite fill value": {
+			card:       parser.CardManyToOne,
+			op:         parser.SUB,
+			fill:       parser.VectorMatchFillValues{RHS: &fillInfinity},
+			manySeries: []labels.Labels{labels.FromStrings("group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: math.Inf(-1)}}}},
+		},
+		"one-to-many applies an infinite fill value": {
+			card:       parser.CardOneToMany,
+			op:         parser.SUB,
+			fill:       parser.VectorMatchFillValues{RHS: &fillInfinity},
+			manySeries: []labels.Labels{labels.FromStrings("group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: math.Inf(1)}}}},
+		},
+		"many-to-one bool comparison accepts a NaN fill value": {
+			card:       parser.CardManyToOne,
+			op:         parser.GTR,
+			returnBool: true,
+			fill:       parser.VectorMatchFillValues{RHS: &fillNaN},
+			manySeries: []labels.Labels{labels.FromStrings("group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 0}}}},
+		},
+		"one-to-many bool comparison accepts a NaN fill value": {
+			card:       parser.CardOneToMany,
+			op:         parser.GTR,
+			returnBool: true,
+			fill:       parser.VectorMatchFillValues{RHS: &fillNaN},
+			manySeries: []labels.Labels{labels.FromStrings("group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			expected:   []expectedSeries{{labels: labels.FromStrings("group", "a"), floats: []promql.FPoint{{T: ts, F: 0}}}},
+		},
+		"many-to-one does not synthesize without a normalized one fill": {
+			card:       parser.CardManyToOne,
+			op:         parser.ADD,
+			fill:       parser.VectorMatchFillValues{LHS: &fillThree},
+			manySeries: []labels.Labels{labels.FromStrings("group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+		},
+		"one-to-many does not synthesize without a normalized one fill": {
+			card:       parser.CardOneToMany,
+			op:         parser.ADD,
+			fill:       parser.VectorMatchFillValues{LHS: &fillThree},
+			manySeries: []labels.Labels{labels.FromStrings("group", "a")},
+			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			copyData := func(source []types.InstantVectorSeriesData) []types.InstantVectorSeriesData {
+				result := make([]types.InstantVectorSeriesData, len(source))
+				for i, data := range source {
+					if len(data.Floats) > 0 {
+						points, err := types.FPointSlicePool.Get(len(data.Floats), memoryConsumptionTracker)
+						require.NoError(t, err)
+						result[i].Floats = append(points, data.Floats...)
+					}
+					if len(data.Histograms) > 0 {
+						points, err := types.HPointSlicePool.Get(len(data.Histograms), memoryConsumptionTracker)
+						require.NoError(t, err)
+						for _, point := range data.Histograms {
+							points = append(points, promql.HPoint{T: point.T, H: point.H.Copy()})
+						}
+						result[i].Histograms = points
+					}
+				}
+				return result
+			}
+
+			many := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series:                   testCase.manySeries,
+				Data:                     copyData(testCase.manyData),
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			one := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series:                   testCase.oneSeries,
+				Data:                     copyData(testCase.oneData),
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			left, right := many, one
+			if testCase.card == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			timeRange := testCase.timeRange
+			if timeRange.StepCount == 0 {
+				timeRange = types.NewInstantQueryTimeRange(timestamp.Time(ts))
+			}
+			vectorMatching := parser.VectorMatching{
+				Card:           testCase.card,
+				On:             true,
+				MatchingLabels: []string{"group"},
+				Include:        testCase.include,
+				FillValues:     testCase.fill,
+			}
+			if testCase.ignoring != nil {
+				vectorMatching.On = false
+				vectorMatching.MatchingLabels = testCase.ignoring
+			} else if testCase.onLabels != nil {
+				vectorMatching.MatchingLabels = testCase.onLabels
+			}
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				vectorMatching,
+				testCase.op,
+				testCase.returnBool,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				timeRange,
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			if testCase.expectOneFinishedAfterMetadata {
+				require.Equal(t, 1, one.finishedReadingCalls)
+			}
+			var expectedMetadata []types.SeriesMetadata
+			if len(testCase.expected) > 0 {
+				expectedMetadata = make([]types.SeriesMetadata, 0, len(testCase.expected))
+			}
+			for _, expected := range testCase.expected {
+				expectedMetadata = append(expectedMetadata, types.SeriesMetadata{Labels: expected.labels})
+			}
+			require.Equal(t, expectedMetadata, metadata)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			if testCase.expectCarrierCollision {
+				require.Len(t, operation.remainingSeries, 1)
+				require.NotNil(t, operation.remainingSeries[0].oneSide)
+				require.NotNil(t, operation.remainingSeries[0].fillCarrier)
+				require.Len(t, operation.remainingSeries[0].oneSide.seriesIndices, 2)
+			}
+			if testCase.carrierFirst {
+				carrierIndex := slices.IndexFunc(operation.remainingSeries, func(series *groupedBinaryOperationOutputSeries) bool {
+					return series.oneSide == nil && series.fillCarrier != nil
+				})
+				require.GreaterOrEqual(t, carrierIndex, 0)
+				carrier := operation.remainingSeries[carrierIndex]
+				copy(operation.remainingSeries[1:carrierIndex+1], operation.remainingSeries[:carrierIndex])
+				operation.remainingSeries[0] = carrier
+				expectedCarrier := testCase.expected[len(testCase.expected)-1]
+				copy(testCase.expected[1:], testCase.expected[:len(testCase.expected)-1])
+				testCase.expected[0] = expectedCarrier
+			}
+
+			for _, expected := range testCase.expected {
+				actual, err := operation.NextSeries(t.Context())
+				require.NoError(t, err)
+				require.Equal(t, expected.floats, actual.Floats)
+				if expected.histogram == nil {
+					require.Empty(t, actual.Histograms)
+				} else {
+					require.Len(t, actual.Histograms, 1)
+					require.Equal(t, ts, actual.Histograms[0].T)
+					require.Equal(t, expected.histogram, actual.Histograms[0].H)
+				}
+				types.PutInstantVectorSeriesData(actual, memoryConsumptionTracker)
+			}
+
+			_, err = operation.NextSeries(t.Context())
+			require.ErrorIs(t, err, types.EOS)
+			left.ReleaseUnreadData(memoryConsumptionTracker)
+			right.ReleaseUnreadData(memoryConsumptionTracker)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Equal(t, 1, left.finishedReadingCalls)
+			require.Equal(t, 1, right.finishedReadingCalls)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_FillCarrierPresenceLifecycle(t *testing.T) {
+	fill := 3.0
+	firstTS := int64(0)
+	secondTS := time.Minute.Milliseconds()
+	testCases := map[string]struct {
+		card          parser.VectorMatchCardinality
+		duplicateTime bool
+	}{
+		"many-to-one early stop": {
+			card: parser.CardManyToOne,
+		},
+		"one-to-many early stop": {
+			card: parser.CardOneToMany,
+		},
+		"many-to-one evaluation error": {
+			card:          parser.CardManyToOne,
+			duplicateTime: true,
+		},
+		"one-to-many evaluation error": {
+			card:          parser.CardOneToMany,
+			duplicateTime: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			newData := func(points ...promql.FPoint) types.InstantVectorSeriesData {
+				pooled, err := types.FPointSlicePool.Get(len(points), memoryConsumptionTracker)
+				require.NoError(t, err)
+				return types.InstantVectorSeriesData{Floats: append(pooled, points...)}
+			}
+
+			secondOneSideTime := secondTS
+			if testCase.duplicateTime {
+				secondOneSideTime = firstTS
+			}
+			many := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series: []labels.Labels{
+					labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "1"),
+					labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "2"),
+				},
+				Data: []types.InstantVectorSeriesData{
+					newData(promql.FPoint{T: firstTS, F: 10}, promql.FPoint{T: secondTS, F: 20}),
+					newData(promql.FPoint{T: firstTS, F: 30}, promql.FPoint{T: secondTS, F: 40}),
+				},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			one := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series: []labels.Labels{
+					labels.FromStrings(model.MetricNameLabel, "one", "group", "a"),
+					labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+				},
+				Data: []types.InstantVectorSeriesData{
+					newData(promql.FPoint{T: firstTS, F: 1}),
+					newData(promql.FPoint{T: secondOneSideTime, F: 2}),
+				},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			left, right := many, one
+			if testCase.card == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           testCase.card,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					Include:        []string{"owner"},
+					FillValues:     parser.VectorMatchFillValues{RHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewRangeQueryTimeRange(timestamp.Time(firstTS), timestamp.Time(secondTS), time.Minute),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			result, err := operation.NextSeries(t.Context())
+			if testCase.duplicateTime {
+				require.ErrorContains(t, err, "duplicate series")
+			} else {
+				require.NoError(t, err)
+				types.PutInstantVectorSeriesData(result, memoryConsumptionTracker)
+			}
+
+			left.ReleaseUnreadData(memoryConsumptionTracker)
+			right.ReleaseUnreadData(memoryConsumptionTracker)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			if !testCase.duplicateTime {
+				require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			}
+			require.Equal(t, 1, left.finishedReadingCalls)
+			require.Equal(t, 1, right.finishedReadingCalls)
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_RejectsInvalidPresenceTimestamps(t *testing.T) {
+	fill := 3.0
+	startTS := int64(0)
+	endTS := time.Minute.Milliseconds()
+	testCases := map[string]struct {
+		card          parser.VectorMatchCardinality
+		invalidTime   int64
+		expectedError string
+	}{
+		"many-to-one out of range": {
+			card:          parser.CardManyToOne,
+			invalidTime:   2 * time.Minute.Milliseconds(),
+			expectedError: "record one-side presence at timestamp 120000: timestamp 120000 is outside query range [0, 60000]",
+		},
+		"one-to-many out of range": {
+			card:          parser.CardOneToMany,
+			invalidTime:   2 * time.Minute.Milliseconds(),
+			expectedError: "record one-side presence at timestamp 120000: timestamp 120000 is outside query range [0, 60000]",
+		},
+		"many-to-one misaligned": {
+			card:          parser.CardManyToOne,
+			invalidTime:   30 * time.Second.Milliseconds(),
+			expectedError: "record one-side presence at timestamp 30000: timestamp 30000 is not aligned to query interval 60000",
+		},
+		"one-to-many misaligned": {
+			card:          parser.CardOneToMany,
+			invalidTime:   30 * time.Second.Milliseconds(),
+			expectedError: "record one-side presence at timestamp 30000: timestamp 30000 is not aligned to query interval 60000",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			newData := func(point promql.FPoint) types.InstantVectorSeriesData {
+				points, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+				require.NoError(t, err)
+				return types.InstantVectorSeriesData{Floats: append(points, point)}
+			}
+			many := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{newData(promql.FPoint{T: startTS, F: 10})},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			one := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{newData(promql.FPoint{T: testCase.invalidTime, F: 20})},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if testCase.card == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           testCase.card,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{RHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewRangeQueryTimeRange(timestamp.Time(startTS), timestamp.Time(endTS), time.Minute),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			_, err = operation.NextSeries(t.Context())
+			require.EqualError(t, err, testCase.expectedError)
+			require.Error(t, errors.Unwrap(err))
+			many.ReleaseUnreadData(memoryConsumptionTracker)
+			one.ReleaseUnreadData(memoryConsumptionTracker)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_CanonicalManySideIncludeValuesRejectOverlappingPoints(t *testing.T) {
+	fill := 3.0
+	testCases := map[string]parser.VectorMatchCardinality{
+		"many-to-one": parser.CardManyToOne,
+		"one-to-many": parser.CardOneToMany,
+	}
+
+	for name, cardinality := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			newData := func(value float64) types.InstantVectorSeriesData {
+				points, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+				require.NoError(t, err)
+				return types.InstantVectorSeriesData{Floats: append(points, promql.FPoint{T: 0, F: value})}
+			}
+			many := &operators.TestOperator{
+				Series: []labels.Labels{
+					labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "x"),
+					labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "instance", "x", "owner", ""),
+				},
+				Data:                     []types.InstantVectorSeriesData{newData(10), newData(20)},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			one := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if cardinality == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           cardinality,
+					MatchingLabels: []string{"instance"},
+					Include:        []string{"owner"},
+					FillValues:     parser.VectorMatchFillValues{RHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewInstantQueryTimeRange(timestamp.Time(0)),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			require.Len(t, metadata, 1)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			_, err = operation.NextSeries(t.Context())
+			require.ErrorIs(t, err, errMultipleMatchesOnManySide)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			operation.Close()
+		})
 	}
 }
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -1277,6 +1277,8 @@ func TestGroupedVectorVectorBinaryOperation_EmptySideMetadataWithFill(t *testing
 					expectedMetadataCount := 0
 					if emptyCase.one && !emptyCase.many && fillCase.fillsOne {
 						expectedMetadataCount = 1
+					} else if emptyCase.many && !emptyCase.one && fillCase.fillsMany {
+						expectedMetadataCount = 1
 					}
 					require.Len(t, metadata, expectedMetadataCount)
 					types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
@@ -1881,6 +1883,234 @@ func TestGroupedVectorVectorBinaryOperation_FillsSyntheticOneSide(t *testing.T) 
 			require.NoError(t, operation.FinishedReading(t.Context()))
 			require.Equal(t, 1, left.finishedReadingCalls)
 			require.Equal(t, 1, right.finishedReadingCalls)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_BuildsSyntheticManySideCarriers(t *testing.T) {
+	fill := 3.0
+	type expectedOutput struct {
+		labels         labels.Labels
+		hasRealMany    bool
+		carrierSources [][]int
+	}
+	testCases := map[string]struct {
+		card         parser.VectorMatchCardinality
+		on           bool
+		matching     []string
+		include      []string
+		op           parser.ItemType
+		returnBool   bool
+		manySeries   []labels.Labels
+		oneSeries    []labels.Labels
+		expected     []expectedOutput
+		expectedRefs map[int]int
+		manyFinished bool
+	}{
+		"many-to-one on creates matched and unmatched variants": {
+			card:     parser.CardManyToOne,
+			on:       true,
+			matching: []string{"group"},
+			include:  []string{"owner"},
+			op:       parser.ADD,
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "1"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "2"),
+			},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one-a", "group", "a", "owner", "team-a"),
+				labels.FromStrings(model.MetricNameLabel, "one-b", "group", "a", "owner", "team-b"),
+				labels.FromStrings(model.MetricNameLabel, "one-c", "group", "b", "owner", "team-c"),
+			},
+			expected: []expectedOutput{
+				{labels: labels.FromStrings("group", "b", "owner", "team-c"), carrierSources: [][]int{{2}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a", "series", "1"), hasRealMany: true},
+				{labels: labels.FromStrings("group", "a", "owner", "team-b", "series", "1"), hasRealMany: true},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a", "series", "2"), hasRealMany: true},
+				{labels: labels.FromStrings("group", "a", "owner", "team-b", "series", "2"), hasRealMany: true},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), carrierSources: [][]int{{0}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-b"), carrierSources: [][]int{{1}}},
+			},
+			expectedRefs: map[int]int{0: 3, 1: 3, 2: 1},
+		},
+		"one-to-many on removes the synthetic metric name for retaining operators": {
+			card:     parser.CardOneToMany,
+			on:       true,
+			matching: []string{"group"},
+			include:  []string{"owner"},
+			op:       parser.LSS,
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "1"),
+			},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "b", "owner", "team-b"),
+			},
+			expected: []expectedOutput{
+				{labels: labels.FromStrings("group", "b", "owner", "team-b"), carrierSources: [][]int{{1}}},
+				{labels: labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "team-a", "series", "1"), hasRealMany: true},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), carrierSources: [][]int{{0}}},
+			},
+			expectedRefs: map[int]int{0: 2, 1: 1},
+		},
+		"many-to-one ignoring builds labels from the one-side match": {
+			card:     parser.CardManyToOne,
+			matching: []string{"instance"},
+			include:  []string{"owner"},
+			op:       parser.ADD,
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "instance", "many", "owner", "team-b", "zone", "eu"),
+			},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "instance", "one", "owner", "team-a", "zone", "us"),
+			},
+			expected: []expectedOutput{
+				{labels: labels.FromStrings("owner", "team-a", "zone", "us"), carrierSources: [][]int{{0}}},
+			},
+			expectedRefs: map[int]int{0: 1},
+			manyFinished: true,
+		},
+		"one-to-many ignoring builds labels from the one-side match": {
+			card:     parser.CardOneToMany,
+			matching: []string{"instance"},
+			include:  []string{"owner"},
+			op:       parser.ADD,
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "instance", "many", "owner", "team-b", "zone", "eu"),
+			},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "instance", "one", "owner", "team-a", "zone", "us"),
+			},
+			expected: []expectedOutput{
+				{labels: labels.FromStrings("owner", "team-a", "zone", "us"), carrierSources: [][]int{{0}}},
+			},
+			expectedRefs: map[int]int{0: 1},
+			manyFinished: true,
+		},
+		"one-to-many merges a real output collision and sorts it last": {
+			card:     parser.CardOneToMany,
+			on:       true,
+			matching: []string{"group"},
+			include:  []string{"owner"},
+			op:       parser.ADD,
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale", "series", "2"),
+			},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+			},
+			expected: []expectedOutput{
+				{labels: labels.FromStrings("group", "a", "owner", "team-a", "series", "2"), hasRealMany: true},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), hasRealMany: true, carrierSources: [][]int{{0}}},
+			},
+			expectedRefs: map[int]int{0: 2},
+		},
+		"many-to-one merges absent and empty carrier variants": {
+			card:     parser.CardManyToOne,
+			on:       true,
+			matching: []string{"group"},
+			include:  []string{"owner"},
+			op:       parser.ADD,
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one-a", "group", "a"),
+				labels.FromStrings(model.MetricNameLabel, "one-b", "group", "a", "owner", ""),
+			},
+			expected: []expectedOutput{
+				{labels: labels.FromStrings("group", "a"), carrierSources: [][]int{{0, 1}}},
+			},
+			expectedRefs: map[int]int{0: 1},
+			manyFinished: true,
+		},
+		"one-to-many merges carriers whose metric names are removed": {
+			card:     parser.CardOneToMany,
+			on:       true,
+			matching: []string{model.MetricNameLabel},
+			op:       parser.ADD,
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one-a"),
+				labels.FromStrings(model.MetricNameLabel, "one-b"),
+			},
+			expected: []expectedOutput{
+				{labels: labels.EmptyLabels(), carrierSources: [][]int{{0}, {1}}},
+			},
+			expectedRefs: map[int]int{0: 1, 1: 1},
+			manyFinished: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			many := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series:                   testCase.manySeries,
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			one := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series:                   testCase.oneSeries,
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if testCase.card == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           testCase.card,
+					On:             testCase.on,
+					MatchingLabels: testCase.matching,
+					Include:        testCase.include,
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				testCase.op,
+				testCase.returnBool,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewInstantQueryTimeRange(timestamp.Time(0)),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			require.Len(t, metadata, len(testCase.expected))
+			for idx, expected := range testCase.expected {
+				require.Equal(t, expected.labels, metadata[idx].Labels)
+				output := operation.remainingSeries[idx]
+				require.Equal(t, expected.hasRealMany, output.manySide != nil)
+				require.Len(t, output.manySideFillCarriers, len(expected.carrierSources))
+				for carrierIdx, sourceIndices := range expected.carrierSources {
+					require.Equal(t, sourceIndices, output.manySideFillCarriers[carrierIdx].oneSide.seriesIndices)
+				}
+			}
+
+			actualRefs := map[int]int{}
+			for _, output := range operation.remainingSeries {
+				if output.oneSide != nil {
+					actualRefs[output.oneSide.seriesIndices[0]] = output.oneSide.outputSeriesCount
+				}
+				for _, carrier := range output.manySideFillCarriers {
+					actualRefs[carrier.oneSide.seriesIndices[0]] = carrier.oneSide.outputSeriesCount
+				}
+			}
+			require.Equal(t, testCase.expectedRefs, actualRefs)
+			if testCase.manyFinished {
+				require.Equal(t, 1, many.finishedReadingCalls)
+			} else {
+				require.Zero(t, many.finishedReadingCalls)
+			}
+			require.Zero(t, one.finishedReadingCalls)
+
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Equal(t, 1, many.finishedReadingCalls)
+			require.Equal(t, 1, one.finishedReadingCalls)
 			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 			operation.Close()
 		})

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -35,6 +37,34 @@ type finishedReadingCountingOperator struct {
 func (o *finishedReadingCountingOperator) FinishedReading(ctx context.Context) error {
 	o.finishedReadingCalls++
 	return o.TestOperator.FinishedReading(ctx)
+}
+
+type failingNextSeriesOperator struct {
+	*finishedReadingCountingOperator
+	failAt int
+	calls  int
+	err    error
+}
+
+type cancelAfterErrChecksContext struct {
+	context.Context
+	remainingChecks int
+}
+
+func (c *cancelAfterErrChecksContext) Err() error {
+	c.remainingChecks--
+	if c.remainingChecks <= 0 {
+		return context.Canceled
+	}
+	return nil
+}
+
+func (o *failingNextSeriesOperator) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	o.calls++
+	if o.calls == o.failAt {
+		return types.InstantVectorSeriesData{}, o.err
+	}
+	return o.finishedReadingCountingOperator.NextSeries(ctx)
 }
 
 func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
@@ -1758,6 +1788,153 @@ func TestGroupedVectorVectorBinaryOperation_FillsSyntheticOneSide(t *testing.T) 
 			manySeries: []labels.Labels{labels.FromStrings("group", "a")},
 			manyData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
 		},
+		"many-to-one fills only after all real many series disappear": {
+			card:      parser.CardManyToOne,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{LHS: &fillThree},
+			include:   []string{"owner"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(thirdTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "1"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "2"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 20}}},
+			},
+			oneSeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a")},
+			oneData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{
+				{T: ts, F: 1},
+				{T: secondTS, F: 2},
+				{T: thirdTS, F: 4},
+			}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "owner", "team-a", "series", "1"), floats: []promql.FPoint{{T: ts, F: 11}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a", "series", "2"), floats: []promql.FPoint{{T: secondTS, F: 22}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: thirdTS, F: 7}}},
+			},
+		},
+		"one-to-many fills only after all real many series disappear": {
+			card:      parser.CardOneToMany,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{LHS: &fillThree},
+			include:   []string{"owner"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(thirdTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "1"),
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "series", "2"),
+			},
+			manyData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 10}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 20}}},
+			},
+			oneSeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a")},
+			oneData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{
+				{T: ts, F: 1},
+				{T: secondTS, F: 2},
+				{T: thirdTS, F: 4},
+			}}},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "owner", "team-a", "series", "1"), floats: []promql.FPoint{{T: ts, F: 11}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a", "series", "2"), floats: []promql.FPoint{{T: secondTS, F: 22}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: thirdTS, F: 7}}},
+			},
+		},
+		"one-to-many merges a real output with its many carrier": {
+			card:      parser.CardOneToMany,
+			op:        parser.SUB,
+			fill:      parser.VectorMatchFillValues{LHS: &fillThree},
+			include:   []string{"owner"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(secondTS), time.Minute),
+			manySeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale"),
+			},
+			manyData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 10}}}},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+			},
+			oneData: []types.InstantVectorSeriesData{{Floats: []promql.FPoint{
+				{T: ts, F: 20},
+				{T: secondTS, F: 30},
+			}}},
+			expected: []expectedSeries{{
+				labels: labels.FromStrings("group", "a", "owner", "team-a"),
+				floats: []promql.FPoint{{T: ts, F: 10}, {T: secondTS, F: 27}},
+			}},
+		},
+		"many-to-one merges collided carriers with disjoint points": {
+			card:      parser.CardManyToOne,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{LHS: &fillThree},
+			onLabels:  []string{model.MetricNameLabel},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(secondTS), time.Minute),
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one-a"),
+				labels.FromStrings(model.MetricNameLabel, "one-b"),
+			},
+			oneData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 1}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 2}}},
+			},
+			expected: []expectedSeries{{
+				labels: labels.EmptyLabels(),
+				floats: []promql.FPoint{{T: ts, F: 4}, {T: secondTS, F: 5}},
+			}},
+		},
+		"many-to-one evaluates multiple one-side carrier variants": {
+			card:    parser.CardManyToOne,
+			op:      parser.ADD,
+			fill:    parser.VectorMatchFillValues{LHS: &fillThree},
+			include: []string{"owner"},
+			oneSeries: []labels.Labels{
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-b"),
+			},
+			oneData: []types.InstantVectorSeriesData{
+				{Floats: []promql.FPoint{{T: ts, F: 1}}},
+				{Floats: []promql.FPoint{{T: ts, F: 2}}},
+			},
+			expected: []expectedSeries{
+				{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: ts, F: 4}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-b"), floats: []promql.FPoint{{T: ts, F: 5}}},
+			},
+		},
+		"one-to-many multiplies a one-side histogram by the many fill": {
+			card:      parser.CardOneToMany,
+			op:        parser.MUL,
+			fill:      parser.VectorMatchFillValues{LHS: &fillTwo},
+			oneSeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "one", "group", "a")},
+			oneData: []types.InstantVectorSeriesData{{Histograms: []promql.HPoint{
+				{T: ts, H: &histogram.FloatHistogram{Count: 3, Sum: 6}},
+			}}},
+			expected: []expectedSeries{{
+				labels:    labels.FromStrings("group", "a"),
+				histogram: &histogram.FloatHistogram{Count: 6, Sum: 12},
+			}},
+		},
+		"many-to-one filters a synthetic many comparison": {
+			card:      parser.CardManyToOne,
+			op:        parser.GTR,
+			fill:      parser.VectorMatchFillValues{LHS: &fillThree},
+			oneSeries: []labels.Labels{labels.FromStrings(model.MetricNameLabel, "one", "group", "a")},
+			oneData:   []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 2}}}},
+			expected: []expectedSeries{{
+				labels: labels.FromStrings("group", "a"),
+				floats: []promql.FPoint{{T: ts, F: 3}},
+			}},
+		},
+		"one-to-many returns bool for a synthetic many comparison": {
+			card:       parser.CardOneToMany,
+			op:         parser.LSS,
+			returnBool: true,
+			fill:       parser.VectorMatchFillValues{LHS: &fillThree},
+			oneSeries:  []labels.Labels{labels.FromStrings(model.MetricNameLabel, "one", "group", "a")},
+			oneData:    []types.InstantVectorSeriesData{{Floats: []promql.FPoint{{T: ts, F: 2}}}},
+			expected: []expectedSeries{{
+				labels: labels.FromStrings("group", "a"),
+				floats: []promql.FPoint{{T: ts, F: 1}},
+			}},
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -1875,6 +2052,7 @@ func TestGroupedVectorVectorBinaryOperation_FillsSyntheticOneSide(t *testing.T) 
 				}
 				types.PutInstantVectorSeriesData(actual, memoryConsumptionTracker)
 			}
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
 
 			_, err = operation.NextSeries(t.Context())
 			require.ErrorIs(t, err, types.EOS)
@@ -2111,6 +2289,9 @@ func TestGroupedVectorVectorBinaryOperation_BuildsSyntheticManySideCarriers(t *t
 			require.NoError(t, operation.FinishedReading(t.Context()))
 			require.Equal(t, 1, many.finishedReadingCalls)
 			require.Equal(t, 1, one.finishedReadingCalls)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Equal(t, 1, many.finishedReadingCalls)
+			require.Equal(t, 1, one.finishedReadingCalls)
 			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 			operation.Close()
 		})
@@ -2124,6 +2305,7 @@ func TestGroupedVectorVectorBinaryOperation_FillCarrierPresenceLifecycle(t *test
 	testCases := map[string]struct {
 		card          parser.VectorMatchCardinality
 		duplicateTime bool
+		fillMany      bool
 	}{
 		"many-to-one early stop": {
 			card: parser.CardManyToOne,
@@ -2138,6 +2320,14 @@ func TestGroupedVectorVectorBinaryOperation_FillCarrierPresenceLifecycle(t *test
 		"one-to-many evaluation error": {
 			card:          parser.CardOneToMany,
 			duplicateTime: true,
+		},
+		"many-to-one many carrier early stop": {
+			card:     parser.CardManyToOne,
+			fillMany: true,
+		},
+		"one-to-many many carrier early stop": {
+			card:     parser.CardOneToMany,
+			fillMany: true,
 		},
 	}
 
@@ -2181,6 +2371,10 @@ func TestGroupedVectorVectorBinaryOperation_FillCarrierPresenceLifecycle(t *test
 				left, right = one, many
 			}
 
+			fillValues := parser.VectorMatchFillValues{RHS: &fill}
+			if testCase.fillMany {
+				fillValues = parser.VectorMatchFillValues{LHS: &fill}
+			}
 			operation, err := NewGroupedVectorVectorBinaryOperation(
 				left,
 				right,
@@ -2189,7 +2383,7 @@ func TestGroupedVectorVectorBinaryOperation_FillCarrierPresenceLifecycle(t *test
 					On:             true,
 					MatchingLabels: []string{"group"},
 					Include:        []string{"owner"},
-					FillValues:     parser.VectorMatchFillValues{RHS: &fill},
+					FillValues:     fillValues,
 				},
 				parser.ADD,
 				false,
@@ -2216,11 +2410,129 @@ func TestGroupedVectorVectorBinaryOperation_FillCarrierPresenceLifecycle(t *test
 			right.ReleaseUnreadData(memoryConsumptionTracker)
 			require.NoError(t, operation.FinishedReading(t.Context()))
 			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
-			if !testCase.duplicateTime {
-				require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
-			}
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 			require.Equal(t, 1, left.finishedReadingCalls)
 			require.Equal(t, 1, right.finishedReadingCalls)
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_OneSidePresenceChecksCancellation(t *testing.T) {
+	fill := 3.0
+	const pointCount = 4096
+	testCases := map[string]struct {
+		card            parser.VectorMatchCardinality
+		histograms      bool
+		includeSamples  bool
+		remainingChecks int
+		expectedError   string
+	}{
+		"many-to-one initialization": {
+			card:            parser.CardManyToOne,
+			remainingChecks: 3,
+			expectedError:   "initialize one-side presence: context canceled",
+		},
+		"one-to-many initialization": {
+			card:            parser.CardOneToMany,
+			remainingChecks: 3,
+			expectedError:   "initialize one-side presence: context canceled",
+		},
+		"many-to-one float scan": {
+			card:            parser.CardManyToOne,
+			includeSamples:  true,
+			remainingChecks: 7,
+			expectedError:   "update one-side float presence: context canceled",
+		},
+		"one-to-many float scan": {
+			card:            parser.CardOneToMany,
+			includeSamples:  true,
+			remainingChecks: 7,
+			expectedError:   "update one-side float presence: context canceled",
+		},
+		"many-to-one histogram scan": {
+			card:            parser.CardManyToOne,
+			histograms:      true,
+			includeSamples:  true,
+			remainingChecks: 7,
+			expectedError:   "update one-side histogram presence: context canceled",
+		},
+		"one-to-many histogram scan": {
+			card:            parser.CardOneToMany,
+			histograms:      true,
+			includeSamples:  true,
+			remainingChecks: 7,
+			expectedError:   "update one-side histogram presence: context canceled",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			oneData := types.InstantVectorSeriesData{}
+			if testCase.includeSamples && testCase.histograms {
+				points, err := types.HPointSlicePool.Get(pointCount, memoryConsumptionTracker)
+				require.NoError(t, err)
+				for pointIndex := range pointCount {
+					points = append(points, promql.HPoint{
+						T: int64(pointIndex) * time.Second.Milliseconds(),
+						H: &histogram.FloatHistogram{Count: 1, Sum: float64(pointIndex)},
+					})
+				}
+				oneData.Histograms = points
+			} else if testCase.includeSamples {
+				points, err := types.FPointSlicePool.Get(pointCount, memoryConsumptionTracker)
+				require.NoError(t, err)
+				for pointIndex := range pointCount {
+					points = append(points, promql.FPoint{T: int64(pointIndex) * time.Second.Milliseconds(), F: float64(pointIndex)})
+				}
+				oneData.Floats = points
+			}
+			many := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a", "series", "1")},
+				Data:                     []types.InstantVectorSeriesData{{}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			one := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{oneData},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if testCase.card == parser.CardOneToMany {
+				left, right = one, many
+			}
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           testCase.card,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{RHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time((pointCount-1)*time.Second.Milliseconds()), time.Second),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			ctx := &cancelAfterErrChecksContext{Context: t.Context(), remainingChecks: testCase.remainingChecks}
+			_, err = operation.NextSeries(ctx)
+			require.EqualError(t, err, testCase.expectedError)
+			require.ErrorIs(t, err, context.Canceled)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.FPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.HPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 			operation.Close()
 		})
 	}
@@ -2233,6 +2545,7 @@ func TestGroupedVectorVectorBinaryOperation_RejectsInvalidPresenceTimestamps(t *
 	testCases := map[string]struct {
 		card          parser.VectorMatchCardinality
 		invalidTime   int64
+		histogram     bool
 		expectedError string
 	}{
 		"many-to-one out of range": {
@@ -2255,24 +2568,44 @@ func TestGroupedVectorVectorBinaryOperation_RejectsInvalidPresenceTimestamps(t *
 			invalidTime:   30 * time.Second.Milliseconds(),
 			expectedError: "record one-side presence at timestamp 30000: timestamp 30000 is not aligned to query interval 60000",
 		},
+		"many-to-one misaligned histogram": {
+			card:          parser.CardManyToOne,
+			invalidTime:   30 * time.Second.Milliseconds(),
+			histogram:     true,
+			expectedError: "record one-side presence at timestamp 30000: timestamp 30000 is not aligned to query interval 60000",
+		},
+		"one-to-many misaligned histogram": {
+			card:          parser.CardOneToMany,
+			invalidTime:   30 * time.Second.Milliseconds(),
+			histogram:     true,
+			expectedError: "record one-side presence at timestamp 30000: timestamp 30000 is not aligned to query interval 60000",
+		},
 	}
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
-			newData := func(point promql.FPoint) types.InstantVectorSeriesData {
+			newData := func() types.InstantVectorSeriesData {
+				if testCase.histogram {
+					points, err := types.HPointSlicePool.Get(1, memoryConsumptionTracker)
+					require.NoError(t, err)
+					return types.InstantVectorSeriesData{Histograms: append(points, promql.HPoint{
+						T: testCase.invalidTime,
+						H: &histogram.FloatHistogram{Count: 1, Sum: 1},
+					})}
+				}
 				points, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
 				require.NoError(t, err)
-				return types.InstantVectorSeriesData{Floats: append(points, point)}
+				return types.InstantVectorSeriesData{Floats: append(points, promql.FPoint{T: testCase.invalidTime, F: 20})}
 			}
 			many := &operators.TestOperator{
 				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
-				Data:                     []types.InstantVectorSeriesData{newData(promql.FPoint{T: startTS, F: 10})},
+				Data:                     []types.InstantVectorSeriesData{{}},
 				MemoryConsumptionTracker: memoryConsumptionTracker,
 			}
 			one := &operators.TestOperator{
 				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
-				Data:                     []types.InstantVectorSeriesData{newData(promql.FPoint{T: testCase.invalidTime, F: 20})},
+				Data:                     []types.InstantVectorSeriesData{newData()},
 				MemoryConsumptionTracker: memoryConsumptionTracker,
 			}
 			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
@@ -2305,10 +2638,708 @@ func TestGroupedVectorVectorBinaryOperation_RejectsInvalidPresenceTimestamps(t *
 			_, err = operation.NextSeries(t.Context())
 			require.EqualError(t, err, testCase.expectedError)
 			require.Error(t, errors.Unwrap(err))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.FPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.HPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
 			many.ReleaseUnreadData(memoryConsumptionTracker)
 			one.ReleaseUnreadData(memoryConsumptionTracker)
 			require.NoError(t, operation.FinishedReading(t.Context()))
 			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_RejectsInvalidManySidePresenceTimestamps(t *testing.T) {
+	fill := 3.0
+	invalidTime := 30 * time.Second.Milliseconds()
+	for name, cardinality := range map[string]parser.VectorMatchCardinality{
+		"many-to-one": parser.CardManyToOne,
+		"one-to-many": parser.CardOneToMany,
+	} {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			manyPoints, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			manyPoints = append(manyPoints, promql.FPoint{T: invalidTime, F: 10})
+			onePoints, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			onePoints = append(onePoints, promql.FPoint{T: 0, F: 20})
+			many := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a", "series", "1")},
+				Data:                     []types.InstantVectorSeriesData{{Floats: manyPoints}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			one := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{{Floats: onePoints}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if cardinality == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           cardinality,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(time.Minute.Milliseconds()), time.Minute),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			_, err = operation.NextSeries(t.Context())
+			require.EqualError(t, err, "record many-side presence at timestamp 30000: timestamp 30000 is not aligned to query interval 60000")
+			require.Error(t, errors.Unwrap(err))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_RejectsOverlappingCarrierResults(t *testing.T) {
+	fill := 3.0
+	for name, cardinality := range map[string]parser.VectorMatchCardinality{
+		"many-to-one": parser.CardManyToOne,
+		"one-to-many": parser.CardOneToMany,
+	} {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			oneData := make([]types.InstantVectorSeriesData, 2)
+			for idx := range oneData {
+				points, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+				require.NoError(t, err)
+				oneData[idx].Floats = append(points, promql.FPoint{T: 0, F: float64(idx + 1)})
+			}
+			many := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
+			one := &operators.TestOperator{
+				Series: []labels.Labels{
+					labels.FromStrings(model.MetricNameLabel, "one-a"),
+					labels.FromStrings(model.MetricNameLabel, "one-b"),
+				},
+				Data:                     oneData,
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if cardinality == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           cardinality,
+					On:             true,
+					MatchingLabels: []string{model.MetricNameLabel},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewInstantQueryTimeRange(timestamp.Time(0)),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			require.Len(t, metadata, 1)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			_, err = operation.NextSeries(t.Context())
+			require.EqualError(t, err, "merge grouped output components: unexpected overlapping result point at timestamp 0")
+			require.Error(t, errors.Unwrap(err))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_MergeComponentResultsRejectsEveryOverlapType(t *testing.T) {
+	testCases := map[string]struct {
+		firstHistogram  bool
+		secondHistogram bool
+	}{
+		"float-float": {},
+		"histogram-histogram": {
+			firstHistogram:  true,
+			secondHistogram: true,
+		},
+		"float-histogram": {
+			secondHistogram: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			newData := func(asHistogram bool) types.InstantVectorSeriesData {
+				if asHistogram {
+					points, err := types.HPointSlicePool.Get(1, memoryConsumptionTracker)
+					require.NoError(t, err)
+					points = append(points, promql.HPoint{T: 0, H: &histogram.FloatHistogram{Count: 1, Sum: 1}})
+					return types.InstantVectorSeriesData{Histograms: points}
+				}
+				points, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+				require.NoError(t, err)
+				points = append(points, promql.FPoint{T: 0, F: 1})
+				return types.InstantVectorSeriesData{Floats: points}
+			}
+			operation := &GroupedVectorVectorBinaryOperation{MemoryConsumptionTracker: memoryConsumptionTracker}
+			_, err := operation.mergeComponentResults(t.Context(), []types.InstantVectorSeriesData{
+				newData(testCase.firstHistogram),
+				newData(testCase.secondHistogram),
+			})
+			require.EqualError(t, err, "merge grouped output components: unexpected overlapping result point at timestamp 0")
+			require.Error(t, errors.Unwrap(err))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_MergeComponentResultsChecksCancellation(t *testing.T) {
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+	const (
+		componentCount     = 4
+		pointsPerComponent = 4096
+	)
+	results := make([]types.InstantVectorSeriesData, componentCount)
+	for componentIndex := range results {
+		if componentIndex%2 == 0 {
+			points, err := types.FPointSlicePool.Get(pointsPerComponent, memoryConsumptionTracker)
+			require.NoError(t, err)
+			for pointIndex := range pointsPerComponent {
+				points = append(points, promql.FPoint{T: int64(pointIndex*componentCount + componentIndex), F: float64(pointIndex)})
+			}
+			results[componentIndex].Floats = points
+			continue
+		}
+		points, err := types.HPointSlicePool.Get(pointsPerComponent, memoryConsumptionTracker)
+		require.NoError(t, err)
+		for pointIndex := range pointsPerComponent {
+			points = append(points, promql.HPoint{
+				T: int64(pointIndex*componentCount + componentIndex),
+				H: &histogram.FloatHistogram{Count: 1, Sum: float64(pointIndex)},
+			})
+		}
+		results[componentIndex].Histograms = points
+	}
+	ctx := &cancelAfterErrChecksContext{Context: t.Context(), remainingChecks: 5}
+	operation := &GroupedVectorVectorBinaryOperation{MemoryConsumptionTracker: memoryConsumptionTracker}
+	_, err := operation.mergeComponentResults(ctx, results)
+	require.EqualError(t, err, "merge grouped output components: context canceled")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+}
+
+func TestGroupedVectorVectorBinaryOperation_SuppressedManyFillEmitsNoAnnotation(t *testing.T) {
+	fill := 3.0
+	testCases := map[string]struct {
+		card                parser.VectorMatchCardinality
+		withRealMany        bool
+		expectedAnnotations int
+	}{
+		"many-to-one suppresses the annotation": {
+			card:         parser.CardManyToOne,
+			withRealMany: true,
+		},
+		"one-to-many suppresses the annotation": {
+			card:         parser.CardOneToMany,
+			withRealMany: true,
+		},
+		"many-to-one emits the annotation without real many data": {
+			card:                parser.CardManyToOne,
+			expectedAnnotations: 1,
+		},
+		"one-to-many emits the annotation without real many data": {
+			card:                parser.CardOneToMany,
+			expectedAnnotations: 1,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			many := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
+			if testCase.withRealMany {
+				manyPoints, err := types.HPointSlicePool.Get(1, memoryConsumptionTracker)
+				require.NoError(t, err)
+				manyPoints = append(manyPoints, promql.HPoint{T: 0, H: &histogram.FloatHistogram{Count: 2, Sum: 4}})
+				many.Series = []labels.Labels{labels.FromStrings("group", "a", "series", "1")}
+				many.Data = []types.InstantVectorSeriesData{{Histograms: manyPoints}}
+			}
+			onePoints, err := types.HPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			onePoints = append(onePoints, promql.HPoint{T: 0, H: &histogram.FloatHistogram{Count: 3, Sum: 6}})
+			one := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{{Histograms: onePoints}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if testCase.card == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           testCase.card,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewInstantQueryTimeRange(timestamp.Time(0)),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			outputCount := len(metadata)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			for range outputCount {
+				result, err := operation.NextSeries(t.Context())
+				require.NoError(t, err)
+				types.PutInstantVectorSeriesData(result, memoryConsumptionTracker)
+			}
+			_, resultAnnotations, err := operation.Finalize(t.Context())
+			require.NoError(t, err)
+			require.Len(t, resultAnnotations, testCase.expectedAnnotations)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_ManyPresenceRespectsMemoryLimit(t *testing.T) {
+	fill := 3.0
+	start := timestamp.Time(0)
+	timeRange := types.NewRangeQueryTimeRange(start, start.Add(10_999*time.Second), time.Second)
+	for name, cardinality := range map[string]parser.VectorMatchCardinality{
+		"many-to-one": parser.CardManyToOne,
+		"one-to-many": parser.CardOneToMany,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rejectionCount := promauto.With(prometheus.NewRegistry()).NewCounter(prometheus.CounterOpts{Name: "test_grouped_many_presence_rejections_total"})
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(t.Context(), 64*1024, rejectionCount, "grouped many presence test")
+			many := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a", "series", "1")},
+				Data:                     []types.InstantVectorSeriesData{{}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			one := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{{}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if cardinality == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           cardinality,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				timeRange,
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			_, err = operation.NextSeries(t.Context())
+			require.ErrorContains(t, err, "allocate many-side presence: the query exceeded the maximum allowed estimated amount of memory consumed by a single query")
+			require.Error(t, errors.Unwrap(err))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_ManyPresenceChecksCancellationInSampleLoops(t *testing.T) {
+	fill := 3.0
+	const pointCount = 4096
+	testCases := map[string]struct {
+		histograms    bool
+		expectedError string
+	}{
+		"floats": {
+			expectedError: "update many-side float presence: context canceled",
+		},
+		"histograms": {
+			histograms:    true,
+			expectedError: "update many-side histogram presence: context canceled",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			manyData := types.InstantVectorSeriesData{}
+			if testCase.histograms {
+				points, err := types.HPointSlicePool.Get(pointCount, memoryConsumptionTracker)
+				require.NoError(t, err)
+				for pointIndex := range pointCount {
+					points = append(points, promql.HPoint{
+						T: int64(pointIndex) * time.Second.Milliseconds(),
+						H: &histogram.FloatHistogram{Count: 1, Sum: float64(pointIndex)},
+					})
+				}
+				manyData.Histograms = points
+			} else {
+				points, err := types.FPointSlicePool.Get(pointCount, memoryConsumptionTracker)
+				require.NoError(t, err)
+				for pointIndex := range pointCount {
+					points = append(points, promql.FPoint{T: int64(pointIndex) * time.Second.Milliseconds(), F: float64(pointIndex)})
+				}
+				manyData.Floats = points
+			}
+			many := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a", "series", "1")},
+				Data:                     []types.InstantVectorSeriesData{manyData},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			one := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{{}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				many,
+				one,
+				parser.VectorMatching{
+					Card:           parser.CardManyToOne,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time((pointCount-1)*time.Second.Milliseconds()), time.Second),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			ctx := &cancelAfterErrChecksContext{Context: t.Context(), remainingChecks: 7}
+			_, err = operation.NextSeries(ctx)
+			require.EqualError(t, err, testCase.expectedError)
+			require.ErrorIs(t, err, context.Canceled)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.FPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.HPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_ReleasesManyPresenceAfterChildError(t *testing.T) {
+	fill := 3.0
+	injectedErr := errors.New("injected child error")
+	for name, cardinality := range map[string]parser.VectorMatchCardinality{
+		"many-to-one": parser.CardManyToOne,
+		"one-to-many": parser.CardOneToMany,
+	} {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			manyPoints, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			manyPoints = append(manyPoints, promql.FPoint{T: 0, F: 10})
+			many := &failingNextSeriesOperator{
+				finishedReadingCountingOperator: &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+					Series: []labels.Labels{
+						labels.FromStrings("group", "a", "series", "1"),
+						labels.FromStrings("group", "a", "series", "2"),
+					},
+					Data: []types.InstantVectorSeriesData{
+						{Floats: manyPoints},
+						{},
+					},
+					MemoryConsumptionTracker: memoryConsumptionTracker,
+				}},
+				failAt: 2,
+				err:    injectedErr,
+			}
+			onePoints, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			onePoints = append(onePoints, promql.FPoint{T: 0, F: 20})
+			one := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{{Floats: onePoints}},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if cardinality == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           cardinality,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewInstantQueryTimeRange(timestamp.Time(0)),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			result, err := operation.NextSeries(t.Context())
+			require.NoError(t, err)
+			types.PutInstantVectorSeriesData(result, memoryConsumptionTracker)
+			_, err = operation.NextSeries(t.Context())
+			require.ErrorIs(t, err, injectedErr)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			many.ReleaseUnreadData(memoryConsumptionTracker)
+			one.ReleaseUnreadData(memoryConsumptionTracker)
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Equal(t, 1, many.finishedReadingCalls)
+			require.Equal(t, 1, one.finishedReadingCalls)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_ReleasesManyPresenceAfterEvaluatorError(t *testing.T) {
+	fill := 3.0
+	injectedErr := errors.New("injected evaluator error")
+	for name, cardinality := range map[string]parser.VectorMatchCardinality{
+		"many-to-one": parser.CardManyToOne,
+		"one-to-many": parser.CardOneToMany,
+	} {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			newData := func(value float64) types.InstantVectorSeriesData {
+				points, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+				require.NoError(t, err)
+				return types.InstantVectorSeriesData{Floats: append(points, promql.FPoint{T: 0, F: value})}
+			}
+			many := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a", "series", "1")},
+				Data:                     []types.InstantVectorSeriesData{newData(10)},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			one := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("group", "a")},
+				Data:                     []types.InstantVectorSeriesData{newData(20)},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if cardinality == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           cardinality,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewInstantQueryTimeRange(timestamp.Time(0)),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+			operation.evaluator.opFunc = func(float64, float64, *histogram.FloatHistogram, *histogram.FloatHistogram, bool, bool, types.EmitAnnotationFunc) (float64, *histogram.FloatHistogram, bool, bool, error) {
+				return 0, nil, false, false, injectedErr
+			}
+
+			metadata, err := operation.SeriesMetadata(t.Context(), nil)
+			require.NoError(t, err)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			_, err = operation.NextSeries(t.Context())
+			require.ErrorIs(t, err, injectedErr)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+			operation.Close()
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_CleansCurrentCollisionAfterEvaluationStops(t *testing.T) {
+	fill := 3.0
+	injectedErr := errors.New("injected carrier evaluation error")
+	testCases := map[string]struct {
+		card              parser.VectorMatchCardinality
+		cancelAfterReal   bool
+		failCarrier       bool
+		expectedError     error
+		expectedErrorText string
+	}{
+		"many-to-one cancellation after population": {
+			card:              parser.CardManyToOne,
+			cancelAfterReal:   true,
+			expectedError:     context.Canceled,
+			expectedErrorText: "evaluate grouped output: context canceled",
+		},
+		"one-to-many cancellation after population": {
+			card:              parser.CardOneToMany,
+			cancelAfterReal:   true,
+			expectedError:     context.Canceled,
+			expectedErrorText: "evaluate grouped output: context canceled",
+		},
+		"many-to-one carrier failure": {
+			card:              parser.CardManyToOne,
+			failCarrier:       true,
+			expectedError:     injectedErr,
+			expectedErrorText: "evaluate grouped output component: injected carrier evaluation error",
+		},
+		"one-to-many carrier failure": {
+			card:              parser.CardOneToMany,
+			failCarrier:       true,
+			expectedError:     injectedErr,
+			expectedErrorText: "evaluate grouped output component: injected carrier evaluation error",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+			newData := func(points ...promql.FPoint) types.InstantVectorSeriesData {
+				pooled, err := types.FPointSlicePool.Get(len(points), memoryConsumptionTracker)
+				require.NoError(t, err)
+				return types.InstantVectorSeriesData{Floats: append(pooled, points...)}
+			}
+			many := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series: []labels.Labels{
+					labels.FromStrings(model.MetricNameLabel, "many", "group", "a", "owner", "stale"),
+				},
+				Data:                     []types.InstantVectorSeriesData{newData(promql.FPoint{T: 0, F: 10})},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			one := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{
+				Series: []labels.Labels{
+					labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
+				},
+				Data: []types.InstantVectorSeriesData{newData(
+					promql.FPoint{T: 0, F: 20},
+					promql.FPoint{T: time.Minute.Milliseconds(), F: 30},
+				)},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}}
+			left, right := types.InstantVectorOperator(many), types.InstantVectorOperator(one)
+			if testCase.card == parser.CardOneToMany {
+				left, right = one, many
+			}
+
+			operation, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           testCase.card,
+					On:             true,
+					MatchingLabels: []string{"group"},
+					Include:        []string{"owner"},
+					FillValues:     parser.VectorMatchFillValues{LHS: &fill},
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(time.Minute.Milliseconds()), time.Minute),
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			metadata, err := operation.SeriesMetadata(ctx, nil)
+			require.NoError(t, err)
+			require.Len(t, metadata, 1)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+			originalOpFunc := operation.evaluator.opFunc
+			calls := 0
+			operation.evaluator.opFunc = func(lF, rF float64, lH, rH *histogram.FloatHistogram, canMutateLeft, canMutateRight bool, emitAnnotation types.EmitAnnotationFunc) (float64, *histogram.FloatHistogram, bool, bool, error) {
+				calls++
+				if testCase.failCarrier && calls == 2 {
+					return 0, nil, false, false, injectedErr
+				}
+				resultFloat, resultHistogram, keep, valid, err := originalOpFunc(lF, rF, lH, rH, canMutateLeft, canMutateRight, emitAnnotation)
+				if testCase.cancelAfterReal && calls == 1 {
+					cancel()
+				}
+				return resultFloat, resultHistogram, keep, valid, err
+			}
+
+			_, err = operation.NextSeries(ctx)
+			require.EqualError(t, err, testCase.expectedErrorText)
+			require.ErrorIs(t, err, testCase.expectedError)
+			require.Len(t, operation.remainingSeries, 1)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.FPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.HPointSlices))
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.IntSlices))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.NoError(t, operation.FinishedReading(t.Context()))
+			require.Equal(t, 1, many.finishedReadingCalls)
+			require.Equal(t, 1, one.finishedReadingCalls)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 			operation.Close()
 		})
 	}
@@ -2367,7 +3398,7 @@ func TestGroupedVectorVectorBinaryOperation_CanonicalManySideIncludeValuesReject
 			require.Len(t, metadata, 1)
 			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
 			_, err = operation.NextSeries(t.Context())
-			require.ErrorIs(t, err, errMultipleMatchesOnManySide)
+			require.EqualError(t, err, errMultipleMatchesOnManySide.Error())
 			require.NoError(t, operation.FinishedReading(t.Context()))
 			operation.Close()
 		})

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -24,6 +24,16 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
+type finishedReadingCountingOperator struct {
+	*operators.TestOperator
+	finishedReadingCalls int
+}
+
+func (o *finishedReadingCountingOperator) FinishedReading(ctx context.Context) error {
+	o.finishedReadingCalls++
+	return o.TestOperator.FinishedReading(ctx)
+}
+
 func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
 	testCases := map[string]struct {
 		leftSeries  []labels.Labels
@@ -1044,6 +1054,259 @@ func TestGroupedVectorVectorBinaryOperation_IgnoresMatchersWithFill(t *testing.T
 			require.Nil(t, right.MatchersProvided)
 		})
 	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_NormalizesSidesAndEvaluatorFillValues(t *testing.T) {
+	lhsFill := 11.0
+	rhsFill := 22.0
+	testCases := map[string]struct {
+		card parser.VectorMatchCardinality
+		fill parser.VectorMatchFillValues
+
+		leftIsMany     bool
+		normalizedMany *float64
+		normalizedOne  *float64
+		evaluatorLeft  *float64
+		evaluatorRight *float64
+	}{
+		"many-to-one without fill": {
+			card:       parser.CardManyToOne,
+			leftIsMany: true,
+		},
+		"many-to-one with LHS fill": {
+			card:           parser.CardManyToOne,
+			fill:           parser.VectorMatchFillValues{LHS: &lhsFill},
+			leftIsMany:     true,
+			normalizedMany: &lhsFill,
+			evaluatorLeft:  &lhsFill,
+		},
+		"many-to-one with RHS fill": {
+			card:           parser.CardManyToOne,
+			fill:           parser.VectorMatchFillValues{RHS: &rhsFill},
+			leftIsMany:     true,
+			normalizedOne:  &rhsFill,
+			evaluatorRight: &rhsFill,
+		},
+		"many-to-one with both fills": {
+			card:           parser.CardManyToOne,
+			fill:           parser.VectorMatchFillValues{LHS: &lhsFill, RHS: &rhsFill},
+			leftIsMany:     true,
+			normalizedMany: &lhsFill,
+			normalizedOne:  &rhsFill,
+			evaluatorLeft:  &lhsFill,
+			evaluatorRight: &rhsFill,
+		},
+		"one-to-many without fill": {
+			card: parser.CardOneToMany,
+		},
+		"one-to-many with LHS fill": {
+			card:           parser.CardOneToMany,
+			fill:           parser.VectorMatchFillValues{LHS: &lhsFill},
+			normalizedMany: &lhsFill,
+			evaluatorRight: &lhsFill,
+		},
+		"one-to-many with RHS fill": {
+			card:          parser.CardOneToMany,
+			fill:          parser.VectorMatchFillValues{RHS: &rhsFill},
+			normalizedOne: &rhsFill,
+			evaluatorLeft: &rhsFill,
+		},
+		"one-to-many with both fills": {
+			card:           parser.CardOneToMany,
+			fill:           parser.VectorMatchFillValues{LHS: &lhsFill, RHS: &rhsFill},
+			normalizedMany: &lhsFill,
+			normalizedOne:  &rhsFill,
+			evaluatorLeft:  &rhsFill,
+			evaluatorRight: &lhsFill,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+			left := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
+			right := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
+
+			o, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{Card: testCase.card, FillValues: testCase.fill},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.QueryTimeRange{},
+				nil,
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			if testCase.leftIsMany {
+				require.Same(t, left, o.manySide)
+				require.Same(t, right, o.oneSide)
+			} else {
+				require.Same(t, right, o.manySide)
+				require.Same(t, left, o.oneSide)
+			}
+			require.Same(t, testCase.normalizedMany, o.fillValues.LHS)
+			require.Same(t, testCase.normalizedOne, o.fillValues.RHS)
+			require.Same(t, testCase.evaluatorLeft, o.evaluator.fillLeft)
+			require.Same(t, testCase.evaluatorRight, o.evaluator.fillRight)
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_EmptySideMetadataWithFill(t *testing.T) {
+	fillValue := 1.0
+	fillCases := map[string]struct {
+		card      parser.VectorMatchCardinality
+		fill      parser.VectorMatchFillValues
+		fillsMany bool
+		fillsOne  bool
+	}{
+		"many-to-one without fill": {
+			card: parser.CardManyToOne,
+		},
+		"many-to-one with LHS fill": {
+			card:      parser.CardManyToOne,
+			fill:      parser.VectorMatchFillValues{LHS: &fillValue},
+			fillsMany: true,
+		},
+		"many-to-one with RHS fill": {
+			card:     parser.CardManyToOne,
+			fill:     parser.VectorMatchFillValues{RHS: &fillValue},
+			fillsOne: true,
+		},
+		"many-to-one with both fills": {
+			card:      parser.CardManyToOne,
+			fill:      parser.VectorMatchFillValues{LHS: &fillValue, RHS: &fillValue},
+			fillsMany: true,
+			fillsOne:  true,
+		},
+		"one-to-many without fill": {
+			card: parser.CardOneToMany,
+		},
+		"one-to-many with LHS fill": {
+			card:      parser.CardOneToMany,
+			fill:      parser.VectorMatchFillValues{LHS: &fillValue},
+			fillsMany: true,
+		},
+		"one-to-many with RHS fill": {
+			card:     parser.CardOneToMany,
+			fill:     parser.VectorMatchFillValues{RHS: &fillValue},
+			fillsOne: true,
+		},
+		"one-to-many with both fills": {
+			card:      parser.CardOneToMany,
+			fill:      parser.VectorMatchFillValues{LHS: &fillValue, RHS: &fillValue},
+			fillsMany: true,
+			fillsOne:  true,
+		},
+	}
+	emptyCases := map[string]struct {
+		many bool
+		one  bool
+	}{
+		"neither side empty": {},
+		"many side empty":    {many: true},
+		"one side empty":     {one: true},
+		"both sides empty":   {many: true, one: true},
+	}
+
+	for fillName, fillCase := range fillCases {
+		for emptyName, emptyCase := range emptyCases {
+			t.Run(fillName+"/"+emptyName, func(t *testing.T) {
+				memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+				manySeries := []labels.Labels{labels.FromStrings("group", "a")}
+				if emptyCase.many {
+					manySeries = nil
+				}
+				oneSeries := []labels.Labels{labels.FromStrings("group", "a")}
+				if emptyCase.one {
+					oneSeries = nil
+				}
+
+				many := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{Series: manySeries, Data: make([]types.InstantVectorSeriesData, len(manySeries)), MemoryConsumptionTracker: memoryConsumptionTracker}}
+				one := &finishedReadingCountingOperator{TestOperator: &operators.TestOperator{Series: oneSeries, Data: make([]types.InstantVectorSeriesData, len(oneSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}}
+				left, right := many, one
+				if fillCase.card == parser.CardOneToMany {
+					left, right = one, many
+				}
+
+				o, err := NewGroupedVectorVectorBinaryOperation(
+					left,
+					right,
+					parser.VectorMatching{Card: fillCase.card, On: true, MatchingLabels: []string{"group"}, FillValues: fillCase.fill},
+					parser.ADD,
+					false,
+					memoryConsumptionTracker,
+					posrange.PositionRange{},
+					types.QueryTimeRange{},
+					nil,
+					log.NewNopLogger(),
+				)
+				require.NoError(t, err)
+
+				canProduceAnySeries, err := o.loadSeriesMetadata(t.Context(), nil)
+				require.NoError(t, err)
+
+				expectedManyCall := !emptyCase.one || fillCase.fillsOne
+				expectedContinuation := !emptyCase.many && !emptyCase.one
+				if emptyCase.many != emptyCase.one {
+					expectedContinuation = (emptyCase.many && fillCase.fillsMany) || (emptyCase.one && fillCase.fillsOne)
+				}
+				require.True(t, one.SeriesMetadataCalled)
+				require.Equal(t, expectedManyCall, many.SeriesMetadataCalled)
+				require.Equal(t, expectedContinuation, canProduceAnySeries)
+				expectedManyFinishedCalls := 0
+				expectedOneFinishedCalls := 0
+				if canProduceAnySeries && emptyCase.many {
+					expectedManyFinishedCalls = 1
+				}
+				if canProduceAnySeries && emptyCase.one {
+					expectedOneFinishedCalls = 1
+				}
+				require.Equal(t, expectedManyFinishedCalls, many.finishedReadingCalls)
+				require.Equal(t, expectedOneFinishedCalls, one.finishedReadingCalls)
+				if canProduceAnySeries && (emptyCase.many || emptyCase.one) {
+					metadata, _, oneUsed, _, manyUsed, _, err := o.computeOutputSeries()
+					require.NoError(t, err)
+					require.Empty(t, metadata)
+					types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
+					types.BoolSlicePool.Put(&oneUsed, memoryConsumptionTracker)
+					types.BoolSlicePool.Put(&manyUsed, memoryConsumptionTracker)
+				}
+
+				require.NoError(t, o.FinishedReading(t.Context()))
+				require.Equal(t, 1, many.finishedReadingCalls)
+				require.Equal(t, 1, one.finishedReadingCalls)
+			})
+		}
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_RejectsMalformedCardinality(t *testing.T) {
+	invalidCardinality := parser.VectorMatchCardinality(99)
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+	left := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
+	right := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
+
+	_, err := NewGroupedVectorVectorBinaryOperation(
+		left,
+		right,
+		parser.VectorMatching{Card: invalidCardinality},
+		parser.ADD,
+		false,
+		memoryConsumptionTracker,
+		posrange.PositionRange{},
+		types.QueryTimeRange{},
+		nil,
+		log.NewNopLogger(),
+	)
+	require.EqualError(t, err, "unsupported cardinality 99")
+
+	_, _, err = (normalizedGroupedSides{}).evaluatorFillValues(invalidCardinality)
+	require.EqualError(t, err, "unsupported cardinality 99")
 }
 
 func TestGroupedVectorVectorBinaryOperation_PassesWithoutDerivedMatchersToManySide(t *testing.T) {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -1280,28 +1280,28 @@ func TestGroupedVectorVectorBinaryOperation_EmptySideMetadataWithFill(t *testing
 				)
 				require.NoError(t, err)
 
-				canProduceAnySeries, err := o.loadSeriesMetadata(t.Context(), nil)
+				shouldContinue, err := o.loadSeriesMetadata(t.Context(), nil)
 				require.NoError(t, err)
 
 				expectedManyCall := !emptyCase.one || fillCase.fillsOne
 				expectedContinuation := !emptyCase.many && !emptyCase.one
 				if emptyCase.many != emptyCase.one {
-					expectedContinuation = (emptyCase.many && fillCase.fillsMany) || (emptyCase.one && fillCase.fillsOne)
+					expectedContinuation = (emptyCase.many && (fillCase.fillsMany || fillCase.fillsOne)) || (emptyCase.one && fillCase.fillsOne)
 				}
 				require.True(t, one.SeriesMetadataCalled)
 				require.Equal(t, expectedManyCall, many.SeriesMetadataCalled)
-				require.Equal(t, expectedContinuation, canProduceAnySeries)
+				require.Equal(t, expectedContinuation, shouldContinue)
 				expectedManyFinishedCalls := 0
 				expectedOneFinishedCalls := 0
-				if canProduceAnySeries && emptyCase.many {
+				if shouldContinue && emptyCase.many {
 					expectedManyFinishedCalls = 1
 				}
-				if canProduceAnySeries && emptyCase.one {
+				if shouldContinue && emptyCase.one {
 					expectedOneFinishedCalls = 1
 				}
 				require.Equal(t, expectedManyFinishedCalls, many.finishedReadingCalls)
 				require.Equal(t, expectedOneFinishedCalls, one.finishedReadingCalls)
-				if canProduceAnySeries && (emptyCase.many || emptyCase.one) {
+				if shouldContinue && (emptyCase.many || emptyCase.one) {
 					metadata, _, oneUsed, _, manyUsed, _, err := o.computeOutputSeries()
 					require.NoError(t, err)
 					expectedMetadataCount := 0
@@ -1314,6 +1314,7 @@ func TestGroupedVectorVectorBinaryOperation_EmptySideMetadataWithFill(t *testing
 					types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
 					types.BoolSlicePool.Put(&oneUsed, memoryConsumptionTracker)
 					types.BoolSlicePool.Put(&manyUsed, memoryConsumptionTracker)
+					o.oneSideValidationGroups = nil
 				}
 
 				require.NoError(t, o.FinishedReading(t.Context()))
@@ -1881,22 +1882,23 @@ func TestGroupedVectorVectorBinaryOperation_FillsSyntheticOneSide(t *testing.T) 
 				floats: []promql.FPoint{{T: ts, F: 4}, {T: secondTS, F: 5}},
 			}},
 		},
-		"many-to-one evaluates multiple one-side carrier variants": {
-			card:    parser.CardManyToOne,
-			op:      parser.ADD,
-			fill:    parser.VectorMatchFillValues{LHS: &fillThree},
-			include: []string{"owner"},
+		"many-to-one evaluates intermittent one-side carrier variants": {
+			card:      parser.CardManyToOne,
+			op:        parser.ADD,
+			fill:      parser.VectorMatchFillValues{LHS: &fillThree},
+			include:   []string{"owner"},
+			timeRange: types.NewRangeQueryTimeRange(timestamp.Time(ts), timestamp.Time(secondTS), time.Minute),
 			oneSeries: []labels.Labels{
 				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-a"),
 				labels.FromStrings(model.MetricNameLabel, "one", "group", "a", "owner", "team-b"),
 			},
 			oneData: []types.InstantVectorSeriesData{
 				{Floats: []promql.FPoint{{T: ts, F: 1}}},
-				{Floats: []promql.FPoint{{T: ts, F: 2}}},
+				{Floats: []promql.FPoint{{T: secondTS, F: 2}}},
 			},
 			expected: []expectedSeries{
 				{labels: labels.FromStrings("group", "a", "owner", "team-a"), floats: []promql.FPoint{{T: ts, F: 4}}},
-				{labels: labels.FromStrings("group", "a", "owner", "team-b"), floats: []promql.FPoint{{T: ts, F: 5}}},
+				{labels: labels.FromStrings("group", "a", "owner", "team-b"), floats: []promql.FPoint{{T: secondTS, F: 5}}},
 			},
 		},
 		"one-to-many multiplies a one-side histogram by the many fill": {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -972,6 +972,80 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 	}
 }
 
+func TestGroupedVectorVectorBinaryOperation_IgnoresMatchersWithFill(t *testing.T) {
+	testCases := map[string]struct {
+		card     parser.VectorMatchCardinality
+		fillLeft bool
+	}{
+		"group_left fill_left": {
+			card:     parser.CardManyToOne,
+			fillLeft: true,
+		},
+		"group_left fill_right": {
+			card: parser.CardManyToOne,
+		},
+		"group_right fill_left": {
+			card:     parser.CardOneToMany,
+			fillLeft: true,
+		},
+		"group_right fill_right": {
+			card: parser.CardOneToMany,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+			left := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("env", "prod")},
+				Data:                     make([]types.InstantVectorSeriesData, 1),
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			right := &operators.TestOperator{
+				Series:                   []labels.Labels{labels.FromStrings("env", "prod")},
+				Data:                     make([]types.InstantVectorSeriesData, 1),
+				MemoryConsumptionTracker: memoryConsumptionTracker,
+			}
+			fillValue := 0.0
+			fillValues := parser.VectorMatchFillValues{RHS: &fillValue}
+			if testCase.fillLeft {
+				fillValues = parser.VectorMatchFillValues{LHS: &fillValue}
+			}
+
+			o, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{
+					Card:           testCase.card,
+					On:             true,
+					MatchingLabels: []string{"env"},
+					Include:        []string{"region"},
+					FillValues:     fillValues,
+				},
+				parser.ADD,
+				false,
+				memoryConsumptionTracker,
+				posrange.PositionRange{},
+				types.QueryTimeRange{},
+				&Hints{Include: []string{"env"}},
+				log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			outerMatchers := types.Matchers{
+				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+				{Type: labels.MatchEqual, Name: "service", Value: "api"},
+			}
+			_, err = o.SeriesMetadata(ctx, outerMatchers)
+			require.NoError(t, err)
+			require.Nil(t, left.MatchersProvided)
+			require.Nil(t, right.MatchersProvided)
+		})
+	}
+}
+
 func TestGroupedVectorVectorBinaryOperation_PassesWithoutDerivedMatchersToManySide(t *testing.T) {
 	// Verifies that exclude-style matchers are forwarded to the many side via explicit
 	// exclude hints (set by an up-to-date query-frontend). When hints are nil (old

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -65,7 +65,7 @@ import (
 // no left series of the group does, the evaluator synthesises a left operand from the fill value.
 //
 // For most operators the synthesised point carries the same output labels as any other point in the
-// group. computeResult adds it to the result inline (missingLeftInResult mode).
+// group. computeResult adds it to the main result.
 //
 // For name-retaining comparison filters (e.g. "a > fill_left(0) b") with ignoring()/without
 // matching, the output labels differ between a both-present step (keeps the left metric name) and a
@@ -79,7 +79,7 @@ import (
 //
 // A group has exactly one set of fill-left points (fill applies only when no left series has a
 // sample). The operator computes them on the last matched read of the group only. Earlier matched
-// reads skip the fill-left branch (missingLeftSkip) to avoid emitting spurious points or
+// reads skip the fill-left branch to avoid spurious points or
 // annotations. The last matched read uses missingLeftSeparate mode and stores the fill-left points
 // in the split holder. sortSeries places the last matched read before the name-dropped sibling,
 // which then takes the points from the holder.
@@ -186,7 +186,7 @@ type oneToOneBinaryOperationFillState struct {
 // left-absent even when another left series of the group has a sample there. Only the last of those
 // reads has the complete left-side presence of the group. Only that read can decide which steps the
 // left fill applies to. Every earlier read therefore skips the fill-left branch (see
-// fillLeftOptionsFor).
+// missingLeftOptionsFor).
 //
 // A group whose fill-left carrier is one of its matched output series has no name-dropped sibling.
 // That carrier emits the group's fill-left points itself, so the holder stays empty and only marks
@@ -1389,9 +1389,10 @@ func (b *OneToOneVectorVectorBinaryOperation) NextSeries(ctx context.Context) (t
 		rightData = rightSide.mergedData
 	}
 
-	fillLeft := b.fillLeftOptionsFor(thisSeries, rightSide, isLastUseOfRightSide)
+	missingLeft := b.missingLeftOptionsFor(thisSeries, rightSide, isLastUseOfRightSide)
 
-	finalResult, fillLeftResult, err := b.evaluator.computeResult(mergedLeftSide, rightData, true, isLastUseOfRightSide, fillLeft)
+	options := computeResultOptions{missingLeft: missingLeft}
+	finalResult, fillLeftResult, err := b.evaluator.computeResult(mergedLeftSide, rightData, true, isLastUseOfRightSide, options)
 	if err != nil {
 		return types.InstantVectorSeriesData{}, err
 	}
@@ -1401,7 +1402,7 @@ func (b *OneToOneVectorVectorBinaryOperation) NextSeries(ctx context.Context) (t
 		return finalResult, nil
 	}
 
-	if fillLeft.mode == missingLeftSeparate {
+	if missingLeft.mode == missingLeftSeparate {
 		// This is the last matched read of a split group, so fillLeftResult holds the group's fill-left
 		// points.
 		if fillLeftCarrier {
@@ -1428,7 +1429,7 @@ func (b *OneToOneVectorVectorBinaryOperation) NextSeries(ctx context.Context) (t
 	return finalResult, nil
 }
 
-// fillLeftOptionsFor returns the fill-left instructions for one read of thisSeries.
+// missingLeftOptionsFor returns the missing-left instructions for one series read.
 //
 // A read that is not part of a name-retaining fill-left split group gets the zero value. The
 // evaluator then adds every kept fill-left point to the main result.
@@ -1446,16 +1447,16 @@ func (b *OneToOneVectorVectorBinaryOperation) NextSeries(ctx context.Context) (t
 // the group covers. rightSide.leftSidePresence is nil when only one output series uses the group's
 // right side. The group then has a single matched output series. The left side of this read is
 // therefore the whole left side of the group, and the evaluator skips no step.
-func (b *OneToOneVectorVectorBinaryOperation) fillLeftOptionsFor(thisSeries *oneToOneBinaryOperationOutputSeries, rightSide *oneToOneBinaryOperationRightSide, isLastUseOfRightSide bool) fillLeftOptions {
+func (b *OneToOneVectorVectorBinaryOperation) missingLeftOptionsFor(thisSeries *oneToOneBinaryOperationOutputSeries, rightSide *oneToOneBinaryOperationRightSide, isLastUseOfRightSide bool) missingSideOptions {
 	if thisSeries.fill == nil || thisSeries.fill.splitHolder == nil {
-		return fillLeftOptions{mode: missingLeftInResult}
+		return missingSideOptions{mode: missingInResult}
 	}
 
 	if !isLastUseOfRightSide {
-		return fillLeftOptions{mode: missingLeftSkip}
+		return missingSideOptions{mode: missingSkip}
 	}
 
-	return fillLeftOptions{mode: missingLeftSeparate, leftSidePresence: rightSide.leftSidePresence}
+	return missingSideOptions{mode: missingLeftSeparate, groupPresence: rightSide.leftSidePresence}
 }
 
 // mergeGroupFillLeftPoints merges the fill-left points of a match group into the result of the
@@ -1511,7 +1512,7 @@ func (b *OneToOneVectorVectorBinaryOperation) nextFilledLeftSeries(ctx context.C
 	// at every right timestep, through the same per-timestep fill path used for intermittently matched
 	// groups. This is a fill-left-only output series; its labels already have no metric name, so the
 	// split path is not needed.
-	finalResult, _, err := b.evaluator.computeResult(types.InstantVectorSeriesData{}, rightSide.mergedData, false, isLastUseOfRightSide, fillLeftOptions{})
+	finalResult, _, err := b.evaluator.computeResult(types.InstantVectorSeriesData{}, rightSide.mergedData, false, isLastUseOfRightSide, computeResultOptions{})
 	if err != nil {
 		return types.InstantVectorSeriesData{}, err
 	}

--- a/pkg/streamingpromql/operators/operator_buffer.go
+++ b/pkg/streamingpromql/operators/operator_buffer.go
@@ -25,6 +25,7 @@ type InstantVectorOperatorBuffer struct {
 	// FIXME: could use a bitmap here to save some memory
 	seriesUsed          []bool
 	lastSeriesIndexUsed int
+	sourceFinished      bool
 
 	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
 
@@ -59,20 +60,30 @@ func (b *InstantVectorOperatorBuffer) GetSeries(ctx context.Context, seriesIndic
 		d, err := b.getSingleSeries(ctx, seriesIndex)
 
 		if err != nil {
+			b.releaseOutput(i)
 			return nil, err
 		}
 
 		b.output[i] = d
 	}
 
-	if b.nextIndexToRead > b.lastSeriesIndexUsed {
+	if b.nextIndexToRead > b.lastSeriesIndexUsed && !b.sourceFinished {
 		// If we're not going to read any more series, call FinishedReading on the inner operator.
+		b.sourceFinished = true
 		if err := b.source.FinishedReading(ctx); err != nil {
+			b.releaseOutput(len(seriesIndices))
 			return nil, err
 		}
 	}
 
 	return b.output, nil
+}
+
+func (b *InstantVectorOperatorBuffer) releaseOutput(count int) {
+	for idx := range count {
+		types.PutInstantVectorSeriesData(b.output[idx], b.memoryConsumptionTracker)
+		b.output[idx] = types.InstantVectorSeriesData{}
+	}
 }
 
 func (b *InstantVectorOperatorBuffer) getSingleSeries(ctx context.Context, seriesIndex int) (types.InstantVectorSeriesData, error) {

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -14,6 +14,16 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
+type finishedReadingCountingTestOperator struct {
+	*TestOperator
+	calls int
+}
+
+func (o *finishedReadingCountingTestOperator) FinishedReading(ctx context.Context) error {
+	o.calls++
+	return o.TestOperator.FinishedReading(ctx)
+}
+
 func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) {
 	series0Data := types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: 0, F: 0}}}
 	series2Data := types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: 0, F: 2}}}
@@ -233,4 +243,49 @@ func TestInstantVectorOperatorBuffer_FinishedReadingReleasesBufferedData(t *test
 	// Calling FinishedReading on the buffer should release the buffered series.
 	buffer.FinishedReading()
 	require.Equalf(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected 0 memory consumption after FinishedReading, but have\n%s", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+}
+
+func TestInstantVectorOperatorBuffer_GetSeriesReleasesPartialOutputAfterError(t *testing.T) {
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+	floats, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+	require.NoError(t, err)
+	floats = append(floats, promql.FPoint{T: 0, F: 1})
+
+	inner := &TestOperator{
+		Series: []labels.Labels{
+			labels.FromStrings("series", "0"),
+			labels.FromStrings("series", "1"),
+		},
+		Data: []types.InstantVectorSeriesData{{Floats: floats}},
+	}
+	buffer := NewInstantVectorOperatorBuffer(inner, nil, 1, memoryConsumptionTracker)
+
+	_, err = buffer.GetSeries(t.Context(), []int{0, 1})
+	require.ErrorIs(t, err, types.EOS)
+	buffer.FinishedReading()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+func TestInstantVectorOperatorBuffer_CallsSourceFinishedReadingOnce(t *testing.T) {
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(t.Context())
+	data := make([]types.InstantVectorSeriesData, 2)
+	for idx := range data {
+		floats, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+		require.NoError(t, err)
+		data[idx].Floats = append(floats, promql.FPoint{T: 0, F: float64(idx)})
+	}
+
+	inner := &finishedReadingCountingTestOperator{TestOperator: &TestOperator{Data: data}}
+	buffer := NewInstantVectorOperatorBuffer(inner, nil, 1, memoryConsumptionTracker)
+
+	series, err := buffer.GetSeries(t.Context(), []int{1})
+	require.NoError(t, err)
+	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
+	series, err = buffer.GetSeries(t.Context(), []int{0})
+	require.NoError(t, err)
+	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
+
+	require.Equal(t, 1, inner.calls)
+	buffer.FinishedReading()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }

--- a/pkg/streamingpromql/optimize/ast/propagate_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/propagate_matchers.go
@@ -98,6 +98,9 @@ func (mapper *propagateMatchers) propagateMatchersInBinaryExpr(e *parser.BinaryE
 	hasVectorSelectorsL := len(vssL) > 0
 	vssR, matchersR := mapper.extractVectorSelectors(e.RHS)
 	hasVectorSelectorsR := len(vssR) > 0
+	if groupedFillActive(e.VectorMatching) {
+		return nil, nil
+	}
 	switch {
 	case !hasVectorSelectorsL && !hasVectorSelectorsR:
 		return nil, nil
@@ -142,6 +145,14 @@ func (mapper *propagateMatchers) propagateMatchersInBinaryExpr(e *parser.BinaryE
 	vss := append(vssL, vssR...)
 	matchers, _ := combineMatchers(newMatchersL, newMatchersR, stringSet{}, false)
 	return vss, matchers
+}
+
+func groupedFillActive(vectorMatching *parser.VectorMatching) bool {
+	if vectorMatching == nil || (vectorMatching.Card != parser.CardOneToMany && vectorMatching.Card != parser.CardManyToOne) {
+		return false
+	}
+
+	return vectorMatching.FillValues.LHS != nil || vectorMatching.FillValues.RHS != nil
 }
 
 // extractVectorSelectors returns the vector selectors found in the expression (wrapped with additional

--- a/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
+++ b/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
@@ -178,6 +178,18 @@ var testCasesPropagateMatchersWithoutData = map[string]string{
 	// fill preserves both sides because every series can produce output.
 	`up{foo="bar"} + fill(0) down`: `up{foo="bar"} + fill(0) down`,
 	`up + fill(0) down{foo="bar"}`: `up + fill(0) down{foo="bar"}`,
+	// Grouped fill prevents all cross-side propagation.
+	`up{foo="bar"} + on(foo) group_left fill_left(0) down{baz="fob"}`:                `up{foo="bar"} + on(foo) group_left fill_left(0) down{baz="fob"}`,
+	`up{foo="bar"} + on(foo) group_left fill_right(0) down{baz="fob"}`:               `up{foo="bar"} + on(foo) group_left fill_right(0) down{baz="fob"}`,
+	`up{foo="bar"} + on(foo) group_left fill_left(0) fill_right(1) down{baz="fob"}`:  `up{foo="bar"} + on(foo) group_left fill_left(0) fill_right(1) down{baz="fob"}`,
+	`up{foo="bar"} + on(foo) group_right fill_left(0) down{baz="fob"}`:               `up{foo="bar"} + on(foo) group_right fill_left(0) down{baz="fob"}`,
+	`up{foo="bar"} + on(foo) group_right fill_right(0) down{baz="fob"}`:              `up{foo="bar"} + on(foo) group_right fill_right(0) down{baz="fob"}`,
+	`up{foo="bar"} + on(foo) group_right fill_left(0) fill_right(1) down{baz="fob"}`: `up{foo="bar"} + on(foo) group_right fill_left(0) fill_right(1) down{baz="fob"}`,
+	// Grouped fill also blocks propagation from enclosing expressions.
+	`(up{foo="bar"} + on(foo) group_left fill_left(0) down) * right{baz="fob"}`:  `(up{foo="bar"} + on(foo) group_left fill_left(0) down) * right{baz="fob"}`,
+	`left{baz="fob"} * (up + on(foo) group_right fill_right(0) down{foo="bar"})`: `left{baz="fob"} * (up + on(foo) group_right fill_right(0) down{foo="bar"})`,
+	// Grouped fill still permits propagation inside each side.
+	`(up{foo="bar"} * left) + on(foo) group_left fill_left(0) down{baz="fob"}`: `(up{foo="bar"} * left{foo="bar"}) + on(foo) group_left fill_left(0) down{baz="fob"}`,
 }
 
 // TestPropagateMatchers tests that queries are rewritten as expected, without running it on sample data.

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -551,7 +551,7 @@ func isEitherBinaryExpressionSideEmptyWithFill(node *core.BinaryExpression, para
 		return false, err
 	}
 
-	lhsFillSet := node.VectorMatching != nil && node.VectorMatching.FillValues.LhsSet
+	lhsFillSet, rhsFillSet := binaryExpressionSyntacticFillSides(node)
 	if lhsEmpty && !lhsFillSet {
 		return true, nil
 	}
@@ -561,12 +561,24 @@ func isEitherBinaryExpressionSideEmptyWithFill(node *core.BinaryExpression, para
 		return false, err
 	}
 
-	rhsFillSet := node.VectorMatching != nil && node.VectorMatching.FillValues.RhsSet
 	if rhsEmpty && !rhsFillSet {
 		return true, nil
 	}
 
 	return false, nil
+}
+
+func binaryExpressionSyntacticFillSides(node *core.BinaryExpression) (lhsFillSet, rhsFillSet bool) {
+	if node.VectorMatching == nil {
+		return false, false
+	}
+
+	fillValues := node.VectorMatching.FillValues
+	if node.VectorMatching.Card == parser.CardOneToMany {
+		return fillValues.RhsSet, fillValues.LhsSet
+	}
+
+	return fillValues.LhsSet, fillValues.RhsSet
 }
 
 // isAlwaysEmptyTimestampComparison returns true if timestampSide and constantSide represent

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_internal_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_internal_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
+)
+
+func TestIsEitherBinaryExpressionSideEmptyWithFillUsesSyntacticSides(t *testing.T) {
+	testCases := map[string]struct {
+		card          parser.VectorMatchCardinality
+		emptyLHS      bool
+		fillValues    core.VectorMatchFillValues
+		expectedEmpty bool
+	}{
+		"one-to-one LhsSet covers the syntactic LHS": {
+			card:       parser.CardOneToOne,
+			emptyLHS:   true,
+			fillValues: core.VectorMatchFillValues{LhsSet: true},
+		},
+		"one-to-one RhsSet does not cover the syntactic LHS": {
+			card:          parser.CardOneToOne,
+			emptyLHS:      true,
+			fillValues:    core.VectorMatchFillValues{RhsSet: true},
+			expectedEmpty: true,
+		},
+		"group_left LhsSet covers the syntactic LHS": {
+			card:       parser.CardManyToOne,
+			emptyLHS:   true,
+			fillValues: core.VectorMatchFillValues{LhsSet: true},
+		},
+		"group_left RhsSet covers the syntactic RHS": {
+			card:       parser.CardManyToOne,
+			fillValues: core.VectorMatchFillValues{RhsSet: true},
+		},
+		"group_right RhsSet covers the syntactic LHS": {
+			card:       parser.CardOneToMany,
+			emptyLHS:   true,
+			fillValues: core.VectorMatchFillValues{RhsSet: true},
+		},
+		"group_right LhsSet does not cover the syntactic LHS": {
+			card:          parser.CardOneToMany,
+			emptyLHS:      true,
+			fillValues:    core.VectorMatchFillValues{LhsSet: true},
+			expectedEmpty: true,
+		},
+		"group_right LhsSet covers the syntactic RHS": {
+			card:       parser.CardOneToMany,
+			fillValues: core.VectorMatchFillValues{LhsSet: true},
+		},
+		"group_right RhsSet does not cover the syntactic RHS": {
+			card:          parser.CardOneToMany,
+			fillValues:    core.VectorMatchFillValues{RhsSet: true},
+			expectedEmpty: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			empty := planning.Node(&core.NoOp{NoOpDetails: &core.NoOpDetails{}})
+			nonEmpty := planning.Node(&core.VectorSelector{VectorSelectorDetails: &core.VectorSelectorDetails{}})
+			lhs, rhs := nonEmpty, empty
+			if testCase.emptyLHS {
+				lhs, rhs = empty, nonEmpty
+			}
+
+			node := &core.BinaryExpression{
+				LHS: lhs,
+				RHS: rhs,
+				BinaryExpressionDetails: &core.BinaryExpressionDetails{
+					Op: core.BINARY_ADD,
+					VectorMatching: &core.VectorMatching{
+						Card:       testCase.card,
+						FillValues: testCase.fillValues,
+					},
+				},
+			}
+
+			actual, err := isEitherBinaryExpressionSideEmptyWithFill(node, &planning.QueryParameters{})
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedEmpty, actual)
+		})
+	}
+}

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -546,17 +546,7 @@ func (p *QueryPlanner) nodeFromExpr(expr parser.Expr, timeRange types.QueryTimeR
 
 	case *parser.BinaryExpr:
 		if expr.VectorMatching != nil && (expr.VectorMatching.FillValues.RHS != nil || expr.VectorMatching.FillValues.LHS != nil) {
-			// Only one-to-one matching supports the 'fill' modifier so far.
-			// Grouped (group_left/group_right) fills remain unsupported.
-			// The parser rejects a fill on a set operator before the query reaches here.
-			if expr.VectorMatching.Card != parser.CardOneToOne {
-				return nil, compat.NewNotSupportedError("'fill' modifier with many-to-one/one-to-many matching (group_left/group_right)")
-			}
-
-			// The match group key keeps __name__ when the query lists it in on(...), but the output
-			// labels of a filled series always drop __name__. So two match groups that differ only
-			// by __name__ produce the same output labels. The engine then needs one output series
-			// that draws from several match groups. MQE does not support that yet.
+			// Filled output labels drop __name__, which can merge distinct match groups into one output series.
 			if expr.VectorMatching.On && slices.Contains(expr.VectorMatching.MatchingLabels, model.MetricNameLabel) {
 				return nil, compat.NewNotSupportedError("'fill' modifier with __name__ in the 'on' clause")
 			}

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
@@ -311,11 +312,79 @@ func (b *BinaryExpression) ExpressionPosition() (posrange.PositionRange, error) 
 }
 
 func (b *BinaryExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
-	if vm := b.GetVectorMatching(); vm != nil && (vm.FillValues.LhsSet || vm.FillValues.RhsSet) {
-		// Queriers that do not understand QueryPlanV20 would silently ignore the fill modifier
-		// and produce incorrect results.
-		return planning.QueryPlanV20, nil
+	vm := b.GetVectorMatching()
+	if vm == nil || (!vm.FillValues.LhsSet && !vm.FillValues.RhsSet) {
+		return planning.QueryPlanVersionZero, nil
 	}
 
-	return planning.QueryPlanVersionZero, nil
+	if !binaryOperationSupportsFill(b.Op) {
+		return planning.QueryPlanVersionZero, fmt.Errorf("binary operation %q does not support fill", b.Op.Describe())
+	}
+	if err := validateFillVectorMatching(vm); err != nil {
+		return planning.QueryPlanVersionZero, err
+	}
+
+	lhsType, err := b.LHS.ResultType()
+	if err != nil {
+		return planning.QueryPlanVersionZero, fmt.Errorf("get left operand type for fill: %w", err)
+	}
+	rhsType, err := b.RHS.ResultType()
+	if err != nil {
+		return planning.QueryPlanVersionZero, fmt.Errorf("get right operand type for fill: %w", err)
+	}
+	if lhsType != parser.ValueTypeVector || rhsType != parser.ValueTypeVector {
+		return planning.QueryPlanVersionZero, fmt.Errorf("fill requires vector-vector operands, got %s-%s", lhsType, rhsType)
+	}
+
+	switch vm.Card {
+	case parser.CardOneToOne:
+		return planning.QueryPlanV20, nil
+	case parser.CardOneToMany, parser.CardManyToOne:
+		return planning.QueryPlanV21, nil
+	default:
+		return planning.QueryPlanVersionZero, fmt.Errorf("fill does not support %s matching", vm.Card)
+	}
+}
+
+func validateFillVectorMatching(vm *VectorMatching) error {
+	if !vm.On {
+		return nil
+	}
+
+	matchingLabels := make(map[string]struct{}, len(vm.MatchingLabels))
+	for _, label := range vm.MatchingLabels {
+		if label == model.MetricNameLabel {
+			return errors.New("fill does not support __name__ in on matching")
+		}
+		matchingLabels[label] = struct{}{}
+	}
+
+	for _, label := range vm.Include {
+		if _, exists := matchingLabels[label]; exists {
+			return fmt.Errorf("fill label %q appears in both on and include", label)
+		}
+	}
+
+	return nil
+}
+
+func binaryOperationSupportsFill(op BinaryOperation) bool {
+	switch op {
+	case BINARY_ATAN2,
+		BINARY_SUB,
+		BINARY_ADD,
+		BINARY_MUL,
+		BINARY_MOD,
+		BINARY_DIV,
+		BINARY_POW,
+		BINARY_EQLC,
+		BINARY_NEQ,
+		BINARY_LTE,
+		BINARY_LSS,
+		BINARY_GTE,
+		BINARY_GTR:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/streamingpromql/planning/core/binary_expression_test.go
+++ b/pkg/streamingpromql/planning/core/binary_expression_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 func TestBinaryExpression_Describe(t *testing.T) {
@@ -654,6 +655,127 @@ func TestBinaryExpression_MergeHints(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, testCase.expected, first.Hints)
 			}
+		})
+	}
+}
+
+func TestBinaryExpression_MinimumRequiredPlanVersionForFill(t *testing.T) {
+	require.Equal(t, planning.QueryPlanV21, planning.MaximumSupportedQueryPlanVersion)
+
+	vector := &VectorSelector{VectorSelectorDetails: &VectorSelectorDetails{}}
+	scalar := &NumberLiteral{NumberLiteralDetails: &NumberLiteralDetails{}}
+
+	testCases := map[string]struct {
+		op              BinaryOperation
+		card            parser.VectorMatchCardinality
+		lhs             planning.Node
+		rhs             planning.Node
+		fill            VectorMatchFillValues
+		expectedVersion planning.QueryPlanVersion
+		expectedError   string
+	}{
+		"no fill": {
+			op:   BINARY_ADD,
+			card: parser.CardOneToOne,
+			lhs:  vector,
+			rhs:  vector,
+		},
+		"one-to-one arithmetic fill": {
+			op:              BINARY_ADD,
+			card:            parser.CardOneToOne,
+			lhs:             vector,
+			rhs:             vector,
+			fill:            VectorMatchFillValues{LhsSet: true},
+			expectedVersion: planning.QueryPlanV20,
+		},
+		"one-to-one comparison fill": {
+			op:              BINARY_EQLC,
+			card:            parser.CardOneToOne,
+			lhs:             vector,
+			rhs:             vector,
+			fill:            VectorMatchFillValues{RhsSet: true},
+			expectedVersion: planning.QueryPlanV20,
+		},
+		"one-to-one atan2 fill": {
+			op:              BINARY_ATAN2,
+			card:            parser.CardOneToOne,
+			lhs:             vector,
+			rhs:             vector,
+			fill:            VectorMatchFillValues{LhsSet: true},
+			expectedVersion: planning.QueryPlanV20,
+		},
+		"one-to-many fill": {
+			op:              BINARY_ADD,
+			card:            parser.CardOneToMany,
+			lhs:             vector,
+			rhs:             vector,
+			fill:            VectorMatchFillValues{LhsSet: true},
+			expectedVersion: planning.QueryPlanV21,
+		},
+		"many-to-one fill": {
+			op:              BINARY_ADD,
+			card:            parser.CardManyToOne,
+			lhs:             vector,
+			rhs:             vector,
+			fill:            VectorMatchFillValues{RhsSet: true},
+			expectedVersion: planning.QueryPlanV21,
+		},
+		"set fill": {
+			op:            BINARY_LAND,
+			card:          parser.CardManyToMany,
+			lhs:           vector,
+			rhs:           vector,
+			fill:          VectorMatchFillValues{LhsSet: true},
+			expectedError: `binary operation "and" does not support fill`,
+		},
+		"vector-scalar fill": {
+			op:            BINARY_ADD,
+			card:          parser.CardOneToOne,
+			lhs:           vector,
+			rhs:           scalar,
+			fill:          VectorMatchFillValues{LhsSet: true},
+			expectedError: "fill requires vector-vector operands, got vector-scalar",
+		},
+		"scalar-vector fill": {
+			op:            BINARY_ADD,
+			card:          parser.CardOneToOne,
+			lhs:           scalar,
+			rhs:           vector,
+			fill:          VectorMatchFillValues{LhsSet: true},
+			expectedError: "fill requires vector-vector operands, got scalar-vector",
+		},
+		"scalar-scalar fill": {
+			op:            BINARY_ADD,
+			card:          parser.CardOneToOne,
+			lhs:           scalar,
+			rhs:           scalar,
+			fill:          VectorMatchFillValues{LhsSet: true},
+			expectedError: "fill requires vector-vector operands, got scalar-scalar",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			expression := &BinaryExpression{
+				LHS: testCase.lhs,
+				RHS: testCase.rhs,
+				BinaryExpressionDetails: &BinaryExpressionDetails{
+					Op: testCase.op,
+					VectorMatching: &VectorMatching{
+						Card:       testCase.card,
+						FillValues: testCase.fill,
+					},
+				},
+			}
+
+			version, err := expression.MinimumRequiredPlanVersion(types.QueryTimeRange{})
+			if testCase.expectedError != "" {
+				require.EqualError(t, err, testCase.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedVersion, version)
 		})
 	}
 }

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -104,7 +104,10 @@ const QueryPlanV19 = QueryPlanVersion(19)
 // incorrect results.
 const QueryPlanV20 = QueryPlanVersion(20)
 
-var MaximumSupportedQueryPlanVersion = QueryPlanV20
+// QueryPlanV21 introduces grouped fill support for binary expressions.
+const QueryPlanV21 = QueryPlanVersion(21)
+
+var MaximumSupportedQueryPlanVersion = QueryPlanV21
 
 type QueryPlan struct {
 	Root       Node
@@ -366,14 +369,52 @@ func (p *QueryPlan) DeterminePlanVersion() error {
 
 // MinimumRequiredPlanVersion returns the minimum required query plan version of node and all its children.
 func MinimumRequiredPlanVersion(node Node, timeRange types.QueryTimeRange) (QueryPlanVersion, error) {
-	maxVersion, err := node.MinimumRequiredPlanVersion(timeRange)
+	validator := newMinimumRequiredPlanVersionValidator(-1)
+	return validator.minimumRequiredPlanVersion(node, timeRange)
+}
+
+type minimumRequiredPlanVersionMemoKey struct {
+	node      Node
+	timeRange types.QueryTimeRange
+}
+
+type minimumRequiredPlanVersionValidator struct {
+	memo          map[minimumRequiredPlanVersionMemoKey]QueryPlanVersion
+	states        map[minimumRequiredPlanVersionMemoKey]struct{}
+	maxStateCount int
+}
+
+func newMinimumRequiredPlanVersionValidator(maxStateCount int) *minimumRequiredPlanVersionValidator {
+	return &minimumRequiredPlanVersionValidator{
+		memo:          make(map[minimumRequiredPlanVersionMemoKey]QueryPlanVersion),
+		states:        make(map[minimumRequiredPlanVersionMemoKey]struct{}),
+		maxStateCount: maxStateCount,
+	}
+}
+
+func (v *minimumRequiredPlanVersionValidator) minimumRequiredPlanVersion(node Node, timeRange types.QueryTimeRange) (QueryPlanVersion, error) {
+	key := minimumRequiredPlanVersionMemoKey{node: node, timeRange: timeRange}
+	if version, exists := v.memo[key]; exists {
+		return version, nil
+	}
+	if _, exists := v.states[key]; !exists {
+		if v.maxStateCount >= 0 && len(v.states) >= v.maxStateCount {
+			return 0, fmt.Errorf("minimum plan version validation exceeded the %d-state limit", v.maxStateCount)
+		}
+		v.states[key] = struct{}{}
+	}
+
+	maxVersion, err := callMinimumRequiredPlanVersion(node, timeRange)
 	if err != nil {
 		return 0, err
 	}
 
-	childTimeRange := node.ChildrenTimeRange(timeRange)
+	childTimeRange, err := callChildrenTimeRange(node, timeRange)
+	if err != nil {
+		return 0, err
+	}
 	for child := range ChildrenIter(node) {
-		childVersion, err := MinimumRequiredPlanVersion(child, childTimeRange)
+		childVersion, err := v.minimumRequiredPlanVersion(child, childTimeRange)
 		if err != nil {
 			return 0, err
 		}
@@ -381,7 +422,28 @@ func MinimumRequiredPlanVersion(node Node, timeRange types.QueryTimeRange) (Quer
 		maxVersion = max(maxVersion, childVersion)
 	}
 
+	v.memo[key] = maxVersion
 	return maxVersion, nil
+}
+
+func callMinimumRequiredPlanVersion(node Node, timeRange types.QueryTimeRange) (version QueryPlanVersion, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("node %T minimum plan version panicked: %v", node, recovered)
+		}
+	}()
+
+	return node.MinimumRequiredPlanVersion(timeRange)
+}
+
+func callChildrenTimeRange(node Node, timeRange types.QueryTimeRange) (childTimeRange types.QueryTimeRange, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("node %T child time range panicked: %v", node, recovered)
+		}
+	}()
+
+	return node.ChildrenTimeRange(timeRange), nil
 }
 
 type queryPlanEncoder struct {
@@ -455,22 +517,85 @@ func NodeTypeName(n Node) string {
 
 // DecodeNodes decodes nodes for the provided nodeIndices from the encoded plan.
 func (p *EncodedQueryPlan) DecodeNodes(nodeIndices ...int64) ([]Node, error) {
+	return p.decodeNodes(nodeIndices, nil, true)
+}
+
+// DecodeNodesWithTimeRanges decodes each node with its effective query time range.
+// It reuses version checks across shared subgraphs.
+func (p *EncodedQueryPlan) DecodeNodesWithTimeRanges(nodeIndices []int64, timeRanges []types.QueryTimeRange) ([]Node, error) {
+	if len(nodeIndices) != len(timeRanges) {
+		return nil, fmt.Errorf("node index count %d does not match time range count %d", len(nodeIndices), len(timeRanges))
+	}
+	return p.decodeNodes(nodeIndices, timeRanges, false)
+}
+
+func (p *EncodedQueryPlan) decodeNodes(nodeIndices []int64, timeRanges []types.QueryTimeRange, useEncodedTimeRange bool) ([]Node, error) {
 	if p.Version > MaximumSupportedQueryPlanVersion {
 		return nil, apierror.Newf(apierror.TypeNotAcceptable, "query plan has version %v, but the maximum supported query plan version is %v", p.Version, MaximumSupportedQueryPlanVersion)
 	}
 
+	maxValidationStates, err := minimumVersionValidationStateLimit(len(p.Nodes), len(nodeIndices))
+	if err != nil {
+		return nil, fmt.Errorf("calculate minimum plan version validation state limit: %w", err)
+	}
+
 	decoder := newQueryPlanDecoder(p.Nodes)
+	validator := newMinimumRequiredPlanVersionValidator(maxValidationStates)
+	var encodedTimeRange types.QueryTimeRange
+	encodedTimeRangeDecoded := false
 
 	nodes := make([]Node, 0, len(nodeIndices))
-	for _, idx := range nodeIndices {
+	for i, idx := range nodeIndices {
 		n, err := decoder.decodeNode(idx)
 		if err != nil {
 			return nil, err
 		}
+
+		var timeRange types.QueryTimeRange
+		if useEncodedTimeRange {
+			if !encodedTimeRangeDecoded {
+				encodedTimeRange, err = decodeEncodedQueryTimeRange(p.TimeRange)
+				if err != nil {
+					return nil, fmt.Errorf("decode query time range: %w", err)
+				}
+				encodedTimeRangeDecoded = true
+			}
+			timeRange = encodedTimeRange
+		} else {
+			timeRange = timeRanges[i]
+		}
+		minimumVersion, err := validator.minimumRequiredPlanVersion(n, timeRange)
+		if err != nil {
+			return nil, fmt.Errorf("validate decoded node %d: %w", idx, err)
+		}
+		if p.Version < minimumVersion {
+			return nil, apierror.Newf(apierror.TypeNotAcceptable, "query plan has version %v, but decoded node %v requires version %v", p.Version, idx, minimumVersion)
+		}
+
 		nodes = append(nodes, n)
 	}
 
 	return nodes, nil
+}
+
+func decodeEncodedQueryTimeRange(encoded types.EncodedQueryTimeRange) (types.QueryTimeRange, error) {
+	if encoded == (types.EncodedQueryTimeRange{}) {
+		return types.QueryTimeRange{}, nil
+	}
+	if !encoded.IsInstant && encoded.IntervalMilliseconds == 0 {
+		return types.QueryTimeRange{}, errors.New("non-instant query time range has a zero interval")
+	}
+
+	return encoded.Decode(), nil
+}
+
+func minimumVersionValidationStateLimit(nodeCount, rootCount int) (int, error) {
+	maxInt := int(^uint(0) >> 1)
+	if nodeCount > maxInt-rootCount {
+		return 0, fmt.Errorf("node count %d and root count %d overflow the state limit", nodeCount, rootCount)
+	}
+
+	return nodeCount + rootCount, nil
 }
 
 func (p *EncodedQueryPlan) DecodeParameters() *QueryParameters {
@@ -485,12 +610,14 @@ func (p *EncodedQueryPlan) DecodeParameters() *QueryParameters {
 type queryPlanDecoder struct {
 	encodedNodes []*EncodedNode
 	nodes        []Node
+	decoding     []bool
 }
 
 func newQueryPlanDecoder(encodedNodes []*EncodedNode) *queryPlanDecoder {
 	return &queryPlanDecoder{
 		encodedNodes: encodedNodes,
 		nodes:        make([]Node, len(encodedNodes)),
+		decoding:     make([]bool, len(encodedNodes)),
 	}
 }
 
@@ -502,6 +629,13 @@ func (d *queryPlanDecoder) decodeNode(idx int64) (Node, error) {
 	if d.nodes[idx] != nil {
 		return d.nodes[idx], nil
 	}
+	if d.decoding[idx] {
+		return nil, fmt.Errorf("cycle detected while decoding node index %d", idx)
+	}
+	d.decoding[idx] = true
+	defer func() {
+		d.decoding[idx] = false
+	}()
 
 	encodedNode := d.encodedNodes[idx]
 	children := make([]Node, 0, len(encodedNode.Children))

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -625,7 +625,7 @@ func newQueryPlanDecoder(encodedNodes []*EncodedNode) *queryPlanDecoder {
 	return &queryPlanDecoder{
 		encodedNodes: encodedNodes,
 		nodes:        make([]Node, len(encodedNodes)),
-		decoding:     make([]bool, len(encodedNodes)),
+		decoding:     make([]bool, len(encodedNodes)), // ignoreunpooledslice: Plan decoding runs before query memory tracking becomes available.
 	}
 }
 

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -384,6 +384,9 @@ type minimumRequiredPlanVersionValidator struct {
 	maxStateCount int
 }
 
+// maxAdditionalMinimumVersionValidationStates supports shared ranges while bounding validation work from compact DAGs.
+const maxAdditionalMinimumVersionValidationStates = 16 * 1024
+
 func newMinimumRequiredPlanVersionValidator(maxStateCount int) *minimumRequiredPlanVersionValidator {
 	return &minimumRequiredPlanVersionValidator{
 		memo:          make(map[minimumRequiredPlanVersionMemoKey]QueryPlanVersion),
@@ -595,7 +598,12 @@ func minimumVersionValidationStateLimit(nodeCount, rootCount int) (int, error) {
 		return 0, fmt.Errorf("node count %d and root count %d overflow the state limit", nodeCount, rootCount)
 	}
 
-	return nodeCount + rootCount, nil
+	structuralStateCount := nodeCount + rootCount
+	if structuralStateCount > maxInt-maxAdditionalMinimumVersionValidationStates {
+		return maxInt, nil
+	}
+
+	return structuralStateCount + maxAdditionalMinimumVersionValidationStates, nil
 }
 
 func (p *EncodedQueryPlan) DecodeParameters() *QueryParameters {

--- a/pkg/streamingpromql/planning/plan_test.go
+++ b/pkg/streamingpromql/planning/plan_test.go
@@ -280,6 +280,59 @@ func TestMinimumRequiredPlanVersionMemoizesSharedDAG(t *testing.T) {
 	})
 }
 
+func TestMinimumRequiredPlanVersionBoundsStates(t *testing.T) {
+	validator := newMinimumRequiredPlanVersionValidator(1)
+	timeRange := types.NewInstantQueryTimeRange(time.Now())
+
+	_, err := validator.minimumRequiredPlanVersion(&testNode{}, timeRange)
+	require.NoError(t, err)
+
+	_, err = validator.minimumRequiredPlanVersion(&testNode{}, timeRange)
+	require.EqualError(t, err, "minimum plan version validation exceeded the 1-state limit")
+}
+
+func TestMinimumVersionValidationStateLimit(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	testCases := map[string]struct {
+		nodeCount     int
+		rootCount     int
+		expected      int
+		expectedError string
+	}{
+		"empty plan": {
+			expected: maxAdditionalMinimumVersionValidationStates,
+		},
+		"structural states": {
+			nodeCount: 6,
+			rootCount: 1,
+			expected:  6 + 1 + maxAdditionalMinimumVersionValidationStates,
+		},
+		"additional states saturate": {
+			nodeCount: maxInt - 1,
+			rootCount: 1,
+			expected:  maxInt,
+		},
+		"structural states overflow": {
+			nodeCount:     maxInt,
+			rootCount:     1,
+			expectedError: fmt.Sprintf("node count %d and root count 1 overflow the state limit", maxInt),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := minimumVersionValidationStateLimit(testCase.nodeCount, testCase.rootCount)
+			if testCase.expectedError != "" {
+				require.EqualError(t, err, testCase.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
 func TestDecodeEncodedQueryTimeRangePreservesZeroValue(t *testing.T) {
 	decoded, err := decodeEncodedQueryTimeRange(types.EncodedQueryTimeRange{})
 	require.NoError(t, err)

--- a/pkg/streamingpromql/planning/plan_test.go
+++ b/pkg/streamingpromql/planning/plan_test.go
@@ -69,6 +69,8 @@ type testNode struct {
 	children                   []Node
 	description                string
 	minimumRequiredPlanVersion QueryPlanVersion
+	minimumVersionCalls        int
+	childrenTimeRange          *types.QueryTimeRange
 }
 
 func (t *testNode) Describe() string {
@@ -123,6 +125,9 @@ func (t *testNode) EquivalentToIgnoringHintsAndChildren(_ Node) bool {
 func (t *testNode) MergeHints(_ Node) error { panic("not supported") }
 
 func (t *testNode) ChildrenTimeRange(timeRange types.QueryTimeRange) types.QueryTimeRange {
+	if t.childrenTimeRange != nil {
+		return *t.childrenTimeRange
+	}
 	return timeRange
 }
 
@@ -139,6 +144,7 @@ func (t *testNode) ExpressionPosition() (posrange.PositionRange, error) {
 }
 
 func (t *testNode) MinimumRequiredPlanVersion(types.QueryTimeRange) (QueryPlanVersion, error) {
+	t.minimumVersionCalls++
 	return t.minimumRequiredPlanVersion, nil
 }
 
@@ -224,6 +230,60 @@ func TestQueryPlanVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMinimumRequiredPlanVersionMemoizesSharedDAG(t *testing.T) {
+	timeRange := types.NewInstantQueryTimeRange(time.Now())
+
+	t.Run("shared nodes with the same time range", func(t *testing.T) {
+		sharedNodes := []*testNode{{minimumRequiredPlanVersion: QueryPlanV20}}
+		shared := Node(sharedNodes[0])
+		for range 20 {
+			parent := &testNode{children: []Node{shared, shared}}
+			sharedNodes = append(sharedNodes, parent)
+			shared = parent
+		}
+
+		roots := []*testNode{
+			{children: []Node{shared}},
+			{children: []Node{shared}},
+		}
+		validator := newMinimumRequiredPlanVersionValidator(-1)
+		for _, root := range roots {
+			version, err := validator.minimumRequiredPlanVersion(root, timeRange)
+			require.NoError(t, err)
+			require.Equal(t, QueryPlanV20, version)
+		}
+
+		for _, node := range sharedNodes {
+			require.Equal(t, 1, node.minimumVersionCalls)
+		}
+	})
+
+	t.Run("shared nodes with different time ranges", func(t *testing.T) {
+		firstChildTimeRange := timeRange
+		secondChildTimeRange := timeRange
+		secondChildTimeRange.StartT++
+		secondChildTimeRange.EndT++
+		shared := &testNode{minimumRequiredPlanVersion: QueryPlanV20}
+		roots := []*testNode{
+			{children: []Node{shared}, childrenTimeRange: &firstChildTimeRange},
+			{children: []Node{shared}, childrenTimeRange: &secondChildTimeRange},
+		}
+		validator := newMinimumRequiredPlanVersionValidator(-1)
+		for _, root := range roots {
+			version, err := validator.minimumRequiredPlanVersion(root, timeRange)
+			require.NoError(t, err)
+			require.Equal(t, QueryPlanV20, version)
+		}
+		require.Equal(t, 2, shared.minimumVersionCalls)
+	})
+}
+
+func TestDecodeEncodedQueryTimeRangePreservesZeroValue(t *testing.T) {
+	decoded, err := decodeEncodedQueryTimeRange(types.EncodedQueryTimeRange{})
+	require.NoError(t, err)
+	require.Equal(t, types.QueryTimeRange{}, decoded)
 }
 
 func TestQueriedTimeRange_Union(t *testing.T) {

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -2136,6 +2136,348 @@ func TestDecodingInvalidPlan(t *testing.T) {
 	}
 }
 
+func TestDecodeNodesValidatesFill(t *testing.T) {
+	testCases := map[string]struct {
+		version        planning.QueryPlanVersion
+		op             core.BinaryOperation
+		card           parser.VectorMatchCardinality
+		lhsType        parser.ValueType
+		rhsType        parser.ValueType
+		on             bool
+		matchingLabels []string
+		includeLabels  []string
+		expectedError  string
+	}{
+		"one-to-one fill at V20": {
+			version: planning.QueryPlanV20,
+			op:      core.BINARY_ADD,
+			card:    parser.CardOneToOne,
+			lhsType: parser.ValueTypeVector,
+			rhsType: parser.ValueTypeVector,
+		},
+		"group_right fill at V21": {
+			version: planning.QueryPlanV21,
+			op:      core.BINARY_ADD,
+			card:    parser.CardOneToMany,
+			lhsType: parser.ValueTypeVector,
+			rhsType: parser.ValueTypeVector,
+		},
+		"group_left fill at V21": {
+			version: planning.QueryPlanV21,
+			op:      core.BINARY_ADD,
+			card:    parser.CardManyToOne,
+			lhsType: parser.ValueTypeVector,
+			rhsType: parser.ValueTypeVector,
+		},
+		"one-to-one fill below V20": {
+			version:       planning.QueryPlanV19,
+			op:            core.BINARY_ADD,
+			card:          parser.CardOneToOne,
+			lhsType:       parser.ValueTypeVector,
+			rhsType:       parser.ValueTypeVector,
+			expectedError: "query plan has version 19, but decoded node 2 requires version 20",
+		},
+		"group_right fill below V21": {
+			version:       planning.QueryPlanV20,
+			op:            core.BINARY_ADD,
+			card:          parser.CardOneToMany,
+			lhsType:       parser.ValueTypeVector,
+			rhsType:       parser.ValueTypeVector,
+			expectedError: "query plan has version 20, but decoded node 2 requires version 21",
+		},
+		"fill with on __name__": {
+			version:        planning.QueryPlanV21,
+			op:             core.BINARY_ADD,
+			card:           parser.CardOneToMany,
+			lhsType:        parser.ValueTypeVector,
+			rhsType:        parser.ValueTypeVector,
+			on:             true,
+			matchingLabels: []string{"__name__"},
+			expectedError:  "validate decoded node 2: fill does not support __name__ in on matching",
+		},
+		"fill with label in on and include": {
+			version:        planning.QueryPlanV21,
+			op:             core.BINARY_ADD,
+			card:           parser.CardManyToOne,
+			lhsType:        parser.ValueTypeVector,
+			rhsType:        parser.ValueTypeVector,
+			on:             true,
+			matchingLabels: []string{"cluster", "namespace"},
+			includeLabels:  []string{"namespace", "pod"},
+			expectedError:  `validate decoded node 2: fill label "namespace" appears in both on and include`,
+		},
+		"set fill": {
+			version:       planning.QueryPlanV21,
+			op:            core.BINARY_LOR,
+			card:          parser.CardManyToMany,
+			lhsType:       parser.ValueTypeVector,
+			rhsType:       parser.ValueTypeVector,
+			expectedError: `validate decoded node 2: binary operation "or" does not support fill`,
+		},
+		"vector-scalar fill": {
+			version:       planning.QueryPlanV21,
+			op:            core.BINARY_ADD,
+			card:          parser.CardOneToOne,
+			lhsType:       parser.ValueTypeVector,
+			rhsType:       parser.ValueTypeScalar,
+			expectedError: "validate decoded node 2: fill requires vector-vector operands, got vector-scalar",
+		},
+		"scalar-vector fill": {
+			version:       planning.QueryPlanV21,
+			op:            core.BINARY_ADD,
+			card:          parser.CardOneToOne,
+			lhsType:       parser.ValueTypeScalar,
+			rhsType:       parser.ValueTypeVector,
+			expectedError: "validate decoded node 2: fill requires vector-vector operands, got scalar-vector",
+		},
+		"scalar-scalar fill": {
+			version:       planning.QueryPlanV21,
+			op:            core.BINARY_ADD,
+			card:          parser.CardOneToOne,
+			lhsType:       parser.ValueTypeScalar,
+			rhsType:       parser.ValueTypeScalar,
+			expectedError: "validate decoded node 2: fill requires vector-vector operands, got scalar-scalar",
+		},
+	}
+
+	encodeOperand := func(valueType parser.ValueType) *planning.EncodedNode {
+		if valueType == parser.ValueTypeScalar {
+			return &planning.EncodedNode{
+				NodeType: planning.NODE_TYPE_NUMBER_LITERAL,
+				Details:  marshalDetails(&core.NumberLiteralDetails{Value: 1}),
+			}
+		}
+
+		return &planning.EncodedNode{
+			NodeType: planning.NODE_TYPE_VECTOR_SELECTOR,
+			Details:  marshalDetails(&core.VectorSelectorDetails{}),
+		}
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			encoded := &planning.EncodedQueryPlan{
+				TimeRange: timeRange.Encode(),
+				Version:   testCase.version,
+				RootNode:  2,
+				Nodes: []*planning.EncodedNode{
+					encodeOperand(testCase.lhsType),
+					encodeOperand(testCase.rhsType),
+					{
+						NodeType: planning.NODE_TYPE_BINARY_EXPRESSION,
+						Details: marshalDetails(&core.BinaryExpressionDetails{
+							Op: testCase.op,
+							VectorMatching: &core.VectorMatching{
+								Card:           testCase.card,
+								On:             testCase.on,
+								MatchingLabels: testCase.matchingLabels,
+								Include:        testCase.includeLabels,
+								FillValues:     core.VectorMatchFillValues{LhsSet: true},
+							},
+						}),
+						Children: []int64{0, 1},
+					},
+				},
+			}
+
+			nodes, err := encoded.DecodeNodes(encoded.RootNode)
+			if testCase.expectedError != "" {
+				require.EqualError(t, err, testCase.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, nodes, 1)
+		})
+	}
+}
+
+func TestDecodeNodesWithTimeRanges(t *testing.T) {
+	timeRange := types.NewInstantQueryTimeRange(time.Now())
+	encoded := &planning.EncodedQueryPlan{
+		TimeRange: timeRange.Encode(),
+		Nodes: []*planning.EncodedNode{
+			{
+				NodeType: planning.NODE_TYPE_NUMBER_LITERAL,
+				Details:  marshalDetails(&core.NumberLiteralDetails{Value: 1}),
+			},
+			{
+				NodeType: planning.NODE_TYPE_NUMBER_LITERAL,
+				Details:  marshalDetails(&core.NumberLiteralDetails{Value: 2}),
+			},
+		},
+	}
+
+	secondTimeRange := timeRange
+	secondTimeRange.StartT++
+	secondTimeRange.EndT++
+	nodes, err := encoded.DecodeNodesWithTimeRanges(
+		[]int64{0, 1},
+		[]types.QueryTimeRange{timeRange, secondTimeRange},
+	)
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+
+	testCases := map[string]struct {
+		nodeIndices []int64
+		timeRanges  []types.QueryTimeRange
+		expected    string
+	}{
+		"missing time range": {
+			nodeIndices: []int64{0, 1},
+			timeRanges:  []types.QueryTimeRange{timeRange},
+			expected:    "node index count 2 does not match time range count 1",
+		},
+		"extra time range": {
+			nodeIndices: []int64{0},
+			timeRanges:  []types.QueryTimeRange{timeRange, secondTimeRange},
+			expected:    "node index count 1 does not match time range count 2",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, err := encoded.DecodeNodesWithTimeRanges(testCase.nodeIndices, testCase.timeRanges)
+			require.EqualError(t, err, testCase.expected)
+		})
+	}
+}
+
+func TestDecodeNodesValidatesEncodedTimeRange(t *testing.T) {
+	encodedNode := &planning.EncodedNode{
+		NodeType: planning.NODE_TYPE_NUMBER_LITERAL,
+		Details:  marshalDetails(&core.NumberLiteralDetails{Value: 1}),
+	}
+
+	testCases := map[string]struct {
+		timeRange     types.EncodedQueryTimeRange
+		expectedError string
+	}{
+		"compatible zero value": {},
+		"non-instant range with zero interval": {
+			timeRange: types.EncodedQueryTimeRange{
+				StartT: 1,
+				EndT:   2,
+			},
+			expectedError: "decode query time range: non-instant query time range has a zero interval",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			encoded := &planning.EncodedQueryPlan{
+				TimeRange: testCase.timeRange,
+				Nodes:     []*planning.EncodedNode{encodedNode},
+			}
+
+			nodes, err := encoded.DecodeNodes(0)
+			if testCase.expectedError != "" {
+				require.EqualError(t, err, testCase.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, nodes, 1)
+		})
+	}
+}
+
+func TestDecodeNodesRejectsZeroStepSubquery(t *testing.T) {
+	timeRange := types.NewInstantQueryTimeRange(time.Now())
+	encoded := &planning.EncodedQueryPlan{
+		TimeRange: timeRange.Encode(),
+		Nodes: []*planning.EncodedNode{
+			{
+				NodeType: planning.NODE_TYPE_NUMBER_LITERAL,
+				Details:  marshalDetails(&core.NumberLiteralDetails{Value: 1}),
+			},
+			{
+				NodeType: planning.NODE_TYPE_SUBQUERY,
+				Details: marshalDetails(&core.SubqueryDetails{
+					Range: time.Minute,
+					Step:  0,
+				}),
+				Children: []int64{0},
+			},
+		},
+	}
+
+	_, err := encoded.DecodeNodes(1)
+	require.ErrorContains(t, err, "validate decoded node 1")
+	require.ErrorContains(t, err, "node *core.Subquery child time range panicked")
+}
+
+func TestDecodeNodesRejectsCyclicGraph(t *testing.T) {
+	encoded := &planning.EncodedQueryPlan{
+		Nodes: []*planning.EncodedNode{
+			{
+				NodeType: planning.NODE_TYPE_BINARY_EXPRESSION,
+				Children: []int64{0, 0},
+			},
+		},
+	}
+
+	_, err := encoded.DecodeNodes(encoded.RootNode)
+	require.EqualError(t, err, "cycle detected while decoding node index 0")
+}
+
+func TestDecodeNodesBoundsDistinctMinimumVersionStates(t *testing.T) {
+	timeRange := types.NewInstantQueryTimeRange(time.Now())
+	encoded := &planning.EncodedQueryPlan{
+		TimeRange: timeRange.Encode(),
+		Nodes: []*planning.EncodedNode{
+			{
+				NodeType: planning.NODE_TYPE_NUMBER_LITERAL,
+				Details:  marshalDetails(&core.NumberLiteralDetails{Value: 1}),
+			},
+			{
+				NodeType: planning.NODE_TYPE_SUBQUERY,
+				Details: marshalDetails(&core.SubqueryDetails{
+					Range: time.Minute,
+					Step:  time.Second,
+				}),
+				Children: []int64{0},
+			},
+			{
+				NodeType: planning.NODE_TYPE_SUBQUERY,
+				Details: marshalDetails(&core.SubqueryDetails{
+					Offset: time.Second,
+					Range:  time.Minute,
+					Step:   time.Second,
+				}),
+				Children: []int64{0},
+			},
+			{
+				NodeType: planning.NODE_TYPE_SUBQUERY,
+				Details: marshalDetails(&core.SubqueryDetails{
+					Offset: 2 * time.Second,
+					Range:  time.Minute,
+					Step:   time.Second,
+				}),
+				Children: []int64{0},
+			},
+			{
+				NodeType: planning.NODE_TYPE_BINARY_EXPRESSION,
+				Details: marshalDetails(&core.BinaryExpressionDetails{
+					Op: core.BINARY_ADD,
+				}),
+				Children: []int64{1, 2},
+			},
+			{
+				NodeType: planning.NODE_TYPE_BINARY_EXPRESSION,
+				Details: marshalDetails(&core.BinaryExpressionDetails{
+					Op: core.BINARY_ADD,
+				}),
+				Children: []int64{4, 3},
+			},
+		},
+	}
+
+	_, err := encoded.DecodeNodes(5)
+	require.EqualError(t, err, "validate decoded node 5: minimum plan version validation exceeded the 7-state limit")
+}
+
 func requireHistogramCounts(t *testing.T, reg *prometheus.Registry, name string, expected string) {
 	metrics := getMetrics(t, reg, name)
 	builder := &strings.Builder{}

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -2422,7 +2422,7 @@ func TestDecodeNodesRejectsCyclicGraph(t *testing.T) {
 	require.EqualError(t, err, "cycle detected while decoding node index 0")
 }
 
-func TestDecodeNodesBoundsDistinctMinimumVersionStates(t *testing.T) {
+func TestDecodeNodesAcceptsSharedDAGWithDistinctEffectiveRanges(t *testing.T) {
 	timeRange := types.NewInstantQueryTimeRange(time.Now())
 	encoded := &planning.EncodedQueryPlan{
 		TimeRange: timeRange.Encode(),
@@ -2474,8 +2474,9 @@ func TestDecodeNodesBoundsDistinctMinimumVersionStates(t *testing.T) {
 		},
 	}
 
-	_, err := encoded.DecodeNodes(5)
-	require.EqualError(t, err, "validate decoded node 5: minimum plan version validation exceeded the 7-state limit")
+	nodes, err := encoded.DecodeNodes(5)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
 }
 
 func requireHistogramCounts(t *testing.T, reg *prometheus.Registry, name string, expected string) {

--- a/pkg/streamingpromql/testdata/ours/binary_operators_fill.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators_fill.test
@@ -619,12 +619,35 @@ load 5m
   duplicate_many{key="a", pod="p1"} 1
   duplicate_one_a{key="a"} 10
   duplicate_one_b{key="a"} 20
+  unmatched_duplicate_many{key="a", pod="p1"} 1
+  unmatched_duplicate_one_a{key="b"} 10
+  unmatched_duplicate_one_b{key="b"} 20
+  unmatched_disjoint_many{key="a", pod="p1"} 1 2
+  unmatched_disjoint_one_a{key="b"} 10 _
+  unmatched_disjoint_one_b{key="b"} _ 20
+  unmatched_disjoint_one_c{key="c"} 30 _
+  unmatched_disjoint_one_d{key="c"} _ 40
 
 eval_fail instant at 0 duplicate_many + on(key) group_left fill(0) {__name__=~"duplicate_one_a|duplicate_one_b"}
   expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
 
 eval_fail instant at 0 {__name__=~"duplicate_one_a|duplicate_one_b"} + on(key) group_right fill(0) duplicate_many
   expected_fail_regexp found duplicate series for the match group .* on the left (hand-)?side of the operation
+
+eval_fail instant at 0 unmatched_duplicate_many + on(key) group_left fill_right(0) {__name__=~"unmatched_duplicate_one_a|unmatched_duplicate_one_b"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+eval_fail instant at 0 {__name__=~"unmatched_duplicate_one_a|unmatched_duplicate_one_b"} + on(key) group_right fill_left(0) unmatched_duplicate_many
+  expected_fail_regexp found duplicate series for the match group .* on the left (hand-)?side of the operation
+
+eval_fail instant at 0 nonexistent + on(key) group_left fill_right(0) {__name__=~"unmatched_duplicate_one_a|unmatched_duplicate_one_b"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+eval_fail instant at 0 nonexistent + on(key) group_left fill_left(0) {__name__=~"unmatched_duplicate_one_a|unmatched_duplicate_one_b"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+eval range from 0 to 5m step 5m unmatched_disjoint_many + on(key) group_left fill_right(0) {__name__=~"unmatched_disjoint_one_.+"}
+  {key="a", pod="p1"} 1 2
 
 # ---------- Grouped output labels and metric names ----------
 

--- a/pkg/streamingpromql/testdata/ours/binary_operators_fill.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators_fill.test
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# These tests exercise the experimental one-to-one 'fill', 'fill_left' and 'fill_right' binary
-# operator modifiers. Grouped (group_left/group_right) fills are not covered here.
+# These tests exercise fill, fill_left, and fill_right binary operator modifiers.
 #
 # Semantics reference:
 # https://promlabs.com/blog/2026/03/05/filling-in-missing-series-in-binary-operator-matching/.
@@ -452,3 +451,202 @@ load 5m
 
 eval range from 0 to 20m step 5m {__name__=~"churned_a|churned_b"} + fill_right(0) missing_metric
   {label="x"} 1 _ _ _ 2
+
+# ---------- Grouped fill combinations ----------
+
+clear
+
+load 5m
+  grouped_many{key="a", pod="p1"} 10
+  grouped_many{key="a", pod="p2"} 20
+  grouped_many{key="b", pod="p3"} 30
+  grouped_one{key="a", owner="team-a"} 100
+  grouped_one{key="c", owner="team-c"} 300
+
+# group_left fill_right fills the missing one side.
+eval instant at 0 grouped_many + on(key) group_left(owner) fill_right(7) grouped_one
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="b", pod="p3"} 37
+
+# group_left fill_left fills the missing many side.
+eval instant at 0 grouped_many + on(key) group_left(owner) fill_left(5) grouped_one
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="c", owner="team-c"} 305
+
+# group_left fill fills both missing sides.
+eval instant at 0 grouped_many + on(key) group_left(owner) fill(0) grouped_one
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="b", pod="p3"} 30
+  {key="c", owner="team-c"} 300
+
+# Distinct values cover the combined modifier grammar.
+eval instant at 0 grouped_many + on(key) group_left(owner) fill_left(5) fill_right(7) grouped_one
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="b", pod="p3"} 37
+  {key="c", owner="team-c"} 305
+
+# group_right fill_left fills the missing many side.
+eval instant at 0 grouped_one + on(key) group_right(owner) fill_left(7) grouped_many
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="c", owner="team-c"} 307
+
+# group_right fill_right fills the missing one side.
+eval instant at 0 grouped_one + on(key) group_right(owner) fill_right(5) grouped_many
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="b", pod="p3"} 35
+
+# group_right fill fills both missing sides.
+eval instant at 0 grouped_one + on(key) group_right(owner) fill(0) grouped_many
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="b", pod="p3"} 30
+  {key="c", owner="team-c"} 300
+
+# Distinct values verify operand orientation after side normalization.
+eval instant at 0 grouped_one + on(key) group_right(owner) fill_left(7) fill_right(5) grouped_many
+  {key="a", owner="team-a", pod="p1"} 110
+  {key="a", owner="team-a", pod="p2"} 120
+  {key="b", pod="p3"} 35
+  {key="c", owner="team-c"} 307
+
+# ---------- Grouped empty sides ----------
+
+clear
+
+load 5m
+  empty_many{key="a", pod="p1"} 10
+  empty_many{key="b", pod="p2"} 20
+  empty_one{key="a"} 100
+  empty_one{key="b"} 200
+
+eval instant at 0 empty_many + on(key) group_left fill_right(3) nonexistent
+  {key="a", pod="p1"} 13
+  {key="b", pod="p2"} 23
+
+eval instant at 0 empty_many + on(key) group_left fill_left(3) nonexistent
+
+eval instant at 0 nonexistent + on(key) group_left fill_left(3) empty_one
+  {key="a"} 103
+  {key="b"} 203
+
+eval instant at 0 nonexistent + on(key) group_left fill_right(3) empty_one
+
+eval instant at 0 nonexistent + on(key) group_right fill_left(3) empty_many
+
+eval instant at 0 nonexistent + on(key) group_right fill_right(3) empty_many
+  {key="a", pod="p1"} 13
+  {key="b", pod="p2"} 23
+
+eval instant at 0 empty_one + on(key) group_right fill_right(3) nonexistent
+
+eval instant at 0 empty_one + on(key) group_right fill_left(3) nonexistent
+  {key="a"} 103
+  {key="b"} 203
+
+# ---------- Grouped intermittent range queries ----------
+
+clear
+
+load 5m
+  range_many{key="a", pod="p1"} 1 _ 3 _ 5
+  range_many{key="a", pod="p2"} _ 20 _ 40 _
+  range_many{key="b", pod="p3"} 9 _ _ 12 _
+  range_one{key="a"} _ 200 _ 400 _
+  range_one{key="c"} 1000 _ _ 4000 5000
+
+eval range from 0 to 20m step 5m range_many + on(key) group_left fill(0) range_one
+  {key="a", pod="p1"} 1 _ 3 _ 5
+  {key="a", pod="p2"} _ 220 _ 440 _
+  {key="b", pod="p3"} 9 _ _ 12 _
+  {key="c"} 1000 _ _ 4000 5000
+
+eval range from 0 to 20m step 5m range_one + on(key) group_right fill(0) range_many
+  {key="a", pod="p1"} 1 _ 3 _ 5
+  {key="a", pod="p2"} _ 220 _ 440 _
+  {key="b", pod="p3"} 9 _ _ 12 _
+  {key="c"} 1000 _ _ 4000 5000
+
+# ---------- Grouped special float values ----------
+
+eval range from 0 to 20m step 5m range_many + on(key) group_left fill(NaN) range_one
+  {key="a", pod="p1"} NaN _ NaN _ NaN
+  {key="a", pod="p2"} _ 220 _ 440 _
+  {key="b", pod="p3"} NaN _ _ NaN _
+  {key="c"} NaN _ _ NaN NaN
+
+eval range from 0 to 20m step 5m range_one + on(key) group_right fill(Inf) range_many
+  {key="a", pod="p1"} +Inf _ +Inf _ +Inf
+  {key="a", pod="p2"} _ 220 _ 440 _
+  {key="b", pod="p3"} +Inf _ _ +Inf _
+  {key="c"} +Inf _ _ +Inf +Inf
+
+eval instant at 0 range_many + on(key) group_left fill(-Inf) range_one
+  {key="a", pod="p1"} -Inf
+  {key="b", pod="p3"} -Inf
+  {key="c"} -Inf
+
+# ---------- Grouped histograms and annotations ----------
+
+clear
+
+load 5m
+  hist_many{key="a", pod="p1"} {{schema:0 sum:2 count:2}}
+  hist_many{key="b", pod="p2"} {{schema:0 sum:3 count:3}}
+  hist_one{key="a"} {{schema:0 sum:5 count:5}}
+  hist_one{key="c"} {{schema:0 sum:7 count:7}}
+
+eval instant at 0 hist_many + on(key) group_left fill_right(0) hist_one
+  {key="a", pod="p1"} {{schema:0 sum:7 count:7}}
+  expect info msg: PromQL info: incompatible sample types encountered for binary operator "+": histogram + float (1:1)
+  expect no_warn
+
+eval instant at 0 hist_one + on(key) group_right fill_left(0) hist_many
+  {key="a", pod="p1"} {{schema:0 sum:7 count:7}}
+  expect info msg: PromQL info: incompatible sample types encountered for binary operator "+": histogram + float (1:1)
+  expect no_warn
+
+# ---------- Grouped duplicate-group errors ----------
+
+clear
+
+load 5m
+  duplicate_many{key="a", pod="p1"} 1
+  duplicate_one_a{key="a"} 10
+  duplicate_one_b{key="a"} 20
+
+eval_fail instant at 0 duplicate_many + on(key) group_left fill(0) {__name__=~"duplicate_one_a|duplicate_one_b"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+eval_fail instant at 0 {__name__=~"duplicate_one_a|duplicate_one_b"} + on(key) group_right fill(0) duplicate_many
+  expected_fail_regexp found duplicate series for the match group .* on the left (hand-)?side of the operation
+
+# ---------- Grouped output labels and metric names ----------
+
+clear
+
+load 5m
+  named_many{key="a", pod="p1"} 10
+  named_many{key="b", pod="p2"} 20
+  named_one{key="a", owner="team-a"} 1
+  named_one{key="c", owner="team-c"} 3
+
+eval instant at 0 named_many != on(key) group_left(owner) fill(0) named_one
+  named_many{key="a", owner="team-a", pod="p1"} 10
+  named_many{key="b", pod="p2"} 20
+  {key="c", owner="team-c"} 0
+
+eval instant at 0 named_many != bool on(key) group_left(owner) fill(0) named_one
+  {key="a", owner="team-a", pod="p1"} 1
+  {key="b", pod="p2"} 1
+  {key="c", owner="team-c"} 1
+
+eval instant at 0 named_one != on(key) group_right(owner) fill(0) named_many
+  named_many{key="a", owner="team-a", pod="p1"} 1
+  named_many{key="b", pod="p2"} 0
+  {key="c", owner="team-c"} 3

--- a/pkg/streamingpromql/testdata/upstream/fill-modifier.test
+++ b/pkg/streamingpromql/testdata/upstream/fill-modifier.test
@@ -133,12 +133,11 @@ eval instant at 0m left_vector + on(job, instance) fill_left(0) right_vector
 
 # fill with ignoring() - requires group_left since ignoring(job) creates many-to-one matching
 # when two left_vector series have same instance but different jobs.
-# Unsupported by streaming engine.
-# eval instant at 0m left_vector + ignoring(job) group_left fill(0) right_vector
-#   {instance="a", job="foo"} 110
-#   {instance="a", job="bar"} 130
-#   {instance="b", job="foo"} 20
-#   {instance="c"} 300
+eval instant at 0m left_vector + ignoring(job) group_left fill(0) right_vector
+  {instance="a", job="foo"} 110
+  {instance="a", job="bar"} 130
+  {instance="b", job="foo"} 20
+  {instance="c"} 300
 
 # ---------- fill with group_left / group_right (many-to-one / one-to-many) ----------
 
@@ -154,31 +153,28 @@ load 5m
   limits{status="500"} 50
 
 # group_left with fill_right: fill missing "one" side series.
-# Unsupported by streaming engine.
-# eval instant at 0m requests / on(status) group_left fill_right(1) limits
-#   {method="GET", status="200"} 0.1
-#   {method="POST", status="200"} 0.2
-#   {method="GET", status="500"} 0.2
-#   {method="POST", status="500"} 0.4
+eval instant at 0m requests / on(status) group_left fill_right(1) limits
+  {method="GET", status="200"} 0.1
+  {method="POST", status="200"} 0.2
+  {method="GET", status="500"} 0.2
+  {method="POST", status="500"} 0.4
 
 # group_left with fill_left: fill missing "many" side series.
 # For status="404", there's no matching requests, so a single series with the match group's labels is filled
-# Unsupported by streaming engine.
-# eval instant at 0m requests + on(status) group_left fill_left(0) limits
-#   {method="GET", status="200"} 1100
-#   {method="POST", status="200"} 1200
-#   {method="GET", status="500"} 60
-#   {method="POST", status="500"} 70
-#   {status="404"} 500
+eval instant at 0m requests + on(status) group_left fill_left(0) limits
+  {method="GET", status="200"} 1100
+  {method="POST", status="200"} 1200
+  {method="GET", status="500"} 60
+  {method="POST", status="500"} 70
+  {status="404"} 500
 
 # group_left with fill on both sides.
-# Unsupported by streaming engine.
-# eval instant at 0m requests + on(status) group_left fill(0) limits
-#   {method="GET", status="200"} 1100
-#   {method="POST", status="200"} 1200
-#   {method="GET", status="500"} 60
-#   {method="POST", status="500"} 70
-#   {status="404"} 500
+eval instant at 0m requests + on(status) group_left fill(0) limits
+  {method="GET", status="200"} 1100
+  {method="POST", status="200"} 1200
+  {method="GET", status="500"} 60
+  {method="POST", status="500"} 70
+  {status="404"} 500
 
 # group_right with fill_left: fill missing "one" side series.
 clear
@@ -191,26 +187,23 @@ load 5m
   node_meta{instance="c"} 300
 
 # fill_left fills the "one" side (node_meta) when missing for a "many" side series.
-# Unsupported by streaming engine.
-# eval instant at 0m node_meta * on(instance) group_right fill_left(1) cpu_info
-#   {instance="a", cpu="0"} 100
-#   {instance="a", cpu="1"} 100
-#   {instance="c"} 300
+eval instant at 0m node_meta * on(instance) group_right fill_left(1) cpu_info
+  {instance="a", cpu="0"} 100
+  {instance="a", cpu="1"} 100
+  {instance="c"} 300
 
 # group_right with fill_right: fill missing "many" side series.
-# Unsupported by streaming engine.
-# eval instant at 0m node_meta * on(instance) group_right fill_right(0) cpu_info
-#   {instance="a", cpu="0"} 100
-#   {instance="a", cpu="1"} 100
-#   {instance="b", cpu="0"} 0
+eval instant at 0m node_meta * on(instance) group_right fill_right(0) cpu_info
+  {instance="a", cpu="0"} 100
+  {instance="a", cpu="1"} 100
+  {instance="b", cpu="0"} 0
 
 # group_right with fill on both sides.
-# Unsupported by streaming engine.
-# eval instant at 0m node_meta * on(instance) group_right fill(1) cpu_info
-#   {instance="a", cpu="0"} 100
-#   {instance="a", cpu="1"} 100
-#   {instance="b", cpu="0"} 1
-#   {instance="c"} 300
+eval instant at 0m node_meta * on(instance) group_right fill(1) cpu_info
+  {instance="a", cpu="0"} 100
+  {instance="a", cpu="1"} 100
+  {instance="b", cpu="0"} 1
+  {instance="c"} 300
 
 # ---------- fill with group_left/group_right and extra labels ----------
 
@@ -224,10 +217,9 @@ load 5m
 
 # group_left with extra label and fill_right.
 # Note: when filling the "one" side, the joined label cannot be filled.
-# Unsupported by streaming engine.
-# eval instant at 0m requests + on(status) group_left(owner) fill_right(0) limits
-#   {method="GET", status="200", owner="team-a"} 1100
-#   {method="POST", status="200", owner="team-a"} 1200
+eval instant at 0m requests + on(status) group_left(owner) fill_right(0) limits
+  {method="GET", status="200", owner="team-a"} 1100
+  {method="POST", status="200", owner="team-a"} 1200
 
 # ---------- Edge cases ----------
 
@@ -333,10 +325,9 @@ load 5m
   matched_rhs{key="a"}  10 20 30
   matched_rhs{key="b"}  100 200 300
 
-# Unsupported by streaming engine.
-# eval range from 0 to 10m step 5m matched_lhs + on(key) group_left fill_left(0) matched_rhs
-#   {key="a"} 11 20 33
-#   {key="b"} 100 200 300
+eval range from 0 to 10m step 5m matched_lhs + on(key) group_left fill_left(0) matched_rhs
+  {key="a"} 11 20 33
+  {key="b"} 100 200 300
 
 # ---------- fill with vectors where one side is empty ----------
 


### PR DESCRIPTION
#### What this PR does

This PR follows on from https://github.com/grafana/mimir/pull/16071 by adding the Grouped fill operators `fill_left` and `fill_right`. This also ensures that many-side metadata is preserved for unmatched sides, that the values are normalised across both one-to-many and many-to-one fills (we get the same result for the same series irregardless of the order of operations), and that we enforce all cardinality and labelling rules in a way that conforms to prometheus's implementation except for on(__name__) due to constraints in delayed name removal. We also now validate the plan DAG in a way that doesn't potentially break binary operation pre-execution validation after they have gone through subset selector elimination.

Also added are compliance/conformance tests,  we're now doing 100% of the upstream prom e2e tests for fill operators as well as a bunch of our own.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
