### PR TITLE
Remove 3.0 from renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -90,7 +90,6 @@
     'main',
     'release-3.2',
     'release-3.1',
-    'release-3.0',
     'release-2.17',
   ],
   postUpdateOptions: [
@@ -102,7 +101,6 @@
       matchBaseBranches: [
         'release-3.2',
         'release-3.1',
-        'release-3.0',
         'release-2.17',
       ],
       enabled: false,


### PR DESCRIPTION
#### What this PR does

This PR is the follow-up to the 3.2 release. The Mimir maintains the last two minor releases (plus, release 2.17 for GEM customers). We don't need to follow 3.0 by now.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/16003

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
