### PR TITLE
Widen TestGroupAtRisk timing margins to fix flakiness under -race 🤖🤖🤖

### DIFF
--- a/pkg/ruler/rule_concurrency_test.go
+++ b/pkg/ruler/rule_concurrency_test.go
@@ -410,8 +410,11 @@ func TestGroupAtRisk(t *testing.T) {
 			expected:         true,
 		},
 		"group last evaluation less than interval": {
-			// Total runtime: 100x1ms ~ 100ms (run sequentially), < 1s -> Not at risk
-			groupInterval:    1 * time.Second,
+			// Total runtime: 100x1ms ~ 100ms (run sequentially), < 5s -> Not at risk.
+			// The interval is intentionally generous (rather than e.g. 1s) so that scheduling
+			// jitter under a loaded CI machine (e.g. with -race) doesn't make this test flaky:
+			// real sleeps can only take longer than requested, never shorter.
+			groupInterval:    10 * time.Second,
 			evalConcurrently: false,
 			expected:         false,
 		},
@@ -422,8 +425,9 @@ func TestGroupAtRisk(t *testing.T) {
 			expected:         true,
 		},
 		"group total rule evaluation duration of last evaluation less than threshold": {
-			// Total runtime: 100x1ms ~ 100ms, < 1s -> Not at risk
-			groupInterval:    1 * time.Second,
+			// Total runtime: 100x1ms ~ 100ms, < 5s -> Not at risk.
+			// See comment above about the generous interval.
+			groupInterval:    10 * time.Second,
 			evalConcurrently: true,
 			expected:         false,
 		},


### PR DESCRIPTION
#### What this PR does

`TestGroupAtRisk` (`pkg/ruler/rule_concurrency_test.go`) evaluates a rule group of 100 rules, each sleeping 1ms in a mocked `QueryFunc`, then asserts whether `isGroupAtRisk` classifies the group's measured evaluation duration as above or below a threshold computed as `interval * thresholdRuleConcurrency / 100`. Two subtests derived their threshold from a 1s interval at a 50% ratio (500ms) against a nominal expected duration of ~100ms — only a 5x margin.

CI runs unit tests with `-race` (see the `test-with-race` Makefile target), which adds real scheduling/synchronization overhead per goroutine. Since `time.Sleep` only guarantees a lower bound, that overhead can only push the real measured duration up, never down, so on a loaded CI runner the actual duration occasionally exceeded the 500ms threshold and flipped the assertion.

This PR widens the two subtests that assert the group is *not* at risk (expecting the real duration to stay below the threshold) by raising their `groupInterval` from 1s to 10s, raising the threshold to 5000ms (~50x margin instead of ~5x). `groupInterval` here only feeds `isGroupAtRisk`'s threshold math; the test calls `rules.DefaultEvalIterationFunc` directly and once, with no ticker tied to the interval, so this has no effect on the test's actual wall-clock runtime. The two subtests that assert the group *is* at risk are left unchanged, since scheduling overhead can only push their (already-exceeded) threshold further, not un-exceed it.

**Validation:**
- `gofmt -l pkg/ruler/rule_concurrency_test.go`: clean.
- `go build ./pkg/ruler/...`: succeeds.
- `go test -vet=off -run TestGroupAtRisk -count=10 ./pkg/ruler`: passes all 10 iterations.
- Could **not** run `go test -race ./pkg/ruler` locally: the sandbox this was built in has very little free disk space, and a full `-race` build of `pkg/ruler`'s dependency graph exceeds what's available. This is an environment limitation of the sandbox, not a platform/code-compatibility issue — happy to address anything a `-race` CI run surfaces that this reasoning missed.

This is a test-only change with no user-visible behavior change, so no `CHANGELOG.md` entry is included (please add the `changelog-not-needed` label).

#### Which issue(s) this PR fixes or relates to

Fixes #11650

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.