### PR TITLE
mimirpb: optimize empty label removal

### DIFF
--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -178,16 +178,27 @@ func (p *PreallocTimeseries) SetLabels(lbls []LabelAdapter) {
 
 // RemoveEmptyLabelValues remove labels with value=="" from this timeseries, updating the slice in-place.
 func (p *PreallocTimeseries) RemoveEmptyLabelValues() {
-	modified := false
+	lastEmpty := -1
 	for i := len(p.Labels) - 1; i >= 0; i-- {
 		if p.Labels[i].Value == "" {
-			p.Labels = append(p.Labels[:i], p.Labels[i+1:]...)
-			modified = true
+			lastEmpty = i
+			break
 		}
 	}
-	if modified {
-		p.clearUnmarshalData()
+	if lastEmpty == -1 {
+		return
 	}
+
+	n := 0
+	for _, label := range p.Labels[:lastEmpty] {
+		if label.Value != "" {
+			p.Labels[n] = label
+			n++
+		}
+	}
+	n += copy(p.Labels[n:], p.Labels[lastEmpty+1:])
+	p.Labels = p.Labels[:n]
+	p.clearUnmarshalData()
 }
 
 // SortLabelsIfNeeded sorts labels if they were not sorted before.

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -592,11 +592,42 @@ func TestPreallocTimeseries_RemoveEmptyLabelValues(t *testing.T) {
 			},
 			marshalledData: []byte{1, 2, 3},
 		}
-		p.RemoveLabel("foo")
+		p.RemoveEmptyLabelValues()
 
 		require.Equal(t, []LabelAdapter{{Name: "__name__", Value: "foo"}, {Name: "bar", Value: "baz"}}, p.Labels)
 		require.NotNil(t, p.marshalledData)
 	})
+}
+
+func BenchmarkPreallocTimeseries_RemoveEmptyLabelValues(b *testing.B) {
+	for _, labelCount := range []int{20, 100} {
+		for _, tc := range []struct {
+			name       string
+			emptyEvery int
+		}{
+			{name: "no_empty"},
+			{name: "one_third_empty", emptyEvery: 3},
+		} {
+			b.Run(fmt.Sprintf("num_labels=%d/%s", labelCount, tc.name), func(b *testing.B) {
+				input := make([]LabelAdapter, labelCount)
+				for i := range input {
+					input[i] = LabelAdapter{Name: fmt.Sprintf("label_%d", i), Value: "value"}
+					if tc.emptyEvery > 0 && i%tc.emptyEvery == 0 {
+						input[i].Value = ""
+					}
+				}
+
+				p := PreallocTimeseries{TimeSeries: &TimeSeries{Labels: make([]LabelAdapter, 0, labelCount)}}
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					p.Labels = append(p.Labels[:0], input...)
+					p.RemoveEmptyLabelValues()
+				}
+			})
+		}
+	}
 }
 
 func TestPreallocTimeseries_SetLabels(t *testing.T) {


### PR DESCRIPTION
## Summary

Speed up empty-label removal by compacting labels in one pass instead of shifting the remaining slice once for every empty label.

- Preserve the fast path when no labels have empty values
- Reduce runtime by up to 75% for inputs containing empty labels

### Benchmark

```text
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/mimirpb
cpu: Apple M3 Pro
                                                                            │ before.txt  │              after.txt              │
                                                                            │   sec/op    │   sec/op     vs base                │
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=20/no_empty-11           15.46n ± 1%   14.46n ± 0%   -6.53% (p=0.000 n=10)
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=20/one_third_empty-11    59.31n ± 0%   30.67n ± 1%  -48.30% (p=0.000 n=10)
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=100/no_empty-11          70.63n ± 1%   62.20n ± 0%  -11.93% (p=0.000 n=10)
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=100/one_third_empty-11   579.5n ± 1%   145.8n ± 0%  -74.83% (p=0.000 n=10)
geomean                                                                       78.28n        44.78n       -42.79%

                                                                            │  before.txt  │              after.txt              │
                                                                            │     B/op     │    B/op     vs base                 │
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=20/no_empty-11           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=20/one_third_empty-11    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=100/no_empty-11          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=100/one_third_empty-11   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                  ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                            │  before.txt  │              after.txt              │
                                                                            │  allocs/op   │ allocs/op   vs base                 │
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=20/no_empty-11           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=20/one_third_empty-11    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=100/no_empty-11          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
PreallocTimeseries_RemoveEmptyLabelValues/num_labels=100/one_third_empty-11   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                  ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
