### PR TITLE
ruler-querier: guard queue-depth trigger against NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [ENHANCEMENT] Add `ingester_zone_(a|b|c)_data_disk_class` and `store_gateway_zone_(a|b|c|a-backup|b-backup)_data_disk_class` config. #16467
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 * [BUGFIX] Fail with an explicit error when `ingester_automated_downscale_v2_enabled` is used together with `ingest_storage_enabled`. That downscale mode relies on the ingester read-only mode, which the ingest storage architecture doesn't support: use `ingest_storage_ingester_autoscaling_enabled` instead. #16469
+* [BUGFIX] Add a `>= 0` / `or vector(0)` guard to the ruler-querier queue-depth autoscaling trigger, so a NaN sample before the first scrape can't stall the scaler. #16563
 
 ### Documentation
 

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2400,7 +2400,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "7"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2400,7 +2400,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -5302,7 +5302,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -5372,7 +5373,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -3790,7 +3790,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -6690,7 +6690,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -6760,7 +6761,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -6830,7 +6832,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -7067,7 +7067,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7137,7 +7138,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7207,7 +7209,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -7067,7 +7067,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7137,7 +7138,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7207,7 +7209,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -7071,7 +7071,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7141,7 +7142,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7211,7 +7213,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -7071,7 +7071,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7141,7 +7142,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7211,7 +7213,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -7083,7 +7083,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7153,7 +7154,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7223,7 +7225,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -6908,7 +6908,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -6978,7 +6979,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7048,7 +7050,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -6921,7 +6921,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -6991,7 +6992,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7061,7 +7063,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -6934,7 +6934,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7004,7 +7005,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7074,7 +7076,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -6934,7 +6934,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7004,7 +7005,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7074,7 +7076,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -7250,7 +7250,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7320,7 +7321,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7390,7 +7392,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -7250,7 +7250,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7320,7 +7321,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7390,7 +7392,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -7044,7 +7044,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod!~"(ruler-querier|ruler-query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7114,7 +7115,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -7184,7 +7186,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -5701,7 +5701,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -5771,7 +5772,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -5701,7 +5701,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -5771,7 +5772,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -5552,7 +5552,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default
@@ -5622,7 +5623,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: ruler_querier_queries_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5",pod=~"(ruler-querier|ruler-query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: ruler_querier_queries_hpa_default

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -694,7 +694,11 @@
           // This metric covers the case queries are piling up in the ruler-query-scheduler queue,
           // but ruler-querier replicas are not scaled up by other scaling metrics (e.g. CPU and memory)
           // because resources utilization is not increasing significantly.
-          query: 'sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[1m]))' % query_params,
+          //
+          // The Prometheus Summary emits NaN for quantile values before the first Observe() call.
+          // >= 0 drops NaN samples (any comparison with NaN is false) before sum, leaving an empty
+          // vector so that or vector(0) can replace it with 0, giving KEDA a well-defined value.
+          query: '(sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[1m]) >= 0) or vector(0))' % query_params,
 
           threshold: '%d' % std.floor(querier_max_concurrent * $._config.autoscaling_ruler_querier_workers_target_utilization),
 


### PR DESCRIPTION
## Why

Querier's equivalent trigger already guards against this. [#15106](https://github.com/grafana/mimir/pull/15106)

## What's Changed

- add `>= 0` / `or vector(0)` guard to the `ruler-querier-queries` KEDA trigger query
- add a comment explaining the guard, matching querier's trigger