### PR TITLE
Vendor mimir-prometheus TSDB chunk ID wrap (2.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [ENHANCEMENT] Ingester: Optimize TSDB head chunk access during compaction to avoid O(n²) linked-list walks. #16373
+* [BUGFIX] Ingester: Wrap TSDB in-order and out-of-order head chunk IDs so they cannot overflow into the OOO flag bit and abort head compaction. #16569
 * [BUGFIX] Update to Go v1.26.3 to address high-severity CVEs [CVE-2026-42501](https://pkg.go.dev/vuln/GO-2026-4984), [CVE-2026-39836](https://pkg.go.dev/vuln/GO-2026-4971), [CVE-2026-33811](https://pkg.go.dev/vuln/GO-2026-4981), [CVE-2026-33814](https://pkg.go.dev/vuln/GO-2026-4918), [CVE-2026-42499](https://pkg.go.dev/vuln/GO-2026-4977), [CVE-2026-39820](https://pkg.go.dev/vuln/GO-2026-4986) and other lower-severity CVEs. #15401
 * [BUGFIX] Ingester: Fix out-of-order queries blocking TSDB head truncation/compaction. #16366
 

--- a/go.mod
+++ b/go.mod
@@ -345,7 +345,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260911075552-e7c2fe165682
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,8 @@ github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700 h1:0t7iOQ5ZkB
 github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700/go.mod h1:Ri9p/tRShbjYnpNf4FFPXG7wxEGY4Nrcn6E7jrVa//4=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250703083430-c31a9568ad96 h1:kq5zJVW9LyFOB5xCeQPTON2HNjwwEkefhegZXGIhQPk=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250703083430-c31a9568ad96/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8 h1:dFCkiw+kLZeXmHrfF60Di/TwH4YekGoI+OknHnXaQ2A=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8/go.mod h1:51sCkEHDpexFCGizYi1W4omiFaKThWThkquNPOxhwxQ=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260911075552-e7c2fe165682 h1:7ILOzpHd6BXsmijeaWJaSmWyQX0O7HUfxQ+Ac9/CoiY=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260911075552-e7c2fe165682/go.mod h1:51sCkEHDpexFCGizYi1W4omiFaKThWThkquNPOxhwxQ=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunks.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunks.go
@@ -77,28 +77,22 @@ func (p HeadChunkRef) Unpack() (HeadSeriesRef, HeadChunkID) {
 }
 
 // HeadChunkID refers to a specific chunk in a series (memSeries) in the Head.
-// Each memSeries has its own monotonically increasing number to refer to its chunks.
-// If the HeadChunkID value is...
-//   - memSeries.firstChunkID+len(memSeries.mmappedChunks), it's the head chunk.
-//   - less than the above, but >= memSeries.firstID, then it's
-//     memSeries.mmappedChunks[i] where i = HeadChunkID - memSeries.firstID.
+// Each memSeries has its own IDs for in-order and out-of-order chunks.
+//
+// IDs occupy bits 0-22 of HeadChunkRef (bit 23 is the OOO flag) and wrap modulo
+// 2^23 (see wrapChunkID, headChunkID, and oooHeadChunkID in tsdb/head_read.go).
+// They are not a globally monotonic counter: never order them, compare them, or
+// bound-check them directly. Recover the live-chunk index with
+//
+//	i = wrapChunkID(HeadChunkID - firstChunkID)
+//
+// For in-order chunks, i indexes mmappedChunks, then the headChunks linked list.
 //
 // If memSeries.headChunks is non-nil it points to a *memChunk that holds the current
-// "open" (accepting appends) instance. *memChunk is a linked list and memChunk.next pointer
-// might link to the older *memChunk instance.
+// "open" (accepting appends) instance. *memChunk is a linked list and memChunk.prev
+// pointer might link to the older *memChunk instance.
 // If there are multiple *memChunk instances linked to each other from memSeries.headChunks
-// they will be m-mapped as soon as possible leaving only "open" *memChunk instance.
-//
-// Example:
-// assume a memSeries.firstChunkID=7 and memSeries.mmappedChunks=[p5,p6,p7,p8,p9].
-//
-//	| HeadChunkID value | refers to ...                                                                          |
-//	|-------------------|----------------------------------------------------------------------------------------|
-//	|               0-6 | chunks that have been compacted to blocks, these won't return data for queries in Head |
-//	|              7-11 | memSeries.mmappedChunks[i] where i is 0 to 4.                                          |
-//	|                12 |                                                         *memChunk{next: nil}
-//	|                13 |                                         *memChunk{next: ^}
-//	|                14 | memSeries.headChunks -> *memChunk{next: ^}
+// they will be m-mapped as soon as possible leaving only one "open" *memChunk instance.
 type HeadChunkID uint64
 
 // BlockChunkRef refers to a chunk within a persisted block.

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -2298,6 +2298,13 @@ func (s *memSeries) maxTime() int64 {
 // (mmapChunks, truncateChunksBefore) must be immediately paired with a
 // setHeadChunks call.
 func (s *memSeries) pushHeadChunk(chk *memChunk) *memChunk {
+	// Chunk IDs can only be 23 bits, so a series cannot hold more than 2^23 chunks
+	// without two of them sharing an ID. This is not reachable in practice (head
+	// compaction keeps the live set tiny); panic rather than serve an ambiguous ID.
+	if len(s.mmappedChunks)+int(s.headChunkCount.Load()) >= oooChunkIDMask-1 {
+		panic(fmt.Sprintf("too many in-order head chunks for series %s (%d)", s.lset.String(), s.ref))
+	}
+
 	chk.prev = s.headChunks
 	s.headChunks = chk
 	s.headChunkCount.Add(1)
@@ -2325,7 +2332,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			if chk.maxTime < mint {
 				// If any head chunk is truncated, we can truncate all mmapped chunks.
 				removedInOrder = chk.len() + len(s.mmappedChunks)
-				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
+				s.firstChunkID = wrapChunkID(s.firstChunkID + chunks.HeadChunkID(removedInOrder))
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
 					s.setHeadChunks(nil, 0)
@@ -2350,7 +2357,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			removedInOrder = i + 1
 		}
 		s.mmappedChunks = append(s.mmappedChunks[:0], s.mmappedChunks[removedInOrder:]...)
-		s.firstChunkID += chunks.HeadChunkID(removedInOrder)
+		s.firstChunkID = wrapChunkID(s.firstChunkID + chunks.HeadChunkID(removedInOrder))
 	}
 
 	var removedOOO int
@@ -2362,7 +2369,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			removedOOO = i + 1
 		}
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks[:0], s.ooo.oooMmappedChunks[removedOOO:]...)
-		s.ooo.firstOOOChunkID += chunks.HeadChunkID(removedOOO)
+		s.ooo.firstOOOChunkID = wrapChunkID(s.ooo.firstOOOChunkID + chunks.HeadChunkID(removedOOO))
 
 		if len(s.ooo.oooMmappedChunks) == 0 && s.ooo.oooHeadChunk == nil {
 			s.ooo = nil

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
@@ -279,22 +279,42 @@ func appendSeriesChunks(s *memSeries, mint, maxt int64, chks []chunks.Meta, head
 	return chks, headChunksBuf
 }
 
+const oooChunkIDMask = 1 << 23
+
+// wrapChunkID reduces id into the 23-bit chunk ID space (bits 0..22 of HeadChunkRef),
+// so that IDs never overflow into the OOO flag at bit 23. Callers wrap in both
+// directions: pos + firstChunkID when a chunk ID is assigned, and id - firstChunkID
+// when its position is looked up.
+// HeadChunkID is uint64, so id - firstChunkID wraps modulo 2^64 when firstChunkID > id;
+// masking with oooChunkIDMask-1 recovers the 23-bit position.
+func wrapChunkID(id chunks.HeadChunkID) chunks.HeadChunkID {
+	return id & (oooChunkIDMask - 1)
+}
+
 // headChunkID returns the HeadChunkID referred to by the given position.
 // * 0 <= pos < len(s.mmappedChunks) refer to s.mmappedChunks[pos]
 // * pos >= len(s.mmappedChunks) refers to s.headChunks linked list.
+//
+// The position is wrapped modulo oooChunkIDMask so that firstChunkID can grow
+// indefinitely without overflowing the 23-bit ID space. Correctness requires the
+// number of chunks a series holds to stay below 2^23,
+// which pushHeadChunk enforces.
 func (s *memSeries) headChunkID(pos int) chunks.HeadChunkID {
-	return chunks.HeadChunkID(pos) + s.firstChunkID
+	return wrapChunkID(chunks.HeadChunkID(pos) + s.firstChunkID)
 }
-
-const oooChunkIDMask = 1 << 23
 
 // oooHeadChunkID returns the HeadChunkID referred to by the given position.
 // Only the bottom 24 bits are used. Bit 23 is always 1 for an OOO chunk; for the rest:
 // * 0 <= pos < len(s.oooMmappedChunks) refer to s.oooMmappedChunks[pos]
 // * pos == len(s.oooMmappedChunks) refers to s.oooHeadChunk
 // The caller must ensure that s.ooo is not nil.
+//
+// The position is wrapped modulo oooChunkIDMask so that firstOOOChunkID can
+// grow indefinitely without overflowing the 23-bit ID space. Correctness
+// requires len(oooMmappedChunks) to stay below 2^23, which is
+// enforced by the guard in mmapCurrentOOOHeadChunk.
 func (s *memSeries) oooHeadChunkID(pos int) chunks.HeadChunkID {
-	return (chunks.HeadChunkID(pos) + s.ooo.firstOOOChunkID) | oooChunkIDMask
+	return wrapChunkID(chunks.HeadChunkID(pos)+s.ooo.firstOOOChunkID) | oooChunkIDMask
 }
 
 func unpackHeadChunkRef(ref chunks.ChunkRef) (seriesID chunks.HeadSeriesRef, chunkID chunks.HeadChunkID, isOOO bool) {
@@ -549,7 +569,8 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 // if isOpen is true, it means that the returned *memChunk is used for appends.
 func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, memChunkPool *sync.Pool, headChunks []*memChunk) (chunk *memChunk, headChunk, isOpen bool, err error) {
 	// ix is the chunk's oldest-first position in the logical sequence. Chunk IDs
-	// increase by one when a chunk is created, so id-firstChunkID yields that position.
+	// increase by one per chunk, so wrapChunkID(id-firstChunkID) yields that
+	// position even after the IDs have wrapped past 0.
 	// s.mmappedChunks is stored oldest-first, while the s.headChunks linked list is
 	// stored newest-first:
 	//
@@ -561,10 +582,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 	// Values below len(s.mmappedChunks) index the slice directly. Remaining values
 	// index head chunks oldest-first; the pre-collected headChunks slice already uses
 	// this order, while the linked-list fallback reverses the index.
-	ix := int(id) - int(s.firstChunkID)
-	if ix < 0 {
-		return nil, false, false, storage.ErrNotFound
-	}
+	ix := int(wrapChunkID(id - s.firstChunkID))
 
 	if ix < len(s.mmappedChunks) {
 		chk, err := chunkDiskMapper.Chunk(s.mmappedChunks[ix].ref)
@@ -619,11 +637,12 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 // oooChunk returns the chunk for the HeadChunkID by m-mapping it from the disk.
 // It never returns the head OOO chunk.
 func (s *memSeries) oooChunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, _ *sync.Pool) (chunk chunkenc.Chunk, maxTime int64, err error) {
-	// ix represents the index of chunk in the s.ooo.oooMmappedChunks slice. The chunk id's are
-	// incremented by 1 when new chunk is created, hence (id - firstOOOChunkID) gives the slice index.
-	ix := int(id) - int(s.ooo.firstOOOChunkID)
+	// ix is the index into s.ooo.oooMmappedChunks. Chunk IDs increase by one per
+	// chunk, so wrapChunkID(id-firstOOOChunkID) recovers the index even after the
+	// IDs have wrapped past 0.
+	ix := int(wrapChunkID(id - s.ooo.firstOOOChunkID))
 
-	if ix < 0 || ix >= len(s.ooo.oooMmappedChunks) {
+	if ix >= len(s.ooo.oooMmappedChunks) {
 		return nil, 0, storage.ErrNotFound
 	}
 
@@ -649,7 +668,7 @@ func (c *safeHeadChunk) Iterator(reuseIter chunkenc.Iterator) chunkenc.Iterator 
 // iterator returns a chunk iterator for the requested chunk ID, or a NopIterator if it is out of range.
 // It is unsafe to call this concurrently with s.append(...) without holding the series lock.
 func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *isolationState, it chunkenc.Iterator) chunkenc.Iterator {
-	ix := int(id) - int(s.firstChunkID)
+	ix := int(wrapChunkID(id - s.firstChunkID))
 
 	numSamples := c.NumSamples()
 	stopAfter := numSamples

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1208,7 +1208,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260911075552-e7c2fe165682
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -2157,7 +2157,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260813165250-9bc72b19dca8
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260911075552-e7c2fe165682
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
## Summary

Vendor the mimir-prometheus `mimir-release-2.17` tip to pick up the TSDB head chunk ID wrap from grafana/mimir-prometheus#1311 (prometheus/prometheus#19450 in-order, prometheus/prometheus#19216 OOO).

Without the wrap, in-order `headChunkID` grows unbounded and eventually sets bit 23 (`oooChunkIDMask`). Head compaction then treats an in-order chunk as OOO and fails with `RANGEHEAD: not found`, so the head never truncates.

- Bump replace to `mimir-prometheus` `e7c2fe165682` (`mimir-release-2.17`)

Made with [Cursor](https://cursor.com)