### PR TITLE
MQE: Add capacity check for AppendSeriesMetadata

### DIFF
--- a/pkg/streamingpromql/types/data.go
+++ b/pkg/streamingpromql/types/data.go
@@ -24,8 +24,15 @@ type SeriesMetadata struct {
 	DropName bool
 }
 
-// AppendSeriesMetadata appends base SeriesMetadataSlice with the provided otherSeriesMetadata.
+// AppendSeriesMetadata appends otherSeriesMetadata to base and accounts for the memory of the
+// appended labels.
+//
+// This assumes that base already has enough capacity for the appended items. Callers that can't
+// be sure of that should grow the slice via SeriesMetadataSlicePool.AppendToSlice instead.
 func AppendSeriesMetadata(tracker *limiter.MemoryConsumptionTracker, base []SeriesMetadata, otherSeriesMetadata ...SeriesMetadata) ([]SeriesMetadata, error) {
+	if len(base)+len(otherSeriesMetadata) > cap(base) {
+		panic(fmt.Sprintf("AppendSeriesMetadata would grow base beyond its capacity (len %d + %d > cap %d); use AppendToSlice to grow a pooled slice (this is a bug)", len(base), len(otherSeriesMetadata), cap(base)))
+	}
 	for _, metadata := range otherSeriesMetadata {
 		err := tracker.IncreaseMemoryConsumptionForLabels(metadata.Labels)
 		if err != nil {


### PR DESCRIPTION
#### What this PR does

Panic in `AppendSeriesMetadata` if the append would exceed `base`'s capacity (which would force a reallocation and silently break the pool's capacity-based memory accounting), and document that callers needing to grow the slice must use `AppendToSlice` instead.

Draft until we decide how to handle MQE panics in https://github.com/grafana/mimir/pull/16383 .

#### Which issue(s) this PR fixes or relates to

Requested in https://github.com/grafana/mimir/pull/16219#discussion_r3872874187

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.