### PR TITLE
fix(distributor): share query subring cache entry when shuffle sharding is disabled

### DIFF
--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -132,23 +132,15 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, ma
 	}
 
 	if d.cfg.IngestStorageConfig.Enabled {
-		// Build a subring to query. We use ShuffleShardWithLookback() to limit the partitions to query
-		// to the tenant's shard (when shuffle sharding is enabled) and to filter out inactive partitions
-		// that have been inactive for longer than the lookback period.
 		shardSize := 0
 		if d.cfg.ShuffleShardingEnabled {
 			shardSize = d.limits.IngestionPartitionsTenantShardSize(userID)
 		}
 
-		// Cap the inactive-partition lookback at query-ingesters-within:
-		//   - past that window, a partition's data isn't queried from ingesters, and its owners may be
-		//     gone; an ownerless partition would otherwise fail the query.
-		//   - 0 means unbounded, so it only tightens the bound when set and below the lookback period.
 		lookbackPeriod := d.cfg.IngestersLookbackPeriod
 		if queryIngestersWithin := d.limits.QueryIngestersWithin(userID); queryIngestersWithin > 0 && queryIngestersWithin < lookbackPeriod {
 			lookbackPeriod = queryIngestersWithin
 		}
-
 		now := time.Now()
 
 		// When compartments are enabled, try to restrict the pool of compartments that need to be queried.
@@ -177,7 +169,7 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, ma
 		}
 
 		// Compartments are disabled.
-		r, err := d.partitionInstanceRings.Get(0).ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, now)
+		r, err := d.queryPartitionsSubring(userID, now)
 		if err != nil {
 			return nil, err
 		}
@@ -200,6 +192,31 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, ma
 	}
 
 	return []ring.ReplicationSet{replicationSet}, nil
+}
+
+// queryPartitionsSubring builds the partitions subring to query for the given tenant. We use
+// ShuffleShardWithLookback() to limit the partitions to query to the tenant's shard (when shuffle
+// sharding is enabled) and to filter out partitions that have been inactive for longer than the
+// lookback period.
+func (d *Distributor) queryPartitionsSubring(userID string, now time.Time) (*ring.PartitionInstanceRing, error) {
+	shardSize := 0
+	identifier := userID
+	if d.cfg.ShuffleShardingEnabled {
+		shardSize = d.limits.IngestionPartitionsTenantShardSize(userID)
+	}
+	if shardSize <= 0 {
+		// Every tenant gets the full ring and the result doesn't depend on the identifier, but the
+		// subring cache is keyed by it. Share a single cache entry instead of keeping one full ring
+		// copy per querying tenant (~0.5MB each, unbounded with tens of thousands of tenants).
+		identifier = ""
+	}
+
+	lookbackPeriod := d.cfg.IngestersLookbackPeriod
+	if queryIngestersWithin := d.limits.QueryIngestersWithin(userID); queryIngestersWithin > 0 && queryIngestersWithin < lookbackPeriod {
+		lookbackPeriod = queryIngestersWithin
+	}
+
+	return d.partitionInstanceRings.Get(0).ShuffleShardWithLookback(identifier, shardSize, lookbackPeriod, now)
 }
 
 // mergeExemplarSets merges and dedupes two sets of already sorted exemplar pairs.

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -834,3 +834,58 @@ type byLabels []labels.Labels
 func (b byLabels) Len() int           { return len(b) }
 func (b byLabels) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b byLabels) Less(i, j int) bool { return labels.Compare(b[i], b[j]) < 0 }
+
+func TestDistributor_QueryPartitionsSubring_ShuffleShardCacheSharing(t *testing.T) {
+	t.Run("shuffle sharding disabled: all tenants share one cached full-ring subring", func(t *testing.T) {
+		distributors, _, _, _ := prepare(t, prepConfig{
+			numIngesters:            3,
+			happyIngesters:          3,
+			numDistributors:         1,
+			replicationFactor:       1,
+			ingestStorageEnabled:    true,
+			ingestStoragePartitions: 3,
+			configure: func(cfg *Config) {
+				cfg.ShuffleShardingEnabled = false
+			},
+		})
+		d := distributors[0]
+
+		now := time.Now()
+		first, err := d.queryPartitionsSubring("tenant-1", now)
+		require.NoError(t, err)
+		second, err := d.queryPartitionsSubring("tenant-2", now)
+		require.NoError(t, err)
+
+		require.Same(t, first.PartitionRing(), second.PartitionRing())
+		require.Len(t, first.PartitionRing().PartitionIDs(), 3)
+	})
+
+	t.Run("shuffle sharding enabled: tenants keep their own subring", func(t *testing.T) {
+		limits := prepareDefaultLimits()
+		limits.IngestionPartitionsTenantShardSize = 1
+
+		distributors, _, _, _ := prepare(t, prepConfig{
+			numIngesters:            3,
+			happyIngesters:          3,
+			numDistributors:         1,
+			replicationFactor:       1,
+			ingestStorageEnabled:    true,
+			ingestStoragePartitions: 3,
+			limits:                  limits,
+			configure: func(cfg *Config) {
+				cfg.ShuffleShardingEnabled = true
+			},
+		})
+		d := distributors[0]
+
+		now := time.Now()
+		first, err := d.queryPartitionsSubring("tenant-1", now)
+		require.NoError(t, err)
+		second, err := d.queryPartitionsSubring("tenant-2", now)
+		require.NoError(t, err)
+
+		require.NotSame(t, first.PartitionRing(), second.PartitionRing())
+		require.Len(t, first.PartitionRing().PartitionIDs(), 1)
+		require.Len(t, second.PartitionRing().PartitionIDs(), 1)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

With ingest storage enabled, every query calls ShuffleShardWithLookback() keyed by tenant even when ingester shuffle sharding is disabled. The result is the same full partition ring for every tenant, but dskit caches one copy per identifier in an unbounded map, so a querier serving ~10k tenants retained ~10k identical ~0.5MB rings (4.4GB of a 4.7GB live heap in a DQS querier heap dump). Use a constant identifier when the shard size is 0 so all tenants share a single cached subring.

#### Which issue(s) this PR fixes or relates to

Fixing querier memory consumtion when ingest storage enabled and shuffle sharding (temporarily) disabled

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
