### PR TITLE
Query-frontend: fix subquery spin-off off-by-one bug for ranges not a multiple of the step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [BUGFIX] Block-builder: Fix silent data loss for jobs spanning exactly one record. #16493
 * [BUGFIX] Querier: Return HTTP 413 instead of 500 from the cardinality `label_names` and `label_values` endpoints when the merged response exceeds `-querier.label-names-and-values-results-max-size-bytes`. #16452
 * [BUGFIX] Querier: Return HTTP 413 instead of 500 from the active series endpoint's framed response format when a single series' JSON exceeds the maximum frame size. #16452
+* [BUGFIX] Query-frontend: Fix subquery spin-off dropping the final step of the subquery range when the subquery range is not an integer multiple of the subquery step, causing results to differ slightly from the query engine's native subquery evaluation. #16504
 * [BUGFIX] Build: Use `#!/usr/bin/env bash`/`#!/usr/bin/env sh` instead of hardcoded interpreter paths in development and CI scripts, fixing failures on systems where those interpreters aren't at that exact path, such as NixOS. #16425
 
 ### Mixin

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_queryable.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_queryable.go
@@ -15,6 +15,8 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/promqlext"
 )
 
@@ -147,17 +149,12 @@ func (q *spinOffSubqueriesQuerier) Select(ctx context.Context, _ bool, hints *st
 			return storage.ErrSeriesSet(errors.New("subqueries spin-off is not supported in range queries"))
 		}
 
-		// Subqueries are always aligned to absolute time in PromQL, so we need to make the same adjustment here for correctness.
-		// Find the first timestamp inside the subquery range that is aligned to the step.
-		// This is taken from MQE: https://github.com/grafana/mimir/blob/266a393379b2c981a83557c5d66e56c97251ffeb/pkg/streamingpromql/query.go#L384-L398
-		alignedStart := step * ((start - queryOffset.Milliseconds() - queryRange.Milliseconds()) / step)
-		if alignedStart < start-queryOffset.Milliseconds()-queryRange.Milliseconds() {
-			alignedStart += step
-		}
-		// Align the end too, to allow for caching
-		alignedEnd := alignedStart + queryRange.Milliseconds()
-		if alignedEnd > end {
-			alignedEnd -= step
+		// Compute the spun-off range query window with the same logic MQE uses natively for subqueries,
+		// so the spun-off range query evaluates the same grid and its result matches native evaluation.
+		alignedStart, alignedEnd, ok := subquerySpinOffChildTimeRange(start, queryRange, queryStep, queryOffset)
+		if !ok {
+			// The subquery range selects no steps (e.g. range smaller than the step and misaligned): no series.
+			return storage.EmptySeriesSet()
 		}
 
 		// Split queries into multiple smaller queries if they have more than 11000 datapoints
@@ -206,6 +203,21 @@ func (q *spinOffSubqueriesQuerier) Select(ctx context.Context, _ bool, hints *st
 	default:
 		return storage.ErrSeriesSet(errors.Errorf("invalid metric name for the spin-off middleware: %s", name))
 	}
+}
+
+// subquerySpinOffChildTimeRange returns the [start, end] (both inclusive, ms since epoch) of the
+// range query that a spun-off subquery evaluated at queryTimeMS should run over. It delegates to the
+// same logic MQE uses natively for subqueries so the spun-off result matches the engine's native
+// subquery grid: the first step is left-open at queryTime-range and the last step is the largest
+// step-aligned timestamp <= queryTime (right-closed). ok is false when the range selects no steps.
+func subquerySpinOffChildTimeRange(queryTimeMS int64, queryRange, queryStep, queryOffset time.Duration) (start, end int64, ok bool) {
+	tr := core.SubqueryChildrenTimeRange(types.NewInstantQueryTimeRange(time.UnixMilli(queryTimeMS)), queryRange, queryStep, queryOffset, nil)
+	if tr.StepCount == 0 {
+		return 0, 0, false
+	}
+	// tr.EndT may not be step-aligned (it is the raw evaluation time for instant queries), so use the
+	// last actual step on the grid.
+	return tr.StartT, tr.IndexTime(int64(tr.StepCount - 1)), true
 }
 
 // LabelValues implements storage.LabelQuerier.

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
@@ -16,12 +16,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/subqueryspinoff"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/testdatagen"
+	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/util"
 )
 
@@ -66,6 +68,15 @@ func TestSubquerySpinOff_Correctness(t *testing.T) {
 			query: `max_over_time(
 							rate(metric_counter[1m])
 						[2h:1m]
+					)`,
+			expectedSpunOffSubqueries: 1,
+		},
+		// A subquery whose range is not an integer multiple of the step; TestSubquerySpinOffChildTimeRange
+		// covers the resulting grid boundaries deterministically.
+		"subquery avg, range not a multiple of step": {
+			query: `avg_over_time(
+							rate(metric_counter[1m])
+						[2h1m:2m]
 					)`,
 			expectedSpunOffSubqueries: 1,
 		},
@@ -403,5 +414,65 @@ func TestSpinOffSubqueries_ShouldNotPanicOnNilQueryExpression(t *testing.T) {
 			require.ErrorContains(t, err, errRequestNoQuery.Error())
 			require.Nil(t, resp)
 		})
+	})
+}
+
+// TestSubquerySpinOff_MatchesNativeEvaluation asserts that spinning off a subquery produces the same
+// result as evaluating it natively (without spin-off), for both the Prometheus engine and MQE, and
+// that the two engines agree natively. It covers a subquery range that is not an integer multiple of
+// its step, evaluated at a step-aligned time so the range boundary is exercised deterministically.
+func TestSubquerySpinOff_MatchesNativeEvaluation(t *testing.T) {
+	const queryTimeMS = int64(85200_000) // Aligned to the 2m subquery step.
+	// Monotonic gauge every 30s covering the whole subquery window, so the value at the last grid point
+	// (the top of the subquery range) affects max_over_time. sum(metric) is a naturally-complex
+	// subquery, so it is spun off without needing the simple-subqueries option.
+	store := promqltest.LoadedStorage(t, "load 30s\n  metric 0+7x3000")
+	req := &PrometheusInstantQueryRequest{
+		path:      "/query",
+		time:      queryTimeMS,
+		queryExpr: parseQuery(t, `max_over_time(sum(metric)[79780s:2m])`),
+	}
+
+	native := func(t *testing.T, eng promql.QueryEngine) *PrometheusResponse {
+		res, err := (&downstreamHandler{engine: eng, queryable: store}).Do(context.Background(), req)
+		require.NoError(t, err)
+		prom, ok := res.GetPrometheusResponse()
+		require.True(t, ok)
+		require.NotEmpty(t, prom.Data.Result)
+		return prom
+	}
+	spunOffResult := func(t *testing.T, eng promql.QueryEngine) *PrometheusResponse {
+		downstream := &downstreamHandler{engine: eng, queryable: store}
+		spunOff := false
+		rangeMiddleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+			return HandlerFunc(func(ctx context.Context, r MetricsQueryRequest) (Response, error) {
+				spunOff = true
+				return next.Do(ctx, r)
+			})
+		})
+		mw := newSpinOffSubqueriesMiddleware(mockLimits{subquerySpinOffEnabled: true}, log.NewNopLogger(), eng, prometheus.NewPedanticRegistry(), rangeMiddleware, defaultStepFunc, subqueryspinoff.Options{})
+		res, err := mw.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+		require.NoError(t, err)
+		require.True(t, spunOff, "the subquery should have been spun off")
+		prom, ok := res.GetPrometheusResponse()
+		require.True(t, ok)
+		return prom
+	}
+
+	_, promEngine := newEngineForTesting(t, querier.PrometheusEngine)
+	_, mqeEngine := newEngineForTesting(t, querier.MimirEngine)
+
+	promNative := native(t, promEngine)
+	mqeNative := native(t, mqeEngine)
+
+	// The Prometheus engine and MQE must agree on the native (non-spun-off) subquery evaluation.
+	approximatelyEquals(t, promNative, mqeNative)
+
+	// The spun-off result must match each engine's native evaluation.
+	t.Run("engine=prometheus", func(t *testing.T) {
+		approximatelyEquals(t, promNative, spunOffResult(t, promEngine))
+	})
+	t.Run("engine=mimir", func(t *testing.T) {
+		approximatelyEquals(t, mqeNative, spunOffResult(t, mqeEngine))
 	})
 }

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
@@ -476,3 +476,39 @@ func TestSubquerySpinOff_MatchesNativeEvaluation(t *testing.T) {
 		approximatelyEquals(t, mqeNative, spunOffResult(t, mqeEngine))
 	})
 }
+
+func TestSubquerySpinOffChildTimeRange(t *testing.T) {
+	const step = 2 * time.Minute
+	stepMS := step.Milliseconds()
+
+	cases := map[string]struct {
+		queryTimeMS int64
+		queryRange  time.Duration
+		offset      time.Duration
+	}{
+		// Cover multiple/non-multiple ranges, an aligned query time, and an offset.
+		"range not a multiple of step":  {queryTimeMS: 1787054732769, queryRange: 79780 * time.Second},
+		"range a multiple of step":      {queryTimeMS: 1787054732769, queryRange: 79680 * time.Second},
+		"query time aligned to step":    {queryTimeMS: 1787054640000, queryRange: 79780 * time.Second},
+		"range not a multiple + offset": {queryTimeMS: 1787054732769, queryRange: 79780 * time.Second, offset: 5 * time.Minute},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			start, end, ok := subquerySpinOffChildTimeRange(c.queryTimeMS, c.queryRange, step, c.offset)
+			require.True(t, ok)
+
+			offMS := c.offset.Milliseconds()
+			// The last step is the largest step-aligned timestamp <= queryTime-offset (the subquery
+			// range is right-closed at the top).
+			require.Equal(t, ((c.queryTimeMS-offMS)/stepMS)*stepMS, end, "last step (right-closed at queryTime-offset)")
+
+			// The first step is the smallest step-aligned timestamp strictly after queryTime-offset-range
+			// (the subquery range is left-open at the bottom).
+			lower := c.queryTimeMS - offMS - c.queryRange.Milliseconds()
+			require.Zero(t, start%stepMS, "start must be step-aligned")
+			require.Greater(t, start, lower, "start must be strictly after queryTime-offset-range")
+			require.LessOrEqual(t, start-stepMS, lower, "start must be the first step after that bound")
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does

Fixes an off-by-one bug in query-frontend subquery spin-off. When a subquery is spun off into a range query, the window's end was derived from the range rather than aligned to the step grid, so for subquery ranges that aren't an integer multiple of the step the final step was dropped, producing one fewer sample than the engine's native subquery evaluation. Ranges that are a multiple of the step are unaffected.

The window is now computed with the same logic MQE uses natively for subqueries, so the spun-off range query covers the same grid and matches native evaluation. Boundaries stay step-aligned, so results caching is unaffected. Tested at the unit level (grid boundaries) and end-to-end (spun-off result equals native evaluation for both the Prometheus engine and MQE). Verified that the tests fail before the fix and pass afterwards.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.