### PR TITLE
[DO NOT MERGE] Test Bugbot Antithesis assertion guidance

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -6,35 +6,34 @@ Mimir vendors the Antithesis Go SDK (`github.com/antithesishq/antithesis-sdk-go/
 `default-no-op` mode. The assertions compile to empty functions unless the binary is built with
 the `enable_antithesis_sdk` build tag, so they are inert in released builds.
 
-When a pull request adds Go code in either of the situations below, add a non-blocking Bug titled
-"Consider an Antithesis assertion":
+### Rule 1: bug-only paths
 
-1. **Properties that should hold.** New code usually relies on some invariant the author has in
-   their head but never wrote down: a value that must always be within a range, an ordering that
-   must always be respected, a state the system should be able to reach at least once. These are
-   what Antithesis explores hardest, and the repo has none of them today, so raising these is the
-   priority. Suggest `Always`, `AlwaysOrUnreachable`, or `Sometimes`.
-2. **Bug-only paths.** A branch reachable only because of a bug, typically one that already ends
-   in an error saying "this is a bug", a `panic`, or a "this should never happen" warning log.
-   Suggest `Unreachable`.
+If a changed non-test `.go` file under `pkg/` or `cmd/` adds a line matching
+`/panic\(|this is a bug|should never happen/`, and the enclosing function contains no line matching
+`/assert\.(Unreachable|AlwaysOrUnreachable|Always|Sometimes|Reachable)\(/`, then:
 
-How to raise it:
+- Add a non-blocking Bug titled "Consider an Antithesis assertion"
+- Body: "This branch is reachable only because of a bug, so Antithesis can watch for it. Consider
+  `assert.Unreachable(\"<short message>\", map[string]any{...})` immediately before the existing
+  panic, error return, or warning log; it augments that handling rather than replacing it. Optional
+  instrumentation, not a defect, so feel free to decline."
 
-- Add one non-blocking Bug per place worth instrumenting, anchored to those lines, the way a human
-  reviewer would comment.
-- In the body, name the property or the bug-only path, recommend an assertion type from the table
-  below, and sketch the call in a line or two.
-- Say in the body that the suggestion is optional. Never request changes over it and never let it
-  block the pull request. The author is free to decline any or all of them.
-- Do not stay silent just because the pull request already adds an Antithesis assertion somewhere.
-  Still point out every remaining candidate of either kind, whether an unstated property or an
-  uninstrumented bug-only path, and still say so when a different assertion from the SDK would fit
-  a case better than the one that was used.
-- A path reachable through normal operation, invalid user input, or an unavailable dependency is
-  an ordinary error, not a bug. Never suggest `Unreachable` there. It may still carry a property
-  worth asserting, so consider the first category instead of staying silent.
-- Only consider non-test Go files under `pkg/` and `cmd/`. Ignore `_test.go` files, `vendor/`,
-  `integration/`, `tools/`, `operations/`, and generated code.
+### Rule 2: properties that should hold
+
+If a changed non-test `.go` file under `pkg/` or `cmd/` establishes an invariant that the diff never
+states as an assertion — a bound, a capacity, an ordering, a monotonic counter, or a state the
+system should be able to reach at least once — then:
+
+- Add a non-blocking Bug titled "Consider an Antithesis assertion"
+- Body: name the invariant, recommend `Always`, `AlwaysOrUnreachable`, or `Sometimes` from the table
+  below, sketch the call, and close with the same "optional, feel free to decline" note.
+
+Both rules: add one Bug per location, anchored to those lines. Judge each candidate on its own, so
+an assertion added elsewhere in the pull request is no reason to stay quiet about the rest. Never
+request changes and never block a pull request over either rule. Ignore `_test.go` files, `vendor/`,
+`integration/`, `tools/`, `operations/`, and generated code. A path reachable through normal
+operation, invalid user input, or an unavailable dependency is an ordinary error rather than a bug,
+so never apply rule 1 there, though it may still carry a property worth rule 2.
 
 Which assertion type to suggest:
 

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -6,7 +6,8 @@ Mimir vendors the Antithesis Go SDK (`github.com/antithesishq/antithesis-sdk-go/
 `default-no-op` mode. The assertions compile to empty functions unless the binary is built with
 the `enable_antithesis_sdk` build tag, so they are inert in released builds.
 
-Look for two kinds of opportunity in a pull request:
+When a pull request adds Go code in either of the situations below, add a non-blocking Bug titled
+"Consider an Antithesis assertion":
 
 1. **Properties that should hold.** New code usually relies on some invariant the author has in
    their head but never wrote down: a value that must always be within a range, an ordering that
@@ -19,10 +20,12 @@ Look for two kinds of opportunity in a pull request:
 
 How to raise it:
 
-- Post a separate inline comment on each place worth instrumenting, anchored to those lines, the
-  way a human reviewer would. Every one of them is a non-blocking suggestion: never report a
-  missing assertion as a bug, and never request changes over it. The author is free to decline
-  any or all of them.
+- Add one non-blocking Bug per place worth instrumenting, anchored to those lines, the way a human
+  reviewer would comment.
+- In the body, name the property or the bug-only path, recommend an assertion type from the table
+  below, and sketch the call in a line or two.
+- Say in the body that the suggestion is optional. Never request changes over it and never let it
+  block the pull request. The author is free to decline any or all of them.
 - Do not stay silent just because the pull request already adds an Antithesis assertion somewhere.
   Still point out every remaining candidate of either kind, whether an unstated property or an
   uninstrumented bug-only path, and still say so when a different assertion from the SDK would fit

--- a/pkg/streamingpromql/types/data.go
+++ b/pkg/streamingpromql/types/data.go
@@ -24,8 +24,15 @@ type SeriesMetadata struct {
 	DropName bool
 }
 
-// AppendSeriesMetadata appends base SeriesMetadataSlice with the provided otherSeriesMetadata.
+// AppendSeriesMetadata appends otherSeriesMetadata to base and accounts for the memory of the
+// appended labels.
+//
+// This assumes that base already has enough capacity for the appended items. Callers that can't
+// be sure of that should grow the slice via SeriesMetadataSlicePool.AppendToSlice instead.
 func AppendSeriesMetadata(tracker *limiter.MemoryConsumptionTracker, base []SeriesMetadata, otherSeriesMetadata ...SeriesMetadata) ([]SeriesMetadata, error) {
+	if len(base)+len(otherSeriesMetadata) > cap(base) {
+		panic(fmt.Sprintf("AppendSeriesMetadata would grow base beyond its capacity (len %d + %d > cap %d); use AppendToSlice to grow a pooled slice (this is a bug)", len(base), len(otherSeriesMetadata), cap(base)))
+	}
 	for _, metadata := range otherSeriesMetadata {
 		err := tracker.IncreaseMemoryConsumptionForLabels(metadata.Labels)
 		if err != nil {


### PR DESCRIPTION
## Summary

**Do not merge.** Throwaway PR that checks whether Bugbot picks up the `.cursor/BUGBOT.md` configuration added in #16523.

Cherry-picks @zenador's commit from #16502 onto latest `main`, unchanged. The real change should land via #16502; this copy exists only to trigger a Bugbot review now that the configuration is on `main`.

Expected behaviour: a non-blocking inline suggestion on the new `panic` in `AppendSeriesMetadata`, recommending an `assert.Unreachable` immediately before it. That branch is reachable only because of a bug and its message already ends in "this is a bug", which is the case the configuration describes.

Closing this without merging once the review lands.

Ref: #16502
