### PR TITLE
ruler-querier: add predictive scaling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * [ENHANCEMENT] Add support for multi-zone query-tee. #16360
 * [ENHANCEMENT] Add `ingester_zone_(a|b|c)_data_disk_class` and `store_gateway_zone_(a|b|c|a-backup|b-backup)_data_disk_class` config. #16467
 * [ENHANCEMENT] Add `autoscaling_ruler_querier_predictive_scaling_enabled` to scale ruler-queriers based on inflight queries from a configurable period ago, mirroring the existing querier predictive scaling mechanism. #16529
+* [ENHANCEMENT] Add `autoscaling_ruler_querier_scaleup_percent_cap` and `autoscaling_ruler_querier_scaledown_percent_cap` to control how fast ruler-queriers scale up and down. #16529
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 * [BUGFIX] Fail with an explicit error when `ingester_automated_downscale_v2_enabled` is used together with `ingest_storage_enabled`. That downscale mode relies on the ingester read-only mode, which the ingest storage architecture doesn't support: use `ingest_storage_ingester_autoscaling_enabled` instead. #16469
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.39.0. #16440
 * [ENHANCEMENT] Add support for multi-zone query-tee. #16360
 * [ENHANCEMENT] Add `ingester_zone_(a|b|c)_data_disk_class` and `store_gateway_zone_(a|b|c|a-backup|b-backup)_data_disk_class` config. #16467
+* [ENHANCEMENT] Add `autoscaling_ruler_querier_predictive_scaling_enabled` to scale ruler-queriers based on inflight queries from a configurable period ago, mirroring the existing querier predictive scaling mechanism. #16529
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 * [BUGFIX] Fail with an explicit error when `ingester_automated_downscale_v2_enabled` is used together with `ingest_storage_enabled`. That downscale mode relies on the ingester read-only mode, which the ingest storage architecture doesn't support: use `ingest_storage_ingester_autoscaling_enabled` instead. #16469
 

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2349,7 +2349,16 @@ spec:
           policies:
           - periodSeconds: 60
             type: Percent
-            value: 10
+            value: 25
+        scaleUp:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 50
+          - periodSeconds: 120
+            type: Pods
+            value: 15
+          stabilizationWindowSeconds: 60
   maxReplicaCount: 30
   minReplicaCount: 3
   pollingInterval: 10

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2405,6 +2405,15 @@ spec:
       threshold: "7"
     name: ruler_querier_queries_hpa_default
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: ruler_querier_queries_predictive_hpa_default
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[30m]
+        offset 6d23h30m) >= 0) or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "7"
+    name: ruler_querier_queries_predictive_hpa_default
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization.jsonnet
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization.jsonnet
@@ -17,5 +17,8 @@
     autoscaling_ruler_query_frontend_memory_target_utilization: targetUtilization,
     autoscaling_alertmanager_cpu_target_utilization: targetUtilization,
     autoscaling_alertmanager_memory_target_utilization: targetUtilization,
+
+    autoscaling_ruler_querier_scaleup_percent_cap: 50,
+    autoscaling_ruler_querier_scaledown_percent_cap: 25,
   },
 }

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2405,6 +2405,15 @@ spec:
       threshold: "6"
     name: ruler_querier_queries_hpa_default
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: ruler_querier_queries_predictive_hpa_default
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[30m]
+        offset 6d23h30m) >= 0) or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: ruler_querier_queries_predictive_hpa_default
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -27,6 +27,7 @@ mimir {
     autoscaling_ruler_querier_enabled: true,
     autoscaling_ruler_querier_min_replicas_per_zone: 3,
     autoscaling_ruler_querier_max_replicas_per_zone: 30,
+    autoscaling_ruler_querier_predictive_scaling_enabled: true,
 
     autoscaling_distributor_enabled: true,
     autoscaling_distributor_min_replicas_per_zone: 3,

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -29,6 +29,9 @@
     autoscaling_ruler_querier_cpu_target_utilization: 1,
     autoscaling_ruler_querier_memory_target_utilization: 1,
     autoscaling_ruler_querier_workers_target_utilization: 0.75,  // Target to utilize 75% ruler-querier workers on peak traffic, so we have 25% room for higher peaks.
+    autoscaling_ruler_querier_predictive_scaling_enabled: false,  // Use inflight queries from the past to predict the number of ruler-queriers needed.
+    autoscaling_ruler_querier_predictive_scaling_period: '6d23h30m',  // The period to consider when considering scheduler metrics for predictive scaling. This is usually slightly lower than the period of the repeating query events to give scaling up lead time.
+    autoscaling_ruler_querier_predictive_scaling_lookback: '30m',  // The time range to consider when considering scheduler metrics for predictive scaling. For example: if lookback is 30m and period is 6d23h30m, the ruler-querier will scale based on the maximum inflight queries between 6d23h30m and 7d0h0m ago.
 
     autoscaling_distributor_enabled: false,
     autoscaling_distributor_min_replicas_per_zone: error 'you must set autoscaling_distributor_min_replicas_per_zone in the _config',
@@ -676,33 +679,72 @@
       cpu_target_utilization=$._config.autoscaling_ruler_querier_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_ruler_querier_memory_target_utilization,
       extra_matchers=extra_matchers,
-      extra_triggers=if $._config.autoscaling_ruler_querier_workers_target_utilization <= 0 then [] else [
-        {
-          local name = 'ruler-querier-queries',
-          local querier_max_concurrent = querier_args['querier.max-concurrent'],
-          local query_params = {
-            namespace: $._config.namespace,
-            extra_matchers: if extra_matchers == '' then '' else ',%s' % extra_matchers,
-          },
+      extra_triggers=
+      (if $._config.autoscaling_ruler_querier_workers_target_utilization <= 0 then [] else [
+         {
+           local name = 'ruler-querier-queries',
+           local querier_max_concurrent = querier_args['querier.max-concurrent'],
+           local query_params = {
+             namespace: $._config.namespace,
+             extra_matchers: if extra_matchers == '' then '' else ',%s' % extra_matchers,
+           },
 
-          metric_name: '%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
+           metric_name: '%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-          // Each ruler-query-scheduler tracks *at regular intervals* the number of inflight requests
-          // (both enqueued and processing queries) as a summary. With the following query we target
-          // to have enough querier workers to run the max observed inflight requests 50% of time.
-          //
-          // This metric covers the case queries are piling up in the ruler-query-scheduler queue,
-          // but ruler-querier replicas are not scaled up by other scaling metrics (e.g. CPU and memory)
-          // because resources utilization is not increasing significantly.
-          query: 'sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[1m]))' % query_params,
+           // Each ruler-query-scheduler tracks *at regular intervals* the number of inflight requests
+           // (both enqueued and processing queries) as a summary. With the following query we target
+           // to have enough querier workers to run the max observed inflight requests 50% of time.
+           //
+           // This metric covers the case queries are piling up in the ruler-query-scheduler queue,
+           // but ruler-querier replicas are not scaled up by other scaling metrics (e.g. CPU and memory)
+           // because resources utilization is not increasing significantly.
+           query: 'sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[1m]))' % query_params,
 
-          threshold: '%d' % std.floor(querier_max_concurrent * $._config.autoscaling_ruler_querier_workers_target_utilization),
+           threshold: '%d' % std.floor(querier_max_concurrent * $._config.autoscaling_ruler_querier_workers_target_utilization),
 
-          // Do not let KEDA use the value "0" as scaling metric if the query returns no result
-          // (e.g. query-scheduler is crashing).
-          ignore_null_values: false,
-        },
-      ],
+           // Do not let KEDA use the value "0" as scaling metric if the query returns no result
+           // (e.g. query-scheduler is crashing).
+           ignore_null_values: false,
+         },
+       ])
+      +
+      (
+        if !$._config.autoscaling_ruler_querier_predictive_scaling_enabled then [] else
+          local querier_max_concurrent = querier_args['querier.max-concurrent'];
+          local threshold = std.floor(querier_max_concurrent * $._config.autoscaling_ruler_querier_workers_target_utilization);
+
+          // A rendered threshold of 0 or less makes KEDA request a non-positive HPA metric target, which
+          // Kubernetes rejects outright, so the whole ScaledObject (including the reactive CPU
+          // and memory triggers) fails to apply. Fail fast at render time instead.
+          assert threshold > 0 :
+                 'autoscaling_ruler_querier_predictive_scaling_enabled requires querier_max_concurrent * autoscaling_ruler_querier_workers_target_utilization > 0, got threshold %d' % threshold;
+          [
+            {
+              local name = 'ruler-querier-queries-predictive',
+              local query_params = {
+                namespace: $._config.namespace,
+                extra_matchers: if extra_matchers == '' then '' else ',%s' % extra_matchers,
+                lookback: $._config.autoscaling_ruler_querier_predictive_scaling_lookback,
+                period: $._config.autoscaling_ruler_querier_predictive_scaling_period,
+              },
+
+              metric_name: '%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
+
+              // Scale ruler-queriers according to how many would have been sufficient to handle
+              // the ruler-query-scheduler queue depth $period ago.
+              //
+              // >= 0 drops NaN samples (emitted by the Prometheus Summary before the first Observe() call)
+              // before sum; or vector(0) handles the absent case when the zone is newer than the offset
+              // period, or when the lookback window aligns with the first NaN scrape at deployment time.
+              query: '(sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[%(lookback)s] offset %(period)s) >= 0) or vector(0))' % query_params,
+
+              threshold: '%d' % threshold,
+
+              // Inert here (the query above already guarantees a numeric result); kept for consistency.
+              ignore_null_values: false,
+            },
+          ]
+      ),
     ),
 
   ruler_querier_scaled_object: if !$._config.autoscaling_ruler_querier_enabled || !$._config.ruler_remote_evaluation_enabled then null else

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -32,6 +32,8 @@
     autoscaling_ruler_querier_predictive_scaling_enabled: false,  // Use inflight queries from the past to predict the number of ruler-queriers needed.
     autoscaling_ruler_querier_predictive_scaling_period: '6d23h30m',  // The period to consider when considering scheduler metrics for predictive scaling. This is usually slightly lower than the period of the repeating query events to give scaling up lead time.
     autoscaling_ruler_querier_predictive_scaling_lookback: '30m',  // The time range to consider when considering scheduler metrics for predictive scaling. For example: if lookback is 30m and period is 6d23h30m, the ruler-querier will scale based on the maximum inflight queries between 6d23h30m and 7d0h0m ago.
+    autoscaling_ruler_querier_scaleup_percent_cap: null,  // The maximum percent a ruler-querier deployment may scale up every 2m. Null leaves scale-up uncapped (Kubernetes' own default).
+    autoscaling_ruler_querier_scaledown_percent_cap: 10,  // The maximum percent a ruler-querier deployment may scale down every 1m.
 
     autoscaling_distributor_enabled: false,
     autoscaling_distributor_min_replicas_per_zone: error 'you must set autoscaling_distributor_min_replicas_per_zone in the _config',
@@ -745,7 +747,43 @@
             },
           ]
       ),
-    ),
+    ) + {
+      spec+: {
+        advanced+: {
+          horizontalPodAutoscalerConfig+: {
+            behavior+: {
+              // Capping the scale-down rate avoids reacting too aggressively to a brief dip in load.
+              scaleDown: {
+                policies: [{
+                  type: 'Percent',
+                  value: $._config.autoscaling_ruler_querier_scaledown_percent_cap,
+                  periodSeconds: 60,
+                }],
+              },
+            } + (
+              if $._config.autoscaling_ruler_querier_scaleup_percent_cap == null then {} else {
+                // Capping the scale-up rate avoids reacting too aggressively to a brief spike in load.
+                scaleUp: {
+                  policies: [
+                    {
+                      type: 'Percent',
+                      value: $._config.autoscaling_ruler_querier_scaleup_percent_cap,
+                      periodSeconds: 120,
+                    },
+                    {
+                      type: 'Pods',
+                      value: 15,
+                      periodSeconds: 120,
+                    },
+                  ],
+                  stabilizationWindowSeconds: 60,
+                },
+              }
+            ),
+          },
+        },
+      },
+    },
 
   ruler_querier_scaled_object: if !$._config.autoscaling_ruler_querier_enabled || !$._config.ruler_remote_evaluation_enabled then null else
     $.newRulerQuerierScaledObject('ruler-querier', $.ruler_querier_args),


### PR DESCRIPTION
## Why

Add predictive scaling support to `ruler-querier`, mirroring what's available for `querier`.

Predictive scaling can be a better fit than a fixed cron schedule.
It suits load that recurs on a regular but not perfectly calendar-fixed cadence.

Predictive scaling is additive: KEDA/HPA takes the max across all triggers, so it can only raise the desired replica count, never lower it.

This PR also adds scale-up and scale-down rate caps as new, opt-in config.
The caps can dampen spikes, preventing unnecessary or continued scale outs arriving after  the spike(s) have been handled by existing capacity. 
The new caps mirror querier's own existing configurable caps (added in https://github.com/grafana/mimir/pull/11862) and default to existing behaviour.

## What's Changed

- predictive scaling support:
  - add config flags:
    - `autoscaling_ruler_querier_predictive_scaling_enabled` 
    - `autoscaling_ruler_querier_predictive_scaling_period`
    - `autoscaling_ruler_querier_predictive_scaling_lookback`
  - add a predictive KEDA trigger to `newRulerQuerierScaledObject`
  - add a render-time assert for a positive rendered threshold
  - extend jsonnet test fixtures
  - new trigger also appears on the existing ruler in-flight-queries dashboard panel
- scale up/down percent cap support:
  - add `autoscaling_ruler_querier_scaleup_percent_cap` config
  - add `autoscaling_ruler_querier_scaledown_percent_cap` config
  - defaults preserve current scale-up/scale-down behavior