### PR TITLE
fix(mimir): exit 0 when shutdown is requested before startup completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [BUGFIX] Querier: Return HTTP 413 instead of 500 from the cardinality `label_names` and `label_values` endpoints when the merged response exceeds `-querier.label-names-and-values-results-max-size-bytes`. #16452
 * [BUGFIX] Querier: Return HTTP 413 instead of 500 from the active series endpoint's framed response format when a single series' JSON exceeds the maximum frame size. #16452
 * [BUGFIX] Query-frontend: Fix subquery spin-off dropping the final step of the subquery range when the subquery range is not an integer multiple of the subquery step, causing results to differ slightly from the query engine's native subquery evaluation. #16504
+* [BUGFIX] Mimir: Exit with status 0, and stop logging `module failed` at error level, when a `SIGTERM` or `SIGINT` arrives before all modules finished starting. Cancelling the start context leaves those modules in a failed state, which was reported as `failed services` and exited 1, making an ordinary rolling restart or node drain of a slow-starting component indistinguishable from a crash. #16524
 * [BUGFIX] Build: Use `#!/usr/bin/env bash`/`#!/usr/bin/env sh` instead of hardcoded interpreter paths in development and CI scripts, fixing failures on systems where those interpreters aren't at that exact path, such as NixOS. #16425
 
 ### Mixin

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -1189,9 +1189,12 @@ func (t *Mimir) Run() error {
 		// let's find out which module failed
 		for m, s := range t.ServiceMap {
 			if s == service {
-				if errors.Is(service.FailureCase(), modules.ErrStopProcess) {
+				switch {
+				case errors.Is(service.FailureCase(), modules.ErrStopProcess):
 					level.Info(util_log.Logger).Log("msg", "received stop signal via return error", "module", m, "err", service.FailureCase())
-				} else {
+				case shutdownRequested.Load():
+					level.Info(util_log.Logger).Log("msg", "module startup aborted by shutdown signal", "module", m, "err", service.FailureCase())
+				default:
 					level.Error(util_log.Logger).Log("msg", "module failed", "module", m, "err", service.FailureCase())
 				}
 				return
@@ -1230,7 +1233,12 @@ func (t *Mimir) Run() error {
 
 	// If there is no error yet (= service manager started and then stopped without problems),
 	// but any service failed, report that failure as an error to caller.
-	if err == nil {
+	//
+	// A shutdown signal received while services are still starting cancels their start
+	// context and leaves them in Failed state. That is a requested shutdown, not a
+	// failure, so it must not be reported as one: doing so makes the process exit
+	// non-zero for what is a routine restart. The failures are logged either way.
+	if err == nil && !shutdownRequested.Load() {
 		if failed := sm.ServicesByState()[services.Failed]; len(failed) > 0 {
 			for _, f := range failed {
 				if !errors.Is(f.FailureCase(), modules.ErrStopProcess) {

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -292,6 +292,62 @@ func TestMimirServerShutdownWithActivityTrackerEnabled(t *testing.T) {
 	}
 }
 
+// TestMimirServerShutdownWhileModuleIsStarting asserts that a shutdown signal received
+// before all modules finished starting is not reported as a failure. Cancelling the start
+// context leaves those modules in Failed state, which must not be mistaken for a crash.
+func TestMimirServerShutdownWhileModuleIsStarting(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	cfg := Config{}
+
+	// This sets default values from flags to the config.
+	flagext.RegisterFlagsWithLogger(log.NewNopLogger(), &cfg)
+
+	cfg.Target = []string{Querier}
+	cfg.Server = getServerConfig(t, dslog.LogfmtFormat, "debug")
+
+	cfg.Server.Log = util_log.InitLogger(cfg.Server.LogFormat, cfg.Server.LogLevel, false, util_log.RateLimitedLoggerCfg{})
+
+	c, err := New(cfg, prometheus.NewPedanticRegistry())
+	require.NoError(t, err)
+
+	// Register a module that never finishes starting and make the target depend on it,
+	// so the signal below is guaranteed to arrive while startup is still in progress.
+	starting := make(chan struct{})
+	c.ModuleManager.RegisterModule("test-blocking-module", func() (services.Service, error) {
+		return services.NewBasicService(func(ctx context.Context) error {
+			close(starting)
+			<-ctx.Done()
+			return ctx.Err()
+		}, nil, nil), nil
+	})
+	require.NoError(t, c.ModuleManager.AddDependency(Querier, "test-blocking-module"))
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- c.Run()
+	}()
+
+	select {
+	case <-starting:
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "test module didn't reach starting state in time")
+	}
+
+	proc, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+
+	// Mimir reacts on SIGINT and does shutdown.
+	require.NoError(t, proc.Signal(syscall.SIGINT))
+
+	select {
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "Mimir didn't stop in time")
+	case err := <-errCh:
+		require.NoError(t, err)
+	}
+}
+
 func TestMetricsEndpointSupportsMetricFiltering(t *testing.T) {
 	// This test checks that our /metrics endpoint handler supports metric filtering through the usage of name[] query param.
 	// This is added to prometheus/client_golang in https://github.com/prometheus/client_golang/pull/1925,


### PR DESCRIPTION
#### What this PR does

Exit 0, rather than 1, when a `SIGTERM` or `SIGINT` arrives before all modules have finished starting.

Cancelling the start context leaves those modules in `Failed` state, which `Run()` reported through the generic failed-services path as a `failed services` error. A rolling restart, node drain, or eviction that caught a slow-starting component therefore looked exactly like a crash — non-zero exit plus `level=error msg="module failed"`. Whether Mimir exited 0 or 1 for the same signal depended only on which side of `Application started` it landed on.

- Gate the failed-services check on `!shutdownRequested.Load()`, which is already stored before `StopAsync()` and so is ordered before the check reads it
- Log the affected modules at info with an accurate message rather than `module failed` at error level

Failures are still logged either way; only the exit code and the log level change.

I deliberately did not narrow this to `errors.Is(f.FailureCase(), context.Canceled)`. A service cancelled mid-startup does not reliably report that sentinel — in the run that surfaced this it appeared as `failed to create topics [ingest]: unable to dial: ... network is unreachable` — so the narrower condition would still exit 1 in the cases that actually occur.

#### Which issue(s) this PR fixes or relates to

No tracking issue. Surfaced by Antithesis fault-injection runs against Grafana Enterprise Metrics: a `node/kill` fault on an ingester produced the expected exit 137, but the `SIGTERM` that reached the replacement container ~4s later, while it was still starting modules, produced exit 1. `Run()` returns a bare `errors.New("failed services")` whose text is byte-identical to a genuine bootstrap failure earlier in the same run, so the caller cannot classify it after the fact.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
