### PR TITLE
compactor: fix broken test compile after split-and-merge factory signature change

### DIFF
--- a/pkg/compactor/executor_test.go
+++ b/pkg/compactor/executor_test.go
@@ -989,9 +989,9 @@ func TestSchedulerExecutor_ExecuteCompactionJob_AbandonsWhenBlockDeletedAfterMet
 	schedulerExec.metadataCache = metaCache
 	c := prepareCompactorForExecutorTest(t, cfg, bkt, mockCfg)
 
-	compactor, planner, err := splitAndMergeCompactorFactory(ctx, cfg, log.NewNopLogger(), prometheus.NewRegistry())
+	compactor, planner, err := splitAndMergeCompactorFactory(ctx, cfg, mockCfg, log.NewNopLogger(), prometheus.NewRegistry())
 	require.NoError(t, err)
-	c.blocksCompactor = compactor
+	c.blocksCompactorProvider = compactor
 	c.blocksPlanner = planner
 
 	spec := &compactorschedulerpb.JobSpec{


### PR DESCRIPTION
## Summary

- `#16488` updated `splitAndMergeCompactorFactory`'s signature to take a `ConfigProvider` and renamed `blocksCompactor` to `blocksCompactorProvider`, updating one call site in `pkg/compactor/executor_test.go` but missing an identical second call site later in the same file, which broke `go test`/`go vet` compilation for the `pkg/compactor` package (not caught by `go build` since it only compiles non-test files).
- Fixes the second call site to pass the already-in-scope `mockCfg` and use the renamed `blocksCompactorProvider` field, mirroring the fix already applied to the first call site.

## Test plan

- [x] `go vet ./pkg/compactor/...` passes
- [x] `go test ./pkg/compactor/... -run TestSchedulerExecutor` passes
- [x] `go build ./...` and `go test -run '^$' ./...` (compile-only) pass across the whole repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)