### PR TITLE
Update 3.1.5 and 3.1.6 CHANGELOG sections on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,20 @@
 * [ENHANCEMENT] Makefile: `build-mixin` and `mixin-screenshots` can now be configured to use native histograms for latency panels in dashboards. #15269
 * [ENHANCEMENT] kafkatool: Add a README. #15898
 
+## 3.1.6
+
+### Grafana Mimir
+
+* [BUGFIX] Upgrade Go to 1.26.7. #16430 #16433
+* [BUGFIX] Update `golang.org/x/crypto` to v0.56.0 to address [CVE-2026-78662](https://pkg.go.dev/vuln/GO-2026-6354) and [CVE-2026-56855](https://pkg.go.dev/vuln/GO-2026-6355). #16517
+* [BUGFIX] Update `google.golang.org/grpc` to v1.83.2 to address [CVE-2026-84304](https://nvd.nist.gov/vuln/detail/CVE-2026-84304) and [CVE-2026-84445](https://nvd.nist.gov/vuln/detail/CVE-2026-84445). #16509 #16543
+
+## 3.1.5
+
+### Grafana Mimir
+
+* [BUGFIX] Upgrade Go to 1.26.6 to address [CVE-2026-33818](https://pkg.go.dev/vuln/GO-2026-5972), [CVE-2026-39821](https://pkg.go.dev/vuln/GO-2026-5026), [CVE-2026-46600](https://pkg.go.dev/vuln/GO-2026-5942), [CVE-2026-56853](https://pkg.go.dev/vuln/GO-2026-6089), [CVE-2026-56858](https://pkg.go.dev/vuln/GO-2026-6091), [CVE-2026-56859](https://pkg.go.dev/vuln/GO-2026-6088), [CVE-2026-56860](https://pkg.go.dev/vuln/GO-2026-6218), and [CVE-2026-56862](https://pkg.go.dev/vuln/GO-2026-6090). #16408
+
 ## 3.1.4
 
 ### Grafana Mimir


### PR DESCRIPTION
#### What this PR does

`main`'s `CHANGELOG.md` jumps from `## 3.2.0` straight to `## 3.1.4`. The `## 3.1.5` and `## 3.1.6` sections are missing, because the "merge release branch into main" step was skipped after both patch releases were cut (the last such PR is #16194, from 2026-07-22).

This adds the two missing sections, copied verbatim from `release-3.1`, with the `### Grafana Mimir` subheading that every neighbouring section in this file uses. **Additive only: 14 insertions, 0 deletions.**

#### Why not merge `release-3.1` into `main` as RELEASE.md prescribes?

Most CVE fixes are already in main branch and some dependency version are newer in main branch.

#### Which issue(s) this PR fixes or relates to

Follow-up to the 3.1.6 release (#16553).

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated — this PR *is* the CHANGELOG change. It backfills historical release sections, so referencing this PR's own number in it would be wrong; applied the `changelog-not-needed` label so the changelog check doesn't demand a self-reference.
- [n/a] `about-versioning.md` updated with experimental features.