### PR TITLE
compactor: abandon compaction job when a file is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [BUGFIX] Query-frontend: Stop the `query stats` log from corrupting queries that span multiple lines. Line breaks in query parameters were removed rather than replaced, so when a line break was the only separator between two tokens the tokens were fused together, leaving a logged `param_query` that no longer parsed. #16462
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 * [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276
+* [BUGFIX] Compactor: Abandon a compaction job in scheduler mode when a source block file is missing from object storage rather than attempting to retry the job. #16538
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
 * [BUGFIX] MQE: Propagate an `@` modifier or offset from the `info` function's first argument to its info series matchers, matching Prometheus. #16220 #16497

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -326,10 +326,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 
 		if err := block.Download(ctx, jobLogger, c.bkt, meta.ULID, bdir); err != nil {
 			if c.bkt.IsObjNotFoundErr(err) {
-				return blockFileNotFoundError{
-					err: fmt.Errorf("block file not found in bucket: %w", err),
-					id:  meta.ULID,
-				}
+				return blockFileNotFoundError{err: err, id: meta.ULID}
 			}
 			return fmt.Errorf("download block %s: %w", meta.ULID, err)
 		}
@@ -694,7 +691,7 @@ type blockFileNotFoundError struct {
 }
 
 func (e blockFileNotFoundError) Error() string {
-	return fmt.Sprintf("%s (block: %s)", e.err.Error(), e.id.String())
+	return fmt.Sprintf("block file not found in bucket: %s (block: %s)", e.err.Error(), e.id.String())
 }
 
 func (e blockFileNotFoundError) Unwrap() error {

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -325,6 +325,12 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 		bdir := filepath.Join(subDir, meta.ULID.String())
 
 		if err := block.Download(ctx, jobLogger, c.bkt, meta.ULID, bdir); err != nil {
+			if c.bkt.IsObjNotFoundErr(err) {
+				return blockFileNotFoundError{
+					err: fmt.Errorf("block file not found in bucket: %w", err),
+					id:  meta.ULID,
+				}
+			}
 			return fmt.Errorf("download block %s: %w", meta.ULID, err)
 		}
 
@@ -679,6 +685,27 @@ func isIssue347Error(err error) (bool, issue347Error) {
 	var ie issue347Error
 	ok := errors.As(err, &ie)
 	return ok, ie
+}
+
+// blockFileNotFoundError is a type wrapper for when a file of a source block is missing from object storage.
+type blockFileNotFoundError struct {
+	err error
+	id  ulid.ULID
+}
+
+func (e blockFileNotFoundError) Error() string {
+	return fmt.Sprintf("%s (block: %s)", e.err.Error(), e.id.String())
+}
+
+func (e blockFileNotFoundError) Unwrap() error {
+	return e.err
+}
+
+// isBlockFileNotFoundError returns true if the base error is a blockFileNotFoundError.
+func isBlockFileNotFoundError(err error) (bool, blockFileNotFoundError) {
+	var notFoundErr blockFileNotFoundError
+	ok := errors.As(err, &notFoundErr)
+	return ok, notFoundErr
 }
 
 // OutOfOrderChunksError is a type wrapper for OOO chunk error from validating block index.

--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -694,6 +694,11 @@ func (e *schedulerExecutor) executeCompactionJob(ctx context.Context, c *Multite
 		c.outOfSpace.Inc()
 	}
 
+	if ok, notFoundErr := isBlockFileNotFoundError(err); ok {
+		level.Warn(userLogger).Log("msg", "block file missing from bucket, abandoning job", "block", notFoundErr.id, "err", err)
+		return compactorschedulerpb.UPDATE_TYPE_ABANDON, err
+	}
+
 	if handleErr := compactor.handleKnownCompactionErrors(ctx, job, err); handleErr == nil {
 		return compactorschedulerpb.UPDATE_TYPE_ABANDON, err
 	}

--- a/pkg/compactor/executor_test.go
+++ b/pkg/compactor/executor_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
@@ -958,6 +960,54 @@ func TestSchedulerExecutor_ExecuteCompactionJob_Compaction(t *testing.T) {
 
 		})
 	}
+}
+
+func TestSchedulerExecutor_ExecuteCompactionJob_AbandonsWhenBlockDeletedAfterMetadataCached(t *testing.T) {
+	tenant := "test-tenant"
+	splitShards := 2
+
+	ctx := t.Context()
+	cfg := makeTestCompactorConfig(t)
+	bkt := objstore.NewInMemBucket()
+	blockID := createTSDBBlock(t, bkt, tenant, 10, 20, 2, nil)
+
+	metaCache := cache.NewMockCache()
+	r, err := bkt.Get(ctx, path.Join(tenant, blockID.String(), block.MetaFilename))
+	require.NoError(t, err)
+	metaContent, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	require.NoError(t, metaCache.Set(ctx, tenantMetaCacheKey(tenant, blockID), metaContent, time.Hour))
+	require.NoError(t, block.Delete(ctx, log.NewNopLogger(), bucket.NewUserBucketClient(tenant, bkt, nil), blockID))
+
+	mockCfg := newMockConfigProvider()
+	mockCfg.splitAndMergeShards = map[string]int{tenant: splitShards}
+	schedulerExec := newTestSchedulerExecutor(t, cfg, nil)
+	schedulerExec.metadataCache = metaCache
+	c := prepareCompactorForExecutorTest(t, cfg, bkt, mockCfg)
+
+	compactor, planner, err := splitAndMergeCompactorFactory(ctx, cfg, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	c.blocksCompactor = compactor
+	c.blocksPlanner = planner
+
+	spec := &compactorschedulerpb.JobSpec{
+		Tenant: tenant,
+		Job: &compactorschedulerpb.CompactionJob{
+			BlockIds: [][]byte{blockID.Bytes()},
+			Split:    true,
+		},
+		JobType: compactorschedulerpb.JOB_TYPE_COMPACTION,
+	}
+
+	key := &compactorschedulerpb.JobKey{Id: "test-job-id"}
+	status, err := schedulerExec.executeCompactionJob(ctx, c, t.TempDir(), key, spec)
+
+	require.Error(t, err)
+	ok, notFoundErr := isBlockFileNotFoundError(err)
+	require.True(t, ok, "expected a blockFileNotFoundError, got: %v", err)
+	require.Equal(t, blockID, notFoundErr.id)
+	require.Equal(t, compactorschedulerpb.UPDATE_TYPE_ABANDON, status)
 }
 
 func countBlocksInBucket(t *testing.T, bkt objstore.Bucket, userID string) int {


### PR DESCRIPTION
#### What this PR does

When we attempt a compaction job in scheduler mode some files may be missing from the bucket. It is better to abandon the job immediately when we hit this case because retries will see the same missing file. This condition wasn't being caught specifically because there was no sentinel to check for in the upper layers. This creates an error type `blockFileNotFoundError` that follows the same pattern as other known compaction errors and we now check for it after `runCompactionJob` in the executor to abandon the job.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
